### PR TITLE
Fix multiple owner references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-
+bounce: build undeploy deploy
 
 build:
 	./gradlew build
@@ -15,6 +15,9 @@ integration-tests:
 clean:
 	./gradlew clean
 
+undeploy:
+	kubectl delete -f ./deploy || echo "skipping"
+
 quickstart: build deploy-dev-environment deploy
 
 deploy-dev-environment: 
@@ -29,13 +32,13 @@ deploy-dev-environment:
 deploy:
 	kubectl apply -f ./deploy/
 
-undeploy:
-	kubectl delete -f ./deploy || echo "skipping"
-
 deploy-samples:
 	kubectl apply -f ./deploy/samples
 
 release:
 	./gradlew publish
 
-.PHONY: build clean quickstart deploy-dev-environment deploy deploy-samples integration-tests
+generate-models:
+	./models/generate-models.sh
+
+.PHONY: build clean quickstart deploy-dev-environment deploy deploy-samples integration-tests bounce generate-models

--- a/deploy/kafkatopics.crd.yaml
+++ b/deploy/kafkatopics.crd.yaml
@@ -32,7 +32,7 @@ spec:
               description: Desired Kafka topic configuration.
               type: object
               properties:
-                name:
+                topicName:
                   description: The topic name.
                   type: string
                 numPartitions:
@@ -67,7 +67,7 @@ spec:
                   additionalProperties:
                     type: string
               required:
-              - name
+              - topicName
             status:
               description: Current state of the topic.
               type: object

--- a/deploy/samples/kafkatopic.yaml
+++ b/deploy/samples/kafkatopic.yaml
@@ -1,8 +1,0 @@
-apiVersion: hoptimator.linkedin.com/v1alpha1
-kind: KafkaTopic
-metadata:
-  name: sample-kafka-topic-1
-spec:
-  name: sample-1
-  clientOverrides:
-    bootstrap.servers: localhost:9092

--- a/deploy/samples/subscription.yaml
+++ b/deploy/samples/subscription.yaml
@@ -1,7 +1,0 @@
-apiVersion: hoptimator.linkedin.com/v1alpha1
-kind: Subscription
-metadata:
-  name: sample-subscription-1
-spec:
-  sql: SELECT NAME FROM DATAGEN.PERSON
-  database: RAWKAFKA

--- a/deploy/samples/subscriptions.yaml
+++ b/deploy/samples/subscriptions.yaml
@@ -1,0 +1,29 @@
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: Subscription
+metadata:
+  name: people
+spec:
+  sql: SELECT NAME FROM DATAGEN.PERSON
+  database: RAWKAFKA
+
+---
+
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: Subscription
+metadata:
+  name: companies
+spec:
+  sql: SELECT NAME FROM DATAGEN.COMPANY
+  database: RAWKAFKA
+
+---
+
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: Subscription
+metadata:
+  name: names
+spec:
+  sql: SELECT p.PAYLOAD || c.PAYLOAD FROM RAWKAFKA."people" p, RAWKAFKA."companies" c
+  database: RAWKAFKA
+
+

--- a/deploy/subscriptions.crd.yaml
+++ b/deploy/subscriptions.crd.yaml
@@ -53,3 +53,13 @@ spec:
                   type: string
       subresources:
         status: {}
