### PR TITLE
Bug fix: handle capitals in Kafka topics

### DIFF
--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopic.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopic.java
@@ -2,14 +2,14 @@ package com.linkedin.hoptimator.catalog.kafka;
 
 import com.linkedin.hoptimator.catalog.Resource;
 
-import java.util.Optional;
-import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 
 class KafkaTopic extends Resource {
-  public KafkaTopic(String topicName, Map<String, String> clientOverrides) {
+  KafkaTopic(String topicName, Map<String, String> clientOverrides) {
     super("KafkaTopic");
     export("topicName", topicName);
+    export("topicNameLowerCase", topicName.toLowerCase(Locale.ROOT));
     export("clientOverrides", clientOverrides);
   }
 }

--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopicAcl.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopicAcl.java
@@ -2,10 +2,13 @@ package com.linkedin.hoptimator.catalog.kafka;
 
 import com.linkedin.hoptimator.catalog.Resource;
 
+import java.util.Locale;
+
 class KafkaTopicAcl extends Resource {
   public KafkaTopicAcl(String topicName, String principal, String method) {
     super("KafkaTopicAcl");
     export("topicName", topicName);
+    export("topicNameLowerCase", topicName.toLowerCase(Locale.ROOT));
     export("principal", principal);
     export("method", method);
   }

--- a/hoptimator-kafka-adapter/src/main/resources/KafkaTopic.yaml.template
+++ b/hoptimator-kafka-adapter/src/main/resources/KafkaTopic.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: hoptimator.linkedin.com/v1alpha1
 kind: KafkaTopic
 metadata:
-  name: {{topicName}}
+  name: {{topicNameLowerCase}}
   namespace: {{pipeline.namespace}}
 spec:
   topicName: {{topicName}}

--- a/hoptimator-kafka-adapter/src/main/resources/KafkaTopicAcl.yaml.template
+++ b/hoptimator-kafka-adapter/src/main/resources/KafkaTopicAcl.yaml.template
@@ -1,11 +1,11 @@
 apiVersion: hoptimator.linkedin.com/v1alpha1
 kind: Acl
 metadata:
-  name: {{topicName}}-acl-{{id}}
+  name: {{topicNameLowerCase}}-acl-{{id}}
   namespace: {{pipeline.namespace}}
 spec:
   resource:
     kind: KafkaTopic
-    name: {{topicName}}
+    name: {{topicNameLowerCase}}
   method: {{method}}
   principal: {{principal}} 


### PR DESCRIPTION
## Summary

The K8s API requires that object names and namespaces are all lowercase. The Kafka adapter was using the topic name as the object name, which K8s would reject if the topic has capital letters.

This fix uses a lowercased version of the topic name as the K8s object name.

## Testing

This bug caused a deploy to get stuck in a testing environment. Hot-fixing this bug caused the deploy to get unstuck and succeed.