### PR TITLE
Support Environment chains

### DIFF
--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ResourceTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ResourceTest.java
@@ -1,0 +1,28 @@
+package com.linkedin.hoptimator.catalog;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ResourceTest {
+
+  @Test
+  public void handlesChainedEnvironments() {
+    Resource.Environment env = new Resource.SimpleEnvironment() {{
+      export("one", "1");
+      export("foo", "bar");
+    }}.orElse(new Resource.SimpleEnvironment() {{
+      export("two", "2");
+      export("foo", "car");
+    }}.orElse(new Resource.SimpleEnvironment() {{
+      export("three", "3");
+      export("foo", "dar");
+    }}));
+    assertEquals("1", env.getOrDefault("one", () -> "x"));
+    assertEquals("2", env.getOrDefault("two", () -> "x"));
+    assertEquals("3", env.getOrDefault("three", () -> "x"));
+    assertEquals("bar", env.getOrDefault("foo", () -> "x"));
+    assertEquals("x", env.getOrDefault("oof", () -> "x"));
+  }
+}

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
@@ -6,6 +6,7 @@ import io.kubernetes.client.util.Config;
 import io.kubernetes.client.extended.controller.Controller;
 import io.kubernetes.client.extended.controller.ControllerManager;
 
+import com.linkedin.hoptimator.catalog.Resource;
 import com.linkedin.hoptimator.models.V1alpha1Subscription;
 import com.linkedin.hoptimator.models.V1alpha1SubscriptionList;
 import com.linkedin.hoptimator.operator.subscription.SubscriptionReconciler;
@@ -34,12 +35,14 @@ public class HoptimatorOperatorApp {
   final String modelPath;
   final String namespace;
   final Properties properties;
+  final Resource.Environment environment;
 
   /** This constructor is likely to evolve and break. */
   public HoptimatorOperatorApp(String modelPath, String namespace, Properties properties) {
     this.modelPath = modelPath;
     this.namespace = namespace;
     this.properties = properties;
+    this.environment = new Resource.SimpleEnvironment(properties);
   }
 
   public static void main(String[] args) throws Exception {
@@ -91,7 +94,7 @@ public class HoptimatorOperatorApp {
 
     List<Controller> controllers = new ArrayList<>();
     controllers.addAll(ControllerService.controllers(operator));
-    controllers.add(SubscriptionReconciler.controller(operator, plannerFactory));
+    controllers.add(SubscriptionReconciler.controller(operator, plannerFactory, environment));
 
     ControllerManager controllerManager = new ControllerManager(operator.informerFactory(),
       controllers.toArray(new Controller[0]));

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionEnvironment.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionEnvironment.java
@@ -26,27 +26,13 @@ import java.util.Collections;
  *     as a basis for deriving K8s object names, Kafka topic names, etc. The
  *     name is guaranteed to be a valid K8s object name, e.g. `my-subscription`.
  *  - `pipeline.avroSchema`, an Avro schema for the pipeline's output type.
- *
- * In addition, any "hints" in the Subscription object (`.spec.hints`) are
- * exported as-is. These can be used to provide optional properties to
- * templates. When using such hints in a template, ensure that you provide a
- * default value, e.g. `{{numPartitions:null}``, since they will usually be
- * missing.
  */
 public class SubscriptionEnvironment extends Resource.SimpleEnvironment {
 
-  public SubscriptionEnvironment(String namespace, String name, Pipeline pipeline,
-      Map<String, String> hints) {
-    if (hints != null) {
-      exportAll(hints);
-    }
+  public SubscriptionEnvironment(String namespace, String name, Pipeline pipeline) {
     export("pipeline.namespace", namespace);
     export("pipeline.name", name);
     export("pipeline.avroSchema", AvroConverter.avro("com.linkedin.hoptimator", "OutputRecord",
       pipeline.outputType()).toString(false));
-  }
-
-  public SubscriptionEnvironment(String namespace, String name, Pipeline pipeline) {
-    this(namespace, name, pipeline, Collections.emptyMap());
   }
 }


### PR DESCRIPTION
Support `Resource.Environment` chains s.t. Resource templates can resolve variables from multiple places while enforcing an order of precedence.

Expose `Operator.properties()` to Resource templates via a root-level `Resource.Environment`. This enables users to pass arbitrary properties to the operator as command-line arguments, which are then visible within templates. Since these are exposed at the root-level (i.e. with lowest precedence), command-line properties will get masked by any other `Resource.Environment`s. For example, `pipeline.namespace` cannot be changed from the command-line, since the operator specifies this variable in an Environment with higher precedence.

We may consider reversing this behavior to give end-users more power, but for now we take the safer course.

### Testing Done ###

New unit test constructs an Environment chain and validates that variables are resolved with proper precedence.