### PR TITLE
Namespace arguments for hoptimator-operator

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,3 +28,5 @@ kubernetesExtendedClient = "io.kubernetes:client-java-extended:16.0.2"
 slf4jSimple = "org.slf4j:slf4j-simple:1.7.30"
 slf4jApi = "org.slf4j:slf4j-api:1.7.30"
 sqlline = "sqlline:sqlline:1.12.0"
+commonsCli = 'commons-cli:commons-cli:1.4'
+

--- a/hoptimator-cli/src/main/java/com/linkedin/hoptimator/HoptimatorCliApp.java
+++ b/hoptimator-cli/src/main/java/com/linkedin/hoptimator/HoptimatorCliApp.java
@@ -360,10 +360,15 @@ public class HoptimatorCliApp {
             }
             break;
           case "value":
+            boolean varFound = false;
             while (iter.hasNext()) {
               if(String.valueOf(iter.next()).contains(value)) {
+                varFound = true;
                 break;
               }
+            }
+            if (varFound) {
+              break;
             }
             throw new IllegalArgumentException("Query result did not contain expected value");
         }

--- a/hoptimator-operator/build.gradle
+++ b/hoptimator-operator/build.gradle
@@ -26,6 +26,8 @@ dependencies {
   implementation libs.kubernetesExtendedClient
   implementation libs.slf4jApi
 
+  implementation 'commons-cli:commons-cli:1.4'
+
   testImplementation libs.junit
   testImplementation libs.assertj
 }

--- a/hoptimator-operator/build.gradle
+++ b/hoptimator-operator/build.gradle
@@ -25,9 +25,8 @@ dependencies {
   implementation libs.kubernetesClient
   implementation libs.kubernetesExtendedClient
   implementation libs.slf4jApi
-
-  implementation 'commons-cli:commons-cli:1.4'
-
+  implementation libs.commonsCli
+  
   testImplementation libs.junit
   testImplementation libs.assertj
 }

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
@@ -45,7 +45,7 @@ public class HoptimatorOperatorApp {
   }
 
   public static void main(String[] args) throws Exception {
-    if (args.length<1) {
+    if (args.length < 1) {
       throw new IllegalArgumentException("Missing model file argument.");
     }
 

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
@@ -60,13 +60,13 @@ public class HoptimatorOperatorApp {
     CommandLine cmd;
 
     try {
-        cmd = parser.parse(options, args);
+      cmd = parser.parse(options, args);
     } catch (ParseException e) {
-        System.out.println(e.getMessage());
-        formatter.printHelp("utility-name", options);
+      System.out.println(e.getMessage());
+      formatter.printHelp("utility-name", options);
 
-        System.exit(1);
-        return;
+      System.exit(1);
+      return;
     }
 
     String modelFileInput = cmd.getArgs()[0];

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
@@ -13,6 +13,14 @@ import com.linkedin.hoptimator.models.V1alpha1SqlJobList;
 import com.linkedin.hoptimator.operator.subscription.SubscriptionReconciler;
 import com.linkedin.hoptimator.planner.HoptimatorPlanner;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,10 +45,34 @@ public class HoptimatorOperatorApp {
   }
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 1) {
+    if (args.length<1) {
       throw new IllegalArgumentException("Missing model file argument.");
     }
-    new HoptimatorOperatorApp(args[0], "default", new Properties()).run();
+
+    Options options = new Options();
+
+    Option namespace = new Option("n", "namespace", true, "specified namespace");
+    namespace.setRequired(false);
+    options.addOption(namespace);
+
+    CommandLineParser parser = new DefaultParser();
+    HelpFormatter formatter = new HelpFormatter();
+    CommandLine cmd;
+
+    try {
+        cmd = parser.parse(options, args);
+    } catch (ParseException e) {
+        System.out.println(e.getMessage());
+        formatter.printHelp("utility-name", options);
+
+        System.exit(1);
+        return;
+    }
+
+    String modelFileInput = cmd.getArgs()[0];
+    String namespaceInput = cmd.getOptionValue("namespace", "default");
+
+    new HoptimatorOperatorApp(modelFileInput, namespaceInput, new Properties()).run();
   }
 
   public void run() throws Exception {


### PR DESCRIPTION
Added Apache Commons CLI to dependencies and used it to create the optional namespace argument for hoptimator-operator. While overkill for a singular flag, I'm expecting more flags will be added later, so a library for parsing arguments will make adding these much easier.

I manually tested with and without the -n/--namespace flag and it worked both times (i.e., the hoptimator-operator registered the namespace).

This PR addresses #17 