### PR TITLE
Drop explicit ROW constructor from SELECTs

### DIFF
--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ScriptImplementor.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ScriptImplementor.java
@@ -3,14 +3,21 @@ package com.linkedin.hoptimator.catalog;
 import org.apache.calcite.sql.SqlWriter;
 //import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.SqlDataTypeSpec;
-import org.apache.calcite.sql.SqlRowTypeNameSpec;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlRowTypeNameSpec;
+import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.fun.SqlRowOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -129,9 +136,30 @@ public interface ScriptImplementor {
     public void implement(SqlWriter w) {
       RelToSqlConverter converter = new RelToSqlConverter(w.getDialect());
       SqlImplementor.Result result = converter.visitRoot(relNode);
-      w.literal(result.asSelect().toSqlString(w.getDialect()).getSql());
+      SqlSelect select = result.asSelect();
+      if (select.getSelectList() != null) {
+        select.setSelectList((SqlNodeList) select.getSelectList().accept(REMOVE_ROW_CONSTRUCTOR));
+      }
+      w.literal(select.toSqlString(w.getDialect()).getSql());
     }
-  } 
+
+    // A `ROW(...)` operator which will unparse as just `(...)`.
+    private final SqlRowOperator SILENT_COLUMN_LIST = new SqlRowOperator(""); // empty string name
+
+    // a shuttle that replaces `Row(...)` with just `(...)`
+    private final SqlShuttle REMOVE_ROW_CONSTRUCTOR = new SqlShuttle() {
+      @Override
+      public SqlNode visit(SqlCall call) {
+        List<SqlNode> operands = call.getOperandList().stream().map(x -> x.accept(this)).collect(Collectors.toList());
+        if (call.getKind() == SqlKind.ROW || call.getKind() == SqlKind.COLUMN_LIST
+              || call.getOperator() instanceof SqlRowOperator) {
+          return SILENT_COLUMN_LIST.createCall(call.getParserPosition(), operands);
+        } else {
+          return call.getOperator().createCall(call.getParserPosition(), operands);
+        }
+      }
+    };
+  }
 
   /**
    * Implements a CREATE TABLE...WITH... DDL statement.

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
@@ -28,10 +28,10 @@ public class ScriptImplementorTest {
     // Output isn't necessarily deterministic, but should be something like:
     //   CREATE TABLE IF NOT EXISTS "DATABASE"."TABLE1" ("idValue1" VARCHAR) WITH
     //   ('connector'='kafka', 'properties.bootstrap.servers'='localhost:9092', 'topic'='topic1')
-    assertTrue(out.contains("CREATE TABLE IF NOT EXISTS \"DATABASE\".\"TABLE1\" (\"idValue1\" VARCHAR) WITH "));
-    assertTrue(out.contains("'connector'='kafka'"));
-    assertTrue(out.contains("'properties.bootstrap.servers'='localhost:9092'"));
-    assertTrue(out.contains("'topic'='topic1'"));
-    assertFalse(out.contains("Row")); 
+    assertTrue(out, out.contains("CREATE TABLE IF NOT EXISTS \"DATABASE\".\"TABLE1\" (\"idValue1\" VARCHAR) WITH "));
+    assertTrue(out, out.contains("'connector'='kafka'"));
+    assertTrue(out, out.contains("'properties.bootstrap.servers'='localhost:9092'"));
+    assertTrue(out, out.contains("'topic'='topic1'"));
+    assertFalse(out, out.contains("Row"));
   }
 }

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionReconciler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionReconciler.java
@@ -148,6 +148,7 @@ public class SubscriptionReconciler implements Reconciler {
           // Mark the Subscription as failed.
           status.setFailed(true);
           status.setMessage("Error: " + e.getMessage());
+          result = new Result(true, operator.failureRetryDuration());
         }
       } else if (status.getReady() == null && status.getResources() != null) {
         // Phase 2


### PR DESCRIPTION
# Summary

Drop explicit `ROW(...)` constructor from `SELECT`s in SQL output.

# Details

Flink seems to choke on pipelines like `INSERT INTO ... SELECT ROW(HEADER.NAME) FROM FOO`. The Flink SQL parser is fine with `ROW(...)` but only if the expressions inside the constructor do not include a field access `.`. Some experiments:

- `SELECT ROW(HEADER) FROM FOO` 👍 
- `SELECT ROW(HEADER.NAME) FROM FOO` 👎 
- `SELECT (HEADER.NAME) FROM FOO` 👍 

This seems like a bug to me, but the last case points to a workaround: we can simply drop the explicit `ROW`, and rely on the parser treating `(...)` as the same thing.

# Testing

This was difficult to test, so I did so manually. The artificially complicated subscription `SELECT ROW("quantity") AS V, "product_id" AS KEY FROM INVENTORY."products_on_hand"` is rendered as follows:

```
INSERT INTO `RAWKAFKA`.`products` (`V`, `KEY`) SELECT(`quantity`) AS `V`,
        `product_id` AS `KEY` FROM `INVENTORY`.`products_on_hand
```

...whereas previously this would have been rendered with a `ROW(...)` constructor. The Flink parser seems to be happy with the change. 

