### PR TITLE
Add support for transformations in resource templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ deploy-dev-environment:
 	kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml || echo "skipping"
 	kubectl create namespace kafka || echo "skipping"
 	kubectl create namespace mysql || echo "skipping"
-	helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.4.0/
+	helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.6.1/
 	helm upgrade --install --atomic --set webhook.create=false flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
 	kubectl apply -f "https://strimzi.io/install/latest?namespace=kafka" -n kafka
 	kubectl wait --for=condition=Established=True crds/kafkas.kafka.strimzi.io

--- a/deploy/dev/kafka.yaml
+++ b/deploy/dev/kafka.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: kafka
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.1
     replicas: 1
     listeners:
       - name: plain

--- a/etc/integration-tests.sql
+++ b/etc/integration-tests.sql
@@ -7,19 +7,20 @@
 SELECT * FROM DATAGEN.PERSON;
 SELECT * FROM DATAGEN.COMPANY;
 
+-- test mermaid and yaml commands
+!mermaid insert into RAWKAFKA."test-sink" SELECT AGE AS PAYLOAD, NAME AS KEY FROM DATAGEN.PERSON
+!yaml insert into RAWKAFKA."test-sink" SELECT AGE AS PAYLOAD, NAME AS KEY FROM DATAGEN.PERSON
+
+-- test insert into command
+!insert into RAWKAFKA."test-sink" SELECT AGE AS PAYLOAD, NAME AS KEY FROM DATAGEN.PERSON
+SELECT * FROM RAWKAFKA."test-sink" LIMIT 5;
+
 -- MySQL CDC tables
 SELECT * FROM INVENTORY."products_on_hand" LIMIT 1;
 
 -- Test check command
 !check not empty SELECT * FROM INVENTORY."products_on_hand";
 
--- MySQL CDC -> Kafka
+-- MySQL CDC -> Kafka (via sample subscription "products")
 SELECT * FROM RAWKAFKA."products" LIMIT 1;
 
--- test insert into command
-!insert into RAWKAFKA."test-sink" SELECT AGE AS PAYLOAD, NAME AS KEY FROM DATAGEN.PERSON
-SELECT * FROM RAWKAFKA."test-sink" LIMIT 5;
-
--- test mermaid and yaml commands
-!mermaid insert into RAWKAFKA."test-sink" SELECT AGE AS PAYLOAD, NAME AS KEY FROM DATAGEN.PERSON
-!yaml insert into RAWKAFKA."test-sink" SELECT AGE AS PAYLOAD, NAME AS KEY FROM DATAGEN.PERSON

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Names.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Names.java
@@ -1,0 +1,19 @@
+package com.linkedin.hoptimator.catalog;
+
+import java.util.Locale;
+
+public final class Names {
+
+  private Names() {
+  }
+
+  /** Attempt to format s as a K8s object name, or part of one. */
+  public static String canonicalize(String s) {
+    return s.toLowerCase(Locale.ROOT)
+      .replaceAll("[^a-z0-9\\-]+", "-")
+      .replaceAll("^[^a-z0-9]*", "")
+      .replaceAll("[^a-z0-9]*$", "")
+      .replaceAll("\\-+", "-");
+  }
+
+}

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ResourceTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ResourceTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
+import java.util.function.Function;
+
 public class ResourceTest {
 
   @Test
@@ -24,5 +26,27 @@ public class ResourceTest {
     assertEquals("3", env.getOrDefault("three", () -> "x"));
     assertEquals("bar", env.getOrDefault("foo", () -> "x"));
     assertEquals("x", env.getOrDefault("oof", () -> "x"));
+  }
+
+  @Test
+  public void rendersTemplates() {
+    Resource.Environment env = new Resource.SimpleEnvironment() {{
+      export("one", "1");
+      export("foo", "bar");
+    }};
+    Resource res = new Resource("x") {{
+      export("car", "Hyundai Accent");
+      export("parts", "wheels\nseats\nbrakes\nwipers");
+    }};
+
+    Function<String, Resource.Template> f = x -> new Resource.SimpleTemplate(env, x);
+    assertEquals("xyz", f.apply("xyz").render(res));
+    assertEquals("bar", f.apply("{{foo}}").render(res));
+    assertEquals("bar", f.apply("{{ foo }}").render(res));
+    assertEquals("abc", f.apply("{{xyz:abc}}").render(res));
+    assertEquals("hyundai-accent", f.apply("{{car toName}}").render(res));
+    assertEquals("HYUNDAI-ACCENT", f.apply("{{car toName toUpperCase}}").render(res));
+    assertEquals("WHEELSSEATSBRAKESWIPERS", f.apply("{{parts concat toUpperCase}}").render(res));
+    assertEquals("BAR\nbar\nxyz", f.apply("{{foo toUpperCase}}\n{{foo toLowerCase}}\n{{x:xyz}}").render(res));
   }
 }

