### PR TITLE
Use implicit row constructors. Optionally skip nested rows. Nullability bug fixes.

### DIFF
--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
@@ -49,6 +49,7 @@ public final class AvroConverter {
         return createAvroSchemaWithNullability(Schema.createArray(avro(null, null, dataType.getComponentType())),
           dataType.isNullable());
   // TODO support map types
+  // Appears to require a Calcite version bump
   //    case MAP:
   //      return createAvroSchemaWithNullability(Schema.createMap(avroPrimitive(dataType.getValueType())), dataType.isNullable());
       case UNKNOWN:
@@ -103,6 +104,7 @@ public final class AvroConverter {
     case ARRAY:
       return typeFactory.createArrayType(rel(schema.getElementType(), typeFactory), -1);
 //  TODO support map types
+//  Appears to require a Calcite version bump
 //    case MAP:
 //      return typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), rel(schema.getValueType(), typeFactory));
     case UNION:

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ScriptImplementor.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ScriptImplementor.java
@@ -8,7 +8,8 @@ import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.rel.rel2sql.SqlImplementor;
 import org.apache.calcite.sql.SqlWriter;
-//import org.apache.calcite.sql.SqlWriterConfig;
+// needed in next Calcite version
+// import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
 import org.apache.calcite.sql.SqlCollectionTypeNameSpec;
@@ -103,6 +104,7 @@ public interface ScriptImplementor {
   /** Render the script as DDL/SQL in the given dialect */
   default String sql(SqlDialect dialect) {
     SqlWriter w = new SqlPrettyWriter(dialect);
+// TODO: fix in next Calcite version
 //  above is deprecated; replace with:
 //    SqlWriter w = new SqlPrettyWriter(SqlWriterConfig.of().withDialect(dialect));
     implement(w);

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableResolver.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableResolver.java
@@ -2,12 +2,18 @@ package com.linkedin.hoptimator.catalog;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
 
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
 /** Resolves a table name into a concrete row type. Usually involves a network call. */
 public interface TableResolver {
   RelDataType resolve(String table) throws InterruptedException, ExecutionException;
+
+  static TableResolver from(Function<String, RelDataType> f) {
+    return x -> f.apply(x);
+  }
 
   /** Appends an extra column to the resolved type */
   default TableResolver with(String name, RelDataType dataType) {
@@ -18,5 +24,21 @@ public interface TableResolver {
       builder.add(name, dataType);
       return builder.build();
     };
+  }
+
+  default TableResolver with(String name, DataType dataType) {
+    return with(name, dataType.rel());
+  }
+
+  default TableResolver with(String name, DataType.Struct struct) {
+    return with(name, struct.rel());
+  }
+
+  default TableResolver mapStruct(Function<DataType.Struct, DataType.Struct> f) {
+    return x -> f.apply(DataType.struct(resolve(x))).rel();
+  }
+
+  default TableResolver map(Function<RelDataType, RelDataType> f) {
+    return x -> f.apply(resolve(x));
   }
 }

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/AvroConverterTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/AvroConverterTest.java
@@ -1,0 +1,42 @@
+package com.linkedin.hoptimator.catalog;
+
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.util.Litmus;
+import org.apache.avro.Schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class AvroConverterTest {
+
+  @Test
+  public void convertsNestedSchemas() {
+    String schemaString = "{\"type\":\"record\",\"name\":\"E\",\"namespace\":\"ns\",\"fields\":[{\"name\":\"h\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"H\",\"namespace\":\"ns\",\"fields\":[{\"name\":\"A\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"A\",\"fields\":[]}]}]}]}]}";
+
+    Schema avroSchema1 = (new Schema.Parser()).parse(schemaString);
+    RelDataType rel1 = AvroConverter.rel(avroSchema1);
+    assertEquals(rel1.toString(), rel1.getFieldCount(), avroSchema1.getFields().size());
+    assertTrue(rel1.toString(), rel1.getField("h", false, false) != null);
+    RelDataType rel2 = rel1.getField("h", false, false).getType();
+    assertTrue(rel2.toString(), rel2.isNullable());
+    Schema avroSchema2 = avroSchema1.getField("h").schema().getTypes().get(1);
+    assertEquals(rel2.toString(), rel2.getFieldCount(), avroSchema2.getFields().size());
+    assertTrue(rel2.toString(), rel2.getField("A", false, false) != null);
+    RelDataType rel3 = rel2.getField("A", false, false).getType();
+    assertTrue(rel3.toString(), rel3.isNullable());
+    Schema avroSchema3 = avroSchema2.getField("A").schema().getTypes().get(1);
+    assertEquals(rel3.toString(), rel3.getFieldCount(), avroSchema3.getFields().size());
+    Schema avroSchema4 = AvroConverter.avro("NS", "R", rel1);
+    assertTrue("!avroSchema4.isNullable()", !avroSchema4.isNullable());
+    assertEquals(avroSchema4.toString(), avroSchema4.getFields().size(), rel1.getFieldCount());
+    Schema avroSchema5 = AvroConverter.avro("NS", "R", rel2);
+    assertTrue("avroSchema5.isNullable()", avroSchema5.isNullable());
+    assertEquals(avroSchema5.toString(), avroSchema5.getTypes().get(1).getFields().size(), rel2.getFieldCount());
+    Schema avroSchema6 = AvroConverter.avro("NS", "R", rel3);
+    assertEquals(avroSchema6.toString(), avroSchema6.getTypes().get(1).getFields().size(), rel3.getFieldCount());
+    RelDataType rel4 = AvroConverter.rel(avroSchema4);
+    assertTrue("types match", RelOptUtil.eq("rel4", rel4, "rel1", rel1, Litmus.THROW));
+  }
+}

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/DataTypeTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/DataTypeTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.hoptimator.catalog;
+
+import org.apache.calcite.rel.type.RelDataType;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class DataTypeTest {
+
+  @Test
+  public void skipsNestedRows() {
+    DataType.Struct struct = DataType.struct().with("one", DataType.VARCHAR)
+        .with("two", DataType.struct().with("three", DataType.VARCHAR));
+    RelDataType row1 = struct.rel();
+    assertTrue(row1.toString(), row1.getFieldCount() == 2);
+    assertTrue(row1.toString(), row1.getField("one", false, false) != null);
+    assertTrue(row1.toString(), row1.getField("two", false, false) != null);
+    RelDataType row2 = struct.dropNestedRows().rel();
+    assertTrue(row2.toString(), row2.getFieldCount() == 1);
+    assertTrue(row2.toString(), row2.getField("one", false, false) != null);
+    assertTrue(row2.toString(), row2.getField("two", false, false) == null);
+  }
+}

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
@@ -28,10 +28,10 @@ public class ScriptImplementorTest {
     // Output isn't necessarily deterministic, but should be something like:
     //   CREATE TABLE IF NOT EXISTS "DATABASE"."TABLE1" ("idValue1" VARCHAR) WITH
     //   ('connector'='kafka', 'properties.bootstrap.servers'='localhost:9092', 'topic'='topic1')
-    assertTrue(out.contains("CREATE TABLE IF NOT EXISTS \"DATABASE\".\"TABLE1\" (\"idValue1\" VARCHAR) WITH "));
-    assertTrue(out.contains("'connector'='kafka'"));
-    assertTrue(out.contains("'properties.bootstrap.servers'='localhost:9092'"));
-    assertTrue(out.contains("'topic'='topic1'"));
-    assertFalse(out.contains("Row")); 
+    assertTrue(out, out.contains("CREATE TABLE IF NOT EXISTS \"DATABASE\".\"TABLE1\" (\"idValue1\" VARCHAR) WITH "));
+    assertTrue(out, out.contains("'connector'='kafka'"));
+    assertTrue(out, out.contains("'properties.bootstrap.servers'='localhost:9092'"));
+    assertTrue(out, out.contains("'topic'='topic1'"));
+    assertFalse(out, out.contains("Row"));
   }
 }

--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/RawKafkaSchemaFactory.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/RawKafkaSchemaFactory.java
@@ -27,8 +27,8 @@ public class RawKafkaSchemaFactory implements SchemaFactory {
     String principal = (String) operand.getOrDefault("principal", "User:ANONYMOUS");
     Map<String, Object> clientConfig = (Map<String, Object>) operand.get("clientConfig");
     DataType.Struct rowType = DataType.struct()
-      .with("PAYLOAD", DataType.VARCHAR_NULL)
-      .with("KEY", DataType.VARCHAR_NULL);
+      .with("PAYLOAD", DataType.VARCHAR)
+      .with("KEY", DataType.VARCHAR);
     ConfigProvider connectorConfigProvider = ConfigProvider.from(clientConfig)
       .withPrefix("properties.")
       .with("connector", "upsert-kafka")

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionReconciler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionReconciler.java
@@ -148,6 +148,7 @@ public class SubscriptionReconciler implements Reconciler {
           // Mark the Subscription as failed.
           status.setFailed(true);
           status.setMessage("Error: " + e.getMessage());
+          result = new Result(true, operator.failureRetryDuration());
         }
       } else if (status.getReady() == null && status.getResources() != null) {
         // Phase 2

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
@@ -1,12 +1,14 @@
 package com.linkedin.hoptimator.planner;
 
 import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.util.Litmus;
 
 import com.linkedin.hoptimator.catalog.Resource;
 import com.linkedin.hoptimator.catalog.ResourceProvider;
@@ -77,6 +79,7 @@ public interface PipelineRel extends RelNode {
 
     /** Script ending in INSERT INTO ... */
     public ScriptImplementor insertInto(HopTable sink) {
+      RelOptUtil.eq(sink.name(), sink.rowType(), "subscription", rowType(), Litmus.THROW);
       return script.database(sink.database()).with(sink)
         .insert(sink.database(), sink.name(), relNode);
     }


### PR DESCRIPTION
# Summary

`TableResolver` and `DataType.Struct` can now optionally skip nested `Row`s. This is useful for pipelines that can't handle complex record types.

`ScriptImplementor` will now replace explicit `Row(...)` constructors with implicit `(...)` row constructors, which is better supported by Flink before 1.18.

Added support for Avro arrays.

Small bug fixes related to nullability of Avro fields.

# Details

Added `dropNestedRows` method to `DataType.Struct`. Added `mapStruct` method to `TableResolver` to enable applying this and similar data type transformations to rows. Adapters can use this as an easy way to deal with complex schemas.

Flink SQL prior to 1.18 doesn't support arbitrary expressions inside an explicit row constructor, so we now rewrite these using an implicit row constructor. This works when the number of elements in the row is more than one.

Added support for Avro arrays, and added a commented-out impl of Avro maps. Maps aren't un-parseable in this version of Calcite, so Avro maps will need to wait for a version bump.

# Testing

New unit tests covering:

- avro --> rel and rel --> type conversions with nested rows
- nullability of nested avro rows
- drop nested rows

Also, spot-tested in a Kafka-->Kafka pipeline.

