### PR TITLE
Drop NULL columns from INSERT INTO

### DIFF
--- a/deploy/samples/subscriptions.yaml
+++ b/deploy/samples/subscriptions.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: names
 spec:
-  sql: SELECT NAME, NAME AS KEY FROM DATAGEN.PERSON
+  sql: SELECT NAME, NULL AS KEY FROM DATAGEN.PERSON
   database: RAWKAFKA
 
 

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/DataType.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/DataType.java
@@ -15,7 +15,8 @@ import java.util.stream.Collectors;
 public enum DataType {
 
   VARCHAR(x -> x.createTypeWithNullability(x.createSqlType(SqlTypeName.VARCHAR), true)),
-  VARCHAR_NOT_NULL(x -> x.createTypeWithNullability(x.createSqlType(SqlTypeName.VARCHAR), false));
+  VARCHAR_NOT_NULL(x -> x.createTypeWithNullability(x.createSqlType(SqlTypeName.VARCHAR), false)),
+  NULL(x -> x.createSqlType(SqlTypeName.NULL));
 
   public static final RelDataTypeFactory DEFAULT_TYPE_FACTORY = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
   private final RelProtoDataType protoType;

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
@@ -34,4 +34,27 @@ public class ScriptImplementorTest {
     assertTrue(out, out.contains("'topic'='topic1'"));
     assertFalse(out, out.contains("Row"));
   }
+
+  @Test
+  public void magicPrimaryKey() {
+    SqlWriter w = new SqlPrettyWriter();
+    RelDataType rowType = DataType.struct().with("F1", DataType.VARCHAR)
+        .with("PRIMARY_KEY", DataType.VARCHAR).rel();
+    HopTable table = new HopTable("DATABASE", "TABLE1", rowType, ConfigProvider.empty().config("x"));
+    table.implement(w);
+    String out = w.toString();
+    assertTrue(out, out.contains("PRIMARY KEY (PRIMARY_KEY)"));
+  }
+
+  @Test
+  public void magicNullFields() {
+    SqlWriter w = new SqlPrettyWriter();
+    RelDataType rowType = DataType.struct().with("F1", DataType.VARCHAR)
+        .with("KEY", DataType.NULL).rel();
+    HopTable table = new HopTable("DATABASE", "TABLE1", rowType, ConfigProvider.empty().config("x"));
+    table.implement(w);
+    String out = w.toString();
+    assertTrue(out, out.contains("\"KEY\" BYTES")); // NULL fields are promoted to BYTES.
+    assertFalse(out, out.contains("\"KEY\" NULL")); // Without magic, this is what you'd get.
+  }
 }

--- a/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/RawKafkaSchemaFactory.java
+++ b/hoptimator-kafka-adapter/src/main/java/com/linkedin/hoptimator/catalog/kafka/RawKafkaSchemaFactory.java
@@ -32,10 +32,11 @@ public class RawKafkaSchemaFactory implements SchemaFactory {
     ConfigProvider connectorConfigProvider = ConfigProvider.from(clientConfig)
       .withPrefix("properties.")
       .with("connector", "kafka")
-      .with("key.format", "csv")
+      .with("key.format", "raw")
       .with("key.fields", "KEY")
       .with("value.format", "csv")
       .with("value.fields-include", "EXCEPT_KEY")
+      .with("scan.startup.mode", "earliest-offset")
       .with("topic", x -> x);
     TableLister tableLister = () -> {
       AdminClient client = AdminClient.create(clientConfig);

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
@@ -80,8 +80,9 @@ public interface PipelineRel extends RelNode {
     /** Script ending in INSERT INTO ... */
     public ScriptImplementor insertInto(HopTable sink) {
       RelOptUtil.eq(sink.name(), sink.rowType(), "subscription", rowType(), Litmus.THROW);
+      RelNode castRel = RelOptUtil.createCastRel(relNode, sink.rowType(), true);
       return script.database(sink.database()).with(sink)
-        .insert(sink.database(), sink.name(), relNode);
+        .insert(sink.database(), sink.name(), castRel);
     }
 
     /** Add any resources, SQL, DDL etc required to access the table. */


### PR DESCRIPTION
## Summary

Drop NULL columns (e.g. `NULL AS KEY`) from INSERT INTO pipelines.

Promote NULL fields to BYTES in DDL (e.g. `KEY BYTES`).

## Details

Flink does not allow NULLs in queries (SQL) or in table definitions (DDL). This is problematic, because we would like to be able to write `NULL AS KEY` in subscriptions.

In Hoptimator, sink tables are _derived_ from subscription SQL. If we write `NULL AS KEY` in a subscription, the sink table would have a `NULL`-typed column, and the Flink job would fail. Instead, `NULL AS KEY` should result in the column being omitted form the pipeline entirely (defaulting to NULL).

At the same time, Flink DDL cannot have NULL-typed fields, so we promote these to BYTES.

The result is that `SELECT ... NULL AS KEY ...` results in a sink table with `KEY BYTES` and pipelines that omit the `KEY` field (defaulting to NULL).

## Testing

New unit tests. Tested locally and by manually tweaking production pipelines.

Changed integration tests to use  `NULL AS KEY`.