--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopic.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopic.java
@@ -2,14 +2,12 @@ package com.linkedin.hoptimator.catalog.kafka;
 
 import com.linkedin.hoptimator.catalog.Resource;
 
-import java.util.Locale;
 import java.util.Map;
 
 class KafkaTopic extends Resource {
   KafkaTopic(String topicName, Map<String, String> clientOverrides) {
     super("KafkaTopic");
     export("topicName", topicName);
-    export("topicNameLowerCase", topicName.toLowerCase(Locale.ROOT));
     export("clientOverrides", clientOverrides);
   }
 }

--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopicAcl.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/KafkaTopicAcl.java
@@ -8,7 +8,6 @@ class KafkaTopicAcl extends Resource {
   public KafkaTopicAcl(String topicName, String principal, String method) {
     super("KafkaTopicAcl");
     export("topicName", topicName);
-    export("topicNameLowerCase", topicName.toLowerCase(Locale.ROOT));
     export("principal", principal);
     export("method", method);
   }

--- a/hoptimator-kafka-adapter/src/main/resources/KafkaTopic.yaml.template
+++ b/hoptimator-kafka-adapter/src/main/resources/KafkaTopic.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: hoptimator.linkedin.com/v1alpha1
 kind: KafkaTopic
 metadata:
-  name: {{topicNameLowerCase}}
+  name: {{topicName toName}}
   namespace: {{pipeline.namespace}}
 spec:
   topicName: {{topicName}}

--- a/hoptimator-kafka-adapter/src/main/resources/KafkaTopicAcl.yaml.template
+++ b/hoptimator-kafka-adapter/src/main/resources/KafkaTopicAcl.yaml.template
@@ -1,11 +1,11 @@
 apiVersion: hoptimator.linkedin.com/v1alpha1
 kind: Acl
 metadata:
-  name: {{topicNameLowerCase}}-acl-{{id}}
+  name: {{topicName toName}}-acl-{{id}}
   namespace: {{pipeline.namespace}}
 spec:
   resource:
     kind: KafkaTopic
-    name: {{topicNameLowerCase}}
+    name: {{topicName toName}}
   method: {{method}}
   principal: {{principal}} 

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionReconciler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionReconciler.java
@@ -71,6 +71,8 @@ public class SubscriptionReconciler implements Reconciler {
       
       String kind = object.getKind();
 
+      object.getMetadata().setNamespace(namespace);
+
       V1alpha1SubscriptionStatus status = object.getStatus();
       if (status == null) {
         status = new V1alpha1SubscriptionStatus();
@@ -198,6 +200,10 @@ public class SubscriptionReconciler implements Reconciler {
 
     DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
     String namespace = obj.getMetadata().getNamespace();
+    if (namespace == null) {
+      namespace = owner.getMetadata().getNamespace();
+      obj.getMetadata().setNamespace(namespace);
+    }
     String name = obj.getMetadata().getName();
     KubernetesApiResponse<DynamicKubernetesObject> existing = operator.apiFor(obj).get(namespace, name);
     if (existing.isSuccess()) {


### PR DESCRIPTION
## Summary

Templates frequently need the same variable in different forms, e.g. `kafkaTopic` and `kafkaTopicLowerCase`. Rather than require `Resource`s to define multiple different formats of the same values, we now support simple transformations to be expressed in the templates themselves. This is similar to how Go/Helm templates allow transformation pipelines.

## Details

The following forms are added:

 - `{{var toName}}`, `{{var:default toName}}`: canonicalize the variable as a valid K8s object name.
 - `{{var toUpperCase}}`, `{{var:default toUpperCase}}`: render in all upper case.
 - `{{var toLowerCase}}`, `{{var:default toLowerCase}}`: render in all lower case.
 - `{{var concat}}`, `{{var:default concat}}`: concatinate a multiline string into one line
 - `{{var concat toUpperCase}}`: apply both transformations in sequence.

## Testing

New unit test exercises these transformations. 