### PR TITLE
Gather attributes of downstream resources

### DIFF
--- a/deploy/subscriptions.crd.yaml
+++ b/deploy/subscriptions.crd.yaml
@@ -68,8 +68,23 @@ spec:
                   type: object
                   additionalProperties:
                     type: string
+                attributes:
+                  description: Physical attributes of the job and sink/output table.
+                  type: object
+                  additionalProperties:
+                    type: string
                 resources:
-                  description: The YAML generated to implement this pipeline.
+                  description: The yaml generated to implement this pipeline.
+                  type: array
+                  items:
+                    type: string
+                jobResources:
+                  description: The yaml generated to implement the job.
+                  type: array
+                  items:
+                    type: string
+                downstreamResources:
+                  description: The yaml generated to implement the sink/output table.
                   type: array
                   items:
                     type: string

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Acl.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Acl.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Access control rule (colloquially, an Acl)
  */
 @ApiModel(description = "Access control rule (colloquially, an Acl)")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1Acl implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclList.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * AclList is a list of Acl
  */
 @ApiModel(description = "AclList is a list of Acl")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1AclList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpec.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpec.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * A set of related ACL rules.
  */
 @ApiModel(description = "A set of related ACL rules.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1AclSpec {
   /**
    * The resource access method.

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpecResource.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpecResource.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * The resource being controlled.
  */
 @ApiModel(description = "The resource being controlled.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1AclSpecResource {
   public static final String SERIALIZED_NAME_KIND = "kind";
   @SerializedName(SERIALIZED_NAME_KIND)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclStatus.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Status, as set by the operator.
  */
 @ApiModel(description = "Status, as set by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1AclStatus {
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopic.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopic.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Kafka Topic
  */
 @ApiModel(description = "Kafka Topic")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1KafkaTopic implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicList.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * KafkaTopicList is a list of KafkaTopic
  */
 @ApiModel(description = "KafkaTopicList is a list of KafkaTopic")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1KafkaTopicList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpec.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpec.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * Desired Kafka topic configuration.
  */
 @ApiModel(description = "Desired Kafka topic configuration.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpec {
   public static final String SERIALIZED_NAME_CLIENT_CONFIGS = "clientConfigs";
   @SerializedName(SERIALIZED_NAME_CLIENT_CONFIGS)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecClientConfigs.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecClientConfigs.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * V1alpha1KafkaTopicSpecClientConfigs
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpecClientConfigs {
   public static final String SERIALIZED_NAME_CONFIG_MAP_REF = "configMapRef";
   @SerializedName(SERIALIZED_NAME_CONFIG_MAP_REF)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecConfigMapRef.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecConfigMapRef.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Reference to a ConfigMap to use for AdminClient configuration.
  */
 @ApiModel(description = "Reference to a ConfigMap to use for AdminClient configuration.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpecConfigMapRef {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicStatus.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Current state of the topic.
  */
 @ApiModel(description = "Current state of the topic.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1KafkaTopicStatus {
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Subscription.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Subscription.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator Subscription
  */
 @ApiModel(description = "Hoptimator Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1Subscription implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionList.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SubscriptionList is a list of Subscription
  */
 @ApiModel(description = "SubscriptionList is a list of Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1SubscriptionList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionSpec.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionSpec.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Subscription spec
  */
 @ApiModel(description = "Subscription spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1SubscriptionSpec {
   public static final String SERIALIZED_NAME_DATABASE = "database";
   @SerializedName(SERIALIZED_NAME_DATABASE)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionStatus.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionStatus.java
@@ -32,8 +32,16 @@ import java.util.Map;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T21:19:50.466Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-09T06:53:38.470Z[Etc/UTC]")
 public class V1alpha1SubscriptionStatus {
+  public static final String SERIALIZED_NAME_ATTRIBUTES = "attributes";
+  @SerializedName(SERIALIZED_NAME_ATTRIBUTES)
+  private Map<String, String> attributes = null;
+
+  public static final String SERIALIZED_NAME_DOWNSTREAM_RESOURCES = "downstreamResources";
+  @SerializedName(SERIALIZED_NAME_DOWNSTREAM_RESOURCES)
+  private List<String> downstreamResources = null;
+
   public static final String SERIALIZED_NAME_FAILED = "failed";
   @SerializedName(SERIALIZED_NAME_FAILED)
   private Boolean failed;
@@ -41,6 +49,10 @@ public class V1alpha1SubscriptionStatus {
   public static final String SERIALIZED_NAME_HINTS = "hints";
   @SerializedName(SERIALIZED_NAME_HINTS)
   private Map<String, String> hints = null;
+
+  public static final String SERIALIZED_NAME_JOB_RESOURCES = "jobResources";
+  @SerializedName(SERIALIZED_NAME_JOB_RESOURCES)
+  private List<String> jobResources = null;
 
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)
@@ -57,6 +69,68 @@ public class V1alpha1SubscriptionStatus {
   public static final String SERIALIZED_NAME_SQL = "sql";
   @SerializedName(SERIALIZED_NAME_SQL)
   private String sql;
+
+
+  public V1alpha1SubscriptionStatus attributes(Map<String, String> attributes) {
+    
+    this.attributes = attributes;
+    return this;
+  }
+
+  public V1alpha1SubscriptionStatus putAttributesItem(String key, String attributesItem) {
+    if (this.attributes == null) {
+      this.attributes = new HashMap<>();
+    }
+    this.attributes.put(key, attributesItem);
+    return this;
+  }
+
+   /**
+   * Physical attributes of the job and sink/output table.
+   * @return attributes
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Physical attributes of the job and sink/output table.")
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+
+  public V1alpha1SubscriptionStatus downstreamResources(List<String> downstreamResources) {
+    
+    this.downstreamResources = downstreamResources;
+    return this;
+  }
+
+  public V1alpha1SubscriptionStatus addDownstreamResourcesItem(String downstreamResourcesItem) {
+    if (this.downstreamResources == null) {
+      this.downstreamResources = new ArrayList<>();
+    }
+    this.downstreamResources.add(downstreamResourcesItem);
+    return this;
+  }
+
+   /**
+   * The yaml generated to implement the sink/output table.
+   * @return downstreamResources
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The yaml generated to implement the sink/output table.")
+
+  public List<String> getDownstreamResources() {
+    return downstreamResources;
+  }
+
+
+  public void setDownstreamResources(List<String> downstreamResources) {
+    this.downstreamResources = downstreamResources;
+  }
 
 
   public V1alpha1SubscriptionStatus failed(Boolean failed) {
@@ -110,6 +184,37 @@ public class V1alpha1SubscriptionStatus {
 
   public void setHints(Map<String, String> hints) {
     this.hints = hints;
+  }
+
+
+  public V1alpha1SubscriptionStatus jobResources(List<String> jobResources) {
+    
+    this.jobResources = jobResources;
+    return this;
+  }
+
+  public V1alpha1SubscriptionStatus addJobResourcesItem(String jobResourcesItem) {
+    if (this.jobResources == null) {
+      this.jobResources = new ArrayList<>();
+    }
+    this.jobResources.add(jobResourcesItem);
+    return this;
+  }
+
+   /**
+   * The yaml generated to implement the job.
+   * @return jobResources
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The yaml generated to implement the job.")
+
+  public List<String> getJobResources() {
+    return jobResources;
+  }
+
+
+  public void setJobResources(List<String> jobResources) {
+    this.jobResources = jobResources;
   }
 
 
@@ -174,11 +279,11 @@ public class V1alpha1SubscriptionStatus {
   }
 
    /**
-   * The YAML generated to implement this pipeline.
+   * The yaml generated to implement this pipeline.
    * @return resources
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "The YAML generated to implement this pipeline.")
+  @ApiModelProperty(value = "The yaml generated to implement this pipeline.")
 
   public List<String> getResources() {
     return resources;
@@ -222,8 +327,11 @@ public class V1alpha1SubscriptionStatus {
       return false;
     }
     V1alpha1SubscriptionStatus v1alpha1SubscriptionStatus = (V1alpha1SubscriptionStatus) o;
-    return Objects.equals(this.failed, v1alpha1SubscriptionStatus.failed) &&
+    return Objects.equals(this.attributes, v1alpha1SubscriptionStatus.attributes) &&
+        Objects.equals(this.downstreamResources, v1alpha1SubscriptionStatus.downstreamResources) &&
+        Objects.equals(this.failed, v1alpha1SubscriptionStatus.failed) &&
         Objects.equals(this.hints, v1alpha1SubscriptionStatus.hints) &&
+        Objects.equals(this.jobResources, v1alpha1SubscriptionStatus.jobResources) &&
         Objects.equals(this.message, v1alpha1SubscriptionStatus.message) &&
         Objects.equals(this.ready, v1alpha1SubscriptionStatus.ready) &&
         Objects.equals(this.resources, v1alpha1SubscriptionStatus.resources) &&
@@ -232,7 +340,7 @@ public class V1alpha1SubscriptionStatus {
 
   @Override
   public int hashCode() {
-    return Objects.hash(failed, hints, message, ready, resources, sql);
+    return Objects.hash(attributes, downstreamResources, failed, hints, jobResources, message, ready, resources, sql);
   }
 
 
@@ -240,8 +348,11 @@ public class V1alpha1SubscriptionStatus {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class V1alpha1SubscriptionStatus {\n");
+    sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+    sb.append("    downstreamResources: ").append(toIndentedString(downstreamResources)).append("\n");
     sb.append("    failed: ").append(toIndentedString(failed)).append("\n");
     sb.append("    hints: ").append(toIndentedString(hints)).append("\n");
+    sb.append("    jobResources: ").append(toIndentedString(jobResources)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    ready: ").append(toIndentedString(ready)).append("\n");
     sb.append("    resources: ").append(toIndentedString(resources)).append("\n");


### PR DESCRIPTION
# Summary

The subscription controller now gathers "attributes" from downstream resources and reports them as `.status.attributes`. These attributes are open-ended and depend on the various downstream controllers, but currently include `jobId`, `numPartitions`, `startTime`, and more, as reported by the Kafka topic controller and Flink operator.

The Kafka topic controller now reports the actual number of partitions, which may diverge from the `kafka.numPartitions` hint. This means users can request a specific number of partitions with `.spec.hints.kafka.numPartitions` and then check `.status.attributes.numPartitions` to see the actual number of partitions.

# Details

Attributes are collected from downstream resources and the job, not from upstream/input resources. For example, `numPartitions` would refer to an output Kafka topic, not an input Kafka topic.

Since it's possible for a sink/output table to have multiple physical tables under-the-hood (e.g. an adapter may create multiple Kafka topics for a single table), it's possible that attributes from different controllers will clash/conflict. We make a best effort by bubbling up the last seen attribute with a given key. This jibes with the strategy for applying "hints": they are applied across the entire set of output resources. In particular, setting the hint `kafka.numPartitions = N` will likely mean that `.status.attributes.numPartitions = N`, unless an adapter is doing something goofy.

# Testing

Validated that the Flink operator and KafkaTopic controller bubble-up attributes to Subscriptions:

```
$ kubectl get subs -ojsonpath={.items..status.attributes} | jq
{
  "jobId": "b3c1dd9f48ac15620e5d35ef17dfc041",
  "jobName": "products-flink-job",
  "numPartitions": "1",
  "startTime": "1707459424703",
  "state": "RUNNING",
  "updateTime": "1707459561622"
}
```

A neat consequence of this feature is that you can now check the `state` of the underlying Flink job.