### PR TITLE
Support longs

### DIFF
--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
@@ -32,6 +32,8 @@ public final class AvroConverter {
       switch (dataType.getSqlTypeName()) {
       case INTEGER:
         return createAvroTypeWithNullability(Schema.Type.INT, dataType.isNullable());
+      case BIGINT:
+        return createAvroTypeWithNullability(Schema.Type.LONG, dataType.isNullable());
       case VARCHAR:
         return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
       case FLOAT:
@@ -72,9 +74,10 @@ public final class AvroConverter {
         .filter(x -> x.getValue().getSqlTypeName() != unknown.getSqlTypeName())
         .collect(Collectors.toList()));
     case INT:
-    case LONG:
       // schema.isNullable() should be false for basic types iiuc
       return createRelTypeWithNullability(typeFactory, SqlTypeName.INTEGER, schema.isNullable());
+    case LONG:
+      return createRelTypeWithNullability(typeFactory, SqlTypeName.BIGINT, schema.isNullable());
     case ENUM:
     case STRING:
       return createRelTypeWithNullability(typeFactory, SqlTypeName.VARCHAR, schema.isNullable());

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/builtin/DatagenSchemaFactory.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/builtin/DatagenSchemaFactory.java
@@ -27,7 +27,8 @@ public class DatagenSchemaFactory implements SchemaFactory {
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     Map<String, HopTable> datagenTables = new HashMap<>();
     datagenTables.put("PERSON", new HopTable("DATAGEN", "PERSON", (new RelDataTypeFactory.Builder(typeFactory))
-      .add("NAME", SqlTypeName.VARCHAR).add("AGE", SqlTypeName.INTEGER).build(), ConfigProvider.empty()
+      .add("NAME", SqlTypeName.VARCHAR).add("AGE", SqlTypeName.INTEGER)
+      .add("EMPID", SqlTypeName.BIGINT).build(), ConfigProvider.empty()
       .with("connector", "datagen").with("number-of-rows", "10").with("fields.AGE.min", "0")
       .with("fields.AGE.max", "100").with("fields.NAME.length", "5").config("PERSON")));
     datagenTables.put("COMPANY", new HopTable("DATAGEN", "COMPANY", (new RelDataTypeFactory.Builder(typeFactory))


### PR DESCRIPTION
## Summary

Add support for BIGINT aka LONG.

## Details

When an input topic has a Long in the Avro schema, the resulting pipeline was trying to cast from Long down to Int, causing a ClassCastException within Flink (see below). This is because `AvroConverter` was essentially equating Ints and Longs, which works one way but not the other!

## Testing Done

I added a BIGINT field to the built-in PERSON table. The existing integration tests should validate this now works.

## Appendix

Relevant stack trace:

```
    Caused by: java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Integer
	at org.apache.flink.table.data.GenericRowData.getInt(GenericRowData.java:149)
	at org.apache.flink.table.data.RowData.lambda$createFieldGetter$245ca7d1$6(RowData.java:245)
	at org.apache.flink.table.data.RowData.lambda$createFieldGetter$25774257$1(RowData.java:296)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copyRowData(RowDataSerializer.java:170)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:131)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:48)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copyRowData(RowDataSerializer.java:170)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:131)
	at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:48)
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:80)
```