### PR TITLE
Add !mermaid command

### DIFF
--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ResourceProvider.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ResourceProvider.java
@@ -1,10 +1,98 @@
 package com.linkedin.hoptimator.catalog;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-/** In Hoptimator, Tables can have baggage in the form of Resources. */
+/**
+ * Enables an adapter to emit arbitrary Resources for a given table.
+ *
+ * Optionally, establishes source->sink relationships between such Resources. These are used
+ * strictly for debugging purposes.
+ */
 public interface ResourceProvider {
 
   /** Resources for the given table */
   Collection<Resource> resources(String tableName);
+
+  /**
+   * Establishes a source->sink relationship between this ResourceProvider and a sink Resource.
+   *
+   * All leaf-node Resources provided by this ResourceProvider will become inputs to the sink.
+   *
+   * e.g.
+   * <pre>
+   *   ResourceProvider.empty().with(x -> a).with(x -> b).to(x -> c).to(x -> d)
+   * </pre>
+   *
+   * encodes the following DAG:
+   * <pre>
+   *   a --> c
+   *   b --> c
+   *   c --> d
+   * </pre>
+   */
+  default ResourceProvider toAll(ResourceProvider sink) {
+    return x -> {
+      List<Resource> combined = new ArrayList<>();
+      List<Resource> sources = new ArrayList<>();
+      List<Resource> sinks = new ArrayList<>();
+      sources.addAll(resources(x));
+      combined.addAll(sources);
+
+      // remove all non-leaf-node upstream Resources
+      sources.removeAll(sources.stream().flatMap(y -> y.inputs().stream())
+        .collect(Collectors.toList()));
+
+      // link all sources to all sinks       
+      sink.resources(x).forEach(y -> {
+        combined.add(new Resource(y) {{
+          sources.forEach(z -> input(z));
+        }});
+      });
+
+      return combined;
+    };
+  }
+
+  default ResourceProvider to(Resource resource) {
+    return toAll(x -> Collections.singleton(resource));
+  }
+
+  default ResourceProvider to(Function<String, Resource> resourceFunc) {
+    return toAll(x -> Collections.singleton(resourceFunc.apply(x)));
+  }
+
+  /** Combines this ResourceProvider with another ResourceProvider */
+  default ResourceProvider withAll(ResourceProvider resourceProvider) {
+    return x -> {
+      List<Resource> combined = new ArrayList<>();
+      combined.addAll(resources(x));
+      combined.addAll(resourceProvider.resources(x));
+      return combined;
+    };
+  }
+
+  default ResourceProvider with(Resource resource) {
+    return withAll(x -> Collections.singleton(resource));
+  }
+
+  default ResourceProvider with(Function<String, Resource> resourceFunc) {
+    return withAll(x -> Collections.singleton(resourceFunc.apply(x)));
+  }
+
+  static ResourceProvider empty() {
+    return x -> Collections.emptyList();
+  }
+
+  static ResourceProvider from(Collection<Resource> resources) {
+    return x -> resources;
+  }
+
+  static ResourceProvider from(Resource resource) {
+    return x -> Collections.singleton(resource);
+  }
 }

--- a/hoptimator-cli/src/main/java/com/linkedin/hoptimator/HoptimatorCliApp.java
+++ b/hoptimator-cli/src/main/java/com/linkedin/hoptimator/HoptimatorCliApp.java
@@ -49,7 +49,8 @@ public class HoptimatorCliApp {
     commandHandlers.add(new PipelineCommandHandler());
     commandHandlers.add(new IntroCommandHandler());
     commandHandlers.add(new InsertCommandHandler());
-    commandHandlers.add(new TestCommandHandler());
+    commandHandlers.add(new CheckCommandHandler());
+    commandHandlers.add(new MermaidCommandHandler());
     sqlline.updateCommandHandlers(commandHandlers);
     return sqlline.begin(args, null, true).ordinal();
   }
@@ -267,7 +268,7 @@ public class HoptimatorCliApp {
     }
   }
 
-  private class TestCommandHandler implements CommandHandler {
+  private class CheckCommandHandler implements CommandHandler {
 
     @Override
     public String getName() {
@@ -515,6 +516,81 @@ public class HoptimatorCliApp {
       Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader().getResourceAsStream("intro.txt"));
       while (scanner.hasNext()) {
         sqlline.output(scanner.nextLine());
+      }
+    }
+
+    @Override
+    public List<Completer> getParameterCompleters() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean echoToFile() {
+      return false;
+    }
+  }
+
+  private class MermaidCommandHandler implements CommandHandler {
+
+    @Override
+    public String getName() {
+      return "mermaid";
+    }
+
+    @Override
+    public List<String> getNames() {
+      return Collections.singletonList(getName());
+    }
+
+    @Override
+    public String getHelpText() {
+      return "Render a pipeline in mermaid format (similar to graphviz)";
+    }
+
+    @Override
+    public String matches(String line) {
+      String sql = line;
+      if (sql.startsWith(SqlLine.COMMAND_PREFIX)) {
+        sql = sql.substring(1);
+      }
+
+      if (sql.startsWith("mermaid")) {
+        sql = sql.substring("mermaid".length() + 1);
+        return sql;
+      }
+
+      return null;
+    }
+
+    @Override
+    public void execute(String line, DispatchCallback dispatchCallback) {
+      String sql = line;
+      if (sql.startsWith(SqlLine.COMMAND_PREFIX)) {
+        sql = sql.substring(1);
+      }
+
+      if (sql.startsWith("mermaid")) {
+        sql = sql.substring("mermaid".length() + 1);
+      }
+
+      //remove semicolon from query if present
+      if (sql.length() > 0 && sql.charAt(sql.length() - 1) == ';') {
+        sql = sql.substring(0, sql.length() - 1);
+      }
+
+      String connectionUrl = sqlline.getConnectionMetadata().getUrl();
+      try {
+        HoptimatorPlanner planner = HoptimatorPlanner.fromModelFile(connectionUrl, new Properties());
+        PipelineRel plan = planner.pipeline(sql);
+        PipelineRel.Implementor impl = new PipelineRel.Implementor(plan);
+        HopTable outputTable = new HopTable("PIPELINE", "SINK", plan.getRowType(),
+          Collections.singletonMap("connector", "dummy"));
+        Pipeline pipeline = impl.pipeline(outputTable);
+        sqlline.output(pipeline.mermaid());
+        dispatchCallback.setToSuccess();
+      } catch (Exception e) {
+        sqlline.error(e.toString());
+        dispatchCallback.setToFailure();
       }
     }
 

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/Pipeline.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/Pipeline.java
@@ -5,6 +5,9 @@ import org.apache.calcite.rel.type.RelDataType;
 import com.linkedin.hoptimator.catalog.Resource;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /** A set of Resources that deliver data.
  *
@@ -34,5 +37,47 @@ public class Pipeline {
       sb.append("\n---\n"); // yaml resource separator
     }
     return sb.toString();
+  }
+
+  /** Render a graph of resources in mermaid format */
+  public String mermaid() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("flowchart\n");
+    Map<String, List<Resource>> grouped = resources.stream()
+      .collect(Collectors.groupingBy(x -> x.kind()));
+    grouped.forEach((k, v) -> {
+      sb.append("  subgraph " + k + "\n");
+      v.forEach(x -> {
+        String description = x.keys().stream()
+          .filter(k2 -> x.property(k2) != null)
+          .filter(k2 -> !x.property(k2).isEmpty())
+          .map(k2 -> k2 + ": " + sanitize(x.property(k2)))
+          .collect(Collectors.joining("\n"));
+        sb.append("  " + id(x) + "[\"" + description + "\"]\n");
+      });
+      sb.append("  end\n");
+    });
+    grouped.forEach((k, v) -> {
+      sb.append("  subgraph " + k + "\n");
+      v.forEach(x -> {
+        x.inputs().forEach(y -> {
+          sb.append("    " + id(y) + " --> " + id(x) + "\n");
+        });
+      });
+      sb.append("  end\n");
+    });
+    return sb.toString();
+  }
+
+  private static String id(Resource resource) {
+    return "R" + Integer.toString(resource.hashCode());
+  }
+
+  private static String sanitize(String s) {
+    String safe = s.replaceAll("\"", "&quot;").replaceAll("\n", " ").trim();
+    if (safe.length() > 20) {
+      return safe.substring(0, 17) + "..."; 
+    }
+    return safe;
   }
 }

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
@@ -9,10 +9,12 @@ import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.MysqlSqlDialect;
 
 import com.linkedin.hoptimator.catalog.Resource;
+import com.linkedin.hoptimator.catalog.ResourceProvider;
 import com.linkedin.hoptimator.catalog.HopTable;
 import com.linkedin.hoptimator.catalog.ScriptImplementor;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -90,9 +92,14 @@ public interface PipelineRel extends RelNode {
 
     /** Combine SQL and any Resources into a Pipeline */
     public Pipeline pipeline(HopTable sink) {
-      List<Resource> resourcesAndJob = new ArrayList<>();
-      resourcesAndJob.addAll(resources);
-      resourcesAndJob.add(new SqlJob(insertInto(sink)));
+
+      // We re-use ResourceProvider here for its source->sink relationships
+      ResourceProvider resourceProvider = ResourceProvider.from(resources)
+        .to(new SqlJob(insertInto(sink)));
+
+      // All resources are now "provided", so we can pass null here:
+      Collection<Resource> resourcesAndJob = resourceProvider.resources(null);
+
       return new Pipeline(resourcesAndJob, rowType());
     }
   }


### PR DESCRIPTION
Added a new CLI command `!mermaid` which renders pipelines as mermaid flowcharts. In the resulting graph, resources are grouped by "kind".

Added a builder DSL to `ResourceProvider` to enable expressing source->sink relationships between resources. These relationships are not meaningful to the planner or operator.

## Testing

The existing adapters are too simple to adequately test this against, so I modified the Kafka adapter to include additional "hops" (not included in the PR):

```
ResourceProvider.empty()
  .with(x -> new MySqlTable(x))
  .to(x -> new BrooklinCDC(x))
  .to(x -> new KafkaTopic(x, numPartitions, topicConfigProvider.config(x)))
```

Using this somewhat contrived adapter, I tested a simple query across two tables:

```
0: hoptimator> !mermaid SELECT * FROM RAWKAFKA."products", RAWKAFKA."test-topic"
```

... which produces the following flowchart:

```mermaid
flowchart
  subgraph SqlJob
  R663951423["sql: CREATE DATABASE I..."]
  end
  subgraph BrooklinCDC
  R1206753277["name: products"]
  R-354296883["name: test-topic"]
  end
  subgraph MySqlTable
  R-623545925["name: products"]
  R1664761355["name: test-topic"]
  end
  subgraph KafkaTopic
  R-41078963["clientOverrides: group.id: hoptima...
name: products
numPartitions: null"]
  R1728328189["clientOverrides: group.id: hoptima...
name: test-topic
numPartitions: null"]
  end
  subgraph SqlJob
    R-41078963 --> R663951423
    R1728328189 --> R663951423
  end
  subgraph BrooklinCDC
    R-623545925 --> R1206753277
    R1664761355 --> R-354296883
  end
  subgraph MySqlTable
  end
  subgraph KafkaTopic
    R1206753277 --> R-41078963
    R-354296883 --> R1728328189
  end
```