+      additionalPrinterColumns:
+      - name: DB
+        type: string
+        description: The database where the subscription is materialized.
+        jsonPath: .spec.database
+      - name: SQL
+        type: string
+        description: The SQL query that the subscription materializes.
+        jsonPath: .spec.sql
+

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
@@ -25,7 +25,7 @@ public final class AvroConverter {
     if (dataType.isStruct()) {
       List<Schema.Field> fields = dataType.getFieldList().stream()
         .filter(x -> !x.getName().startsWith("__")) // don't write out hidden fields
-        .map(x -> new Schema.Field(sanitize(x.getName()), avro(x.getName(), namespace, x.getType()), describe(x), null))
+        .map(x -> new Schema.Field(sanitize(x.getName()), avro(namespace, x.getName(), x.getType()), describe(x), null))
         .collect(Collectors.toList());
       return Schema.createRecord(sanitize(name), dataType.toString(), namespace, false, fields);
     } else {

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
@@ -21,7 +21,7 @@ public final class AvroConverter {
   private AvroConverter() {
   }
 
-  public static Schema avro(String name, String namespace, RelDataType dataType) {
+  public static Schema avro(String namespace, String name, RelDataType dataType) {
     if (dataType.isStruct()) {
       List<Schema.Field> fields = dataType.getFieldList().stream()
         .filter(x -> !x.getName().startsWith("__")) // don't write out hidden fields
@@ -49,9 +49,9 @@ public final class AvroConverter {
     }
   }
 
-  public static Schema avro(String name, String namespace, RelProtoDataType relProtoDataType) {
+  public static Schema avro(String namespace, String name, RelProtoDataType relProtoDataType) {
     RelDataTypeFactory factory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
-    return avro(name, namespace, relProtoDataType.apply(factory));
+    return avro(namespace, name, relProtoDataType.apply(factory));
   }
 
   private static Schema createAvroTypeWithNullability(Schema.Type rawType, boolean nullable) {

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Resource.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Resource.java
@@ -29,12 +29,6 @@ public abstract class Resource {
   private final Map<String, Supplier<String>> properties = new HashMap<>();
 
   /** A Resource that will be rendered with the specified template */
-  public Resource(String name, String template) {
-    this(template);
-    export("name", name);
-  }
-
-  /** A Resource that will be rendered with the specified template */
   public Resource(String template) {
     this.template = template;
   }
@@ -73,10 +67,6 @@ public abstract class Resource {
     return properties.keySet();
   }
 
-  public String name() {
-    return getOrDefault("name", () -> "(no name)");
-  }
-
   /** Render this Resource using the given TemplateFactory */
   public String render(TemplateFactory templateFactory) {
     return templateFactory.get(this).render(this);
@@ -103,7 +93,7 @@ public abstract class Resource {
   public String getOrDefault(String key, Supplier<String> f) {
     String computed = properties.getOrDefault(key, f).get();
     if (computed == null) {
-      throw new IllegalArgumentException("Resource '" + name() + "' missing variable '" + key + "'");
+      throw new IllegalArgumentException("Resource missing variable '" + key + "'");
     }
     return computed;
   }

--- a/hoptimator-cli/src/main/java/com/linkedin/hoptimator/HoptimatorCliApp.java
+++ b/hoptimator-cli/src/main/java/com/linkedin/hoptimator/HoptimatorCliApp.java
@@ -98,7 +98,7 @@ public class HoptimatorCliApp {
       try {
         HoptimatorPlanner planner = HoptimatorPlanner.fromModelFile(connectionUrl, new Properties());
         RelNode plan = planner.logical(sql);
-        String avroSchema = AvroConverter.avro("OutputRecord", "OutputNamespace", plan.getRowType()).toString(true);
+        String avroSchema = AvroConverter.avro("OutputNamespace", "OutputName", plan.getRowType()).toString(true);
         sqlline.output(avroSchema); 
         dispatchCallback.setToSuccess();
       } catch (Exception e) {

--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopic.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopic.java
@@ -8,14 +8,11 @@ import java.util.Map;
 
 public class KafkaTopic extends Resource {
   public KafkaTopic(String name, Integer numPartitions, Map<String, String> clientOverrides) {
-    super(name, "KafkaTopic");
+    super("KafkaTopic");
+    export("name", name);
     export("numPartitions", Optional.ofNullable(numPartitions)
       .map(x -> Integer.toString(x)).orElse("null"));
     export("clientOverrides", clientOverrides);
-  }
-
-  public KafkaTopic(String name) {
-    this(name, null, Collections.emptyMap());
   }
 }
 

--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/RawKafkaSchemaFactory.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/RawKafkaSchemaFactory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 public class RawKafkaSchemaFactory implements SchemaFactory {
 
   @Override
+  @SuppressWarnings("unchecked")
   public Schema create(SchemaPlus parentSchema, String name, Map<String, Object> operand) {
     Map<String, Object> clientConfig = (Map<String, Object>) operand.get("clientConfig");
     DataType.Struct rowType = DataType.struct()

--- a/hoptimator-kafka-adapter/src/main/resources/KafkaTopic.yaml.template
+++ b/hoptimator-kafka-adapter/src/main/resources/KafkaTopic.yaml.template
@@ -4,7 +4,7 @@ metadata:
   name: {{name}}-kafka-topic
   namespace: {{namespace}}
 spec:
-  name: {{name}}
+  topicName: {{name}}
   numPartitions: {{numPartitions}}
   clientOverrides:
     {{clientOverrides}}

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/Operator.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/Operator.java
@@ -120,8 +120,7 @@ public class Operator {
       if (owners == null) {
         owners = new ArrayList<>();
       }
-      if (owners.stream().filter(x -> x.getUid().equals(ownerReference.getUid()))
-          .findAny().isPresent()) {
+      if (owners.stream().anyMatch(x -> x.getUid().equals(ownerReference.getUid()))) {
         log.info("Existing downstream resource {}/{} is already owned by {}/{}.",
           namespace, name, ownerReference.getKind(), ownerReference.getName());
       } else {

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/Operator.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/Operator.java
@@ -16,8 +16,10 @@ import io.kubernetes.client.util.generic.dynamic.Dynamics;
 
 import com.linkedin.hoptimator.catalog.Resource;
 
+import java.util.ArrayList;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -111,9 +113,23 @@ public class Operator {
     String name = obj.getMetadata().getName();
     KubernetesApiResponse<DynamicKubernetesObject> existing = apiFor(obj).get(namespace, name);
     if (existing.isSuccess()) {
-      log.info("Updating existing downstream resource {}/{} as \n{}", namespace, name, yaml);
-      obj.setMetadata(obj.getMetadata().resourceVersion(existing.getObject().getMetadata().getResourceVersion())
-        .addOwnerReferencesItem(ownerReference));
+      String resourceVersion = existing.getObject().getMetadata().getResourceVersion();
+      log.info("Updating existing downstream resource {}/{} {} as \n{}",
+        namespace, name, resourceVersion, yaml);
+      List<V1OwnerReference> owners = existing.getObject().getMetadata().getOwnerReferences();
+      if (owners == null) {
+        owners = new ArrayList<>();
+      }
+      if (owners.stream().filter(x -> x.getUid().equals(ownerReference.getUid()))
+          .findAny().isPresent()) {
+        log.info("Existing downstream resource {}/{} is already owned by {}/{}.",
+          namespace, name, ownerReference.getKind(), ownerReference.getName());
+      } else {
+        log.info("Existing downstream resource {}/{} will be owned by {}/{} and {} others.",
+          namespace, name, ownerReference.getKind(), ownerReference.getName(), owners.size());
+        owners.add(ownerReference);
+      }
+      obj.setMetadata(obj.getMetadata().ownerReferences(owners).resourceVersion(resourceVersion));
       KubernetesApiResponse<DynamicKubernetesObject> response = apiFor(obj).update(obj);
       if (!response.isSuccess()) {
         log.error("Error updating downstream resource {}/{}: {}.", namespace, name, response.getStatus().getMessage());

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/kafka/KafkaTopicReconciler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/kafka/KafkaTopicReconciler.java
@@ -54,7 +54,7 @@ public class KafkaTopicReconciler implements Reconciler {
         return new Result(false);
       }
 
-      String topicName = object.getSpec().getName();
+      String topicName = object.getSpec().getTopicName();
       Integer desiredPartitions = object.getSpec().getNumPartitions();
       Integer desiredReplicationFactor = object.getSpec().getReplicationFactor();
       

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopic.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopic.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Kafka Topic
  */
 @ApiModel(description = "Kafka Topic")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1KafkaTopic implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicList.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * KafkaTopicList is a list of KafkaTopic
  */
 @ApiModel(description = "KafkaTopicList is a list of KafkaTopic")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1KafkaTopicList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpec.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpec.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * Desired Kafka topic configuration.
  */
 @ApiModel(description = "Desired Kafka topic configuration.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpec {
   public static final String SERIALIZED_NAME_CLIENT_CONFIGS = "clientConfigs";
   @SerializedName(SERIALIZED_NAME_CLIENT_CONFIGS)
@@ -47,10 +47,6 @@ public class V1alpha1KafkaTopicSpec {
   @SerializedName(SERIALIZED_NAME_CONFIGS)
   private Map<String, String> configs = null;
 
-  public static final String SERIALIZED_NAME_NAME = "name";
-  @SerializedName(SERIALIZED_NAME_NAME)
-  private String name;
-
   public static final String SERIALIZED_NAME_NUM_PARTITIONS = "numPartitions";
   @SerializedName(SERIALIZED_NAME_NUM_PARTITIONS)
   private Integer numPartitions;
@@ -58,6 +54,10 @@ public class V1alpha1KafkaTopicSpec {
   public static final String SERIALIZED_NAME_REPLICATION_FACTOR = "replicationFactor";
   @SerializedName(SERIALIZED_NAME_REPLICATION_FACTOR)
   private Integer replicationFactor;
+
+  public static final String SERIALIZED_NAME_TOPIC_NAME = "topicName";
+  @SerializedName(SERIALIZED_NAME_TOPIC_NAME)
+  private String topicName;
 
 
   public V1alpha1KafkaTopicSpec clientConfigs(List<V1alpha1KafkaTopicSpecClientConfigs> clientConfigs) {
@@ -153,28 +153,6 @@ public class V1alpha1KafkaTopicSpec {
   }
 
 
-  public V1alpha1KafkaTopicSpec name(String name) {
-    
-    this.name = name;
-    return this;
-  }
-
-   /**
-   * The topic name.
-   * @return name
-  **/
-  @ApiModelProperty(required = true, value = "The topic name.")
-
-  public String getName() {
-    return name;
-  }
-
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-
   public V1alpha1KafkaTopicSpec numPartitions(Integer numPartitions) {
     
     this.numPartitions = numPartitions;
@@ -221,6 +199,28 @@ public class V1alpha1KafkaTopicSpec {
   }
 
 
+  public V1alpha1KafkaTopicSpec topicName(String topicName) {
+    
+    this.topicName = topicName;
+    return this;
+  }
+
+   /**
+   * The topic name.
+   * @return topicName
+  **/
+  @ApiModelProperty(required = true, value = "The topic name.")
+
+  public String getTopicName() {
+    return topicName;
+  }
+
+
+  public void setTopicName(String topicName) {
+    this.topicName = topicName;
+  }
+
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -233,14 +233,14 @@ public class V1alpha1KafkaTopicSpec {
     return Objects.equals(this.clientConfigs, v1alpha1KafkaTopicSpec.clientConfigs) &&
         Objects.equals(this.clientOverrides, v1alpha1KafkaTopicSpec.clientOverrides) &&
         Objects.equals(this.configs, v1alpha1KafkaTopicSpec.configs) &&
-        Objects.equals(this.name, v1alpha1KafkaTopicSpec.name) &&
         Objects.equals(this.numPartitions, v1alpha1KafkaTopicSpec.numPartitions) &&
-        Objects.equals(this.replicationFactor, v1alpha1KafkaTopicSpec.replicationFactor);
+        Objects.equals(this.replicationFactor, v1alpha1KafkaTopicSpec.replicationFactor) &&
+        Objects.equals(this.topicName, v1alpha1KafkaTopicSpec.topicName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(clientConfigs, clientOverrides, configs, name, numPartitions, replicationFactor);
+    return Objects.hash(clientConfigs, clientOverrides, configs, numPartitions, replicationFactor, topicName);
   }
 
 
@@ -251,9 +251,9 @@ public class V1alpha1KafkaTopicSpec {
     sb.append("    clientConfigs: ").append(toIndentedString(clientConfigs)).append("\n");
     sb.append("    clientOverrides: ").append(toIndentedString(clientOverrides)).append("\n");
     sb.append("    configs: ").append(toIndentedString(configs)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    numPartitions: ").append(toIndentedString(numPartitions)).append("\n");
     sb.append("    replicationFactor: ").append(toIndentedString(replicationFactor)).append("\n");
+    sb.append("    topicName: ").append(toIndentedString(topicName)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecClientConfigs.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecClientConfigs.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * V1alpha1KafkaTopicSpecClientConfigs
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpecClientConfigs {
   public static final String SERIALIZED_NAME_CONFIG_MAP_REF = "configMapRef";
   @SerializedName(SERIALIZED_NAME_CONFIG_MAP_REF)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecConfigMapRef.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecConfigMapRef.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Reference to a ConfigMap to use for AdminClient configuration.
  */
 @ApiModel(description = "Reference to a ConfigMap to use for AdminClient configuration.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpecConfigMapRef {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicStatus.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Current state of the topic.
  */
 @ApiModel(description = "Current state of the topic.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1KafkaTopicStatus {
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJob.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJob.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * SQL job
  */
 @ApiModel(description = "SQL job")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1SqlJob implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobList.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SqlJobList is a list of SqlJob
  */
 @ApiModel(description = "SqlJobList is a list of SqlJob")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1SqlJobList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobSpec.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * SQL job spec.
  */
 @ApiModel(description = "SQL job spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1SqlJobSpec {
   public static final String SERIALIZED_NAME_SQL = "sql";
   @SerializedName(SERIALIZED_NAME_SQL)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobStatus.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Current state of the SQL job.
  */
 @ApiModel(description = "Current state of the SQL job.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1SqlJobStatus {
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Subscription.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Subscription.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator Subscription
  */
 @ApiModel(description = "Hoptimator Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1Subscription implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionList.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SubscriptionList is a list of Subscription
  */
 @ApiModel(description = "SubscriptionList is a list of Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1SubscriptionList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionSpec.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Subscription spec
  */
 @ApiModel(description = "Subscription spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1SubscriptionSpec {
   public static final String SERIALIZED_NAME_DATABASE = "database";
   @SerializedName(SERIALIZED_NAME_DATABASE)

--- a/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionStatus.java
+++ b/models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-18T02:27:48.458Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-04-28T19:46:31.976Z[Etc/UTC]")
 public class V1alpha1SubscriptionStatus {
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)


### PR DESCRIPTION
Validated that resources can be shared between multiple subscriptions.

## Testing ##

Deployed a subscription `names` which joins the output of two other subscriptions:

```
$ kubectl get subscriptions
NAME        DB         SQL
companies   RAWKAFKA   SELECT NAME FROM DATAGEN.COMPANY
names       RAWKAFKA   SELECT p.PAYLOAD || c.PAYLOAD FROM RAWKAFKA."people" p, RAWKAFKA."companies" c
people      RAWKAFKA   SELECT NAME FROM DATAGEN.PERSON
```

The subscription takes ownership of the two source Kafka topics, as well as the new sink Kafka topic:

```
$ kubectl tree subscription names
NAMESPACE  NAME                                                    READY  REASON  AGE
default    Subscription/names                                      -              63m
default    ├─KafkaTopic/companies-kafka-topic                      -              63m
default    ├─KafkaTopic/names-kafka-topic                          -              63m
default    ├─KafkaTopic/people-kafka-topic                         -              63m
default    └─SqlJob/names-sql                                      -              63m
default      └─FlinkDeployment/names-sql-flink-job                 -              63m
default        └─Deployment/names-sql-flink-job                    -              63m
default          ├─ConfigMap/flink-config-names-sql-flink-job      -              63m
default          ├─Pod/names-sql-flink-job-taskmanager-1-1         True           63m
default          ├─ReplicaSet/names-sql-flink-job-5566d6ff85       -              63m
default          │ └─Pod/names-sql-flink-job-5566d6ff85-x6lg7      True           63m
default          ├─Service/names-sql-flink-job                     -              63m
default          │ └─EndpointSlice/names-sql-flink-job-l4p8z       -              63m
default          └─Service/names-sql-flink-job-rest                -              63m
default            └─EndpointSlice/names-sql-flink-job-rest-56lbf  -              63m
```

The Kafka topics that are shared between subscriptions show multiple owner references:

```
$ kubectl get kafkatopic people-kafka-topic -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: KafkaTopic
metadata:
--->%---
  name: people-kafka-topic
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: Subscription
    name: names
    uid: 532f5e60-1057-458b-b01c-4e22e9e3dc0b
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: Subscription
    name: people
    uid: babcf493-c004-4ccf-8e36-065d406f40b9
--->%---
```