### PR TITLE
Add !check command to Hoptimator CLI

### DIFF
--- a/etc/integration-tests.sql
+++ b/etc/integration-tests.sql
@@ -10,6 +10,9 @@ SELECT * FROM DATAGEN.COMPANY;
 -- MySQL CDC tables
 SELECT * FROM INVENTORY."products_on_hand" LIMIT 1;
 
+-- Test check command
+!check not empty SELECT * FROM INVENTORY."products_on_hand";
+
 -- MySQL CDC -> Kafka
 SELECT * FROM RAWKAFKA."products" LIMIT 1;
 

--- a/hoptimator-cli/src/main/java/com/linkedin/hoptimator/FlinkIterable.java
+++ b/hoptimator-cli/src/main/java/com/linkedin/hoptimator/FlinkIterable.java
@@ -59,6 +59,23 @@ public class FlinkIterable implements Iterable<Object> {
     }
   }
 
+  /* Iterates over the selected field/column only, with a limit set on the number of collected elements */
+  public <T> Iterable<T> field(int pos, Integer limit) {
+    if(limit==null) {
+      return this.field(pos);
+    }
+    return new Iterable<T>() {
+      @Override
+      public Iterator<T> iterator() {
+        try {
+          return datastream().map(r -> r.<T>getFieldAs(pos)).executeAndCollect(limit).iterator();
+        } catch (Exception e) {
+          return new ExceptionalIterator<>(e);
+        }
+      }
+    };
+  }
+
   /** Iterates over the selected field/column only. */
   public <T> Iterable<T> field(int pos) {
     return new Iterable<T>() {


### PR DESCRIPTION
Made a new PR because head repo is on main branch (vs previous publish-hoptimator-cli). The updates to FlinkIterator as mentioned in #19 are still relevant.

I updated the CLI to just have one test command (`!check`) which supports the following:
`!check empty <query>`
`!check not empty <query>`
`!check value <value> <query>`