### PR TITLE
Update README and add undeploy to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ undeploy: undeploy-dev-environment
 	kubectl delete configmap hoptimator-configmap || echo "skipping"
 
 generate-models:
-	./models/generate-models.sh
+	./generate-models.sh
+	./hoptimator-models/generate-models.sh # <-- marked for deletion
 
 release:
 	test -n "$(VERSION)"  # MISSING ARG: $$VERSION

--- a/Makefile
+++ b/Makefile
@@ -18,27 +18,17 @@ integration-tests:
 clean:
 	./gradlew clean
 
-deploy-demo:
-	kubectl apply -f ./deploy/samples/demodb.yaml
+deploy-config:
+	kubectl create configmap hoptimator-configmap --from-file=model.yaml=test-model.yaml --dry-run=client -o yaml | kubectl apply -f -
 
 deploy: deploy-config
 	kubectl apply -f ./hoptimator-k8s/src/main/resources/
 	kubectl apply -f ./deploy
 
-undeploy:
-	kubectl delete -f ./deploy || echo "skipping"
-	kubectl delete configmap hoptimator-configmap || echo "skipping"
-
 quickstart: build deploy
 
-deploy-dev-environment: 
-	kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml || echo "skipping"
-	kubectl create namespace kafka || echo "skipping"
-	helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.9.0/
-	helm upgrade --install --atomic --set webhook.create=false flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
-	kubectl apply -f "https://strimzi.io/install/latest?namespace=kafka" -n kafka
-	kubectl wait --for=condition=Established=True crds/kafkas.kafka.strimzi.io
-	kubectl apply -f ./deploy/dev
+deploy-demo: deploy
+	kubectl apply -f ./deploy/samples/demodb.yaml
 
 deploy-samples: deploy
 	kubectl wait --for=condition=Established=True	\
@@ -47,8 +37,34 @@ deploy-samples: deploy
 	  crds/sqljobs.hoptimator.linkedin.com
 	kubectl apply -f ./deploy/samples
 
-deploy-config:
-	kubectl create configmap hoptimator-configmap --from-file=model.yaml=test-model.yaml --dry-run=client -o yaml | kubectl apply -f -
+deploy-dev-environment: deploy-config
+	kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml || echo "skipping"
+	kubectl create namespace kafka || echo "skipping"
+	helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.9.0/
+	helm upgrade --install --atomic --set webhook.create=false flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
+	kubectl apply -f "https://strimzi.io/install/latest?namespace=kafka" -n kafka
+	kubectl wait --for=condition=Established=True crds/kafkas.kafka.strimzi.io
+	kubectl apply -f ./hoptimator-k8s/src/main/resources/
+	kubectl apply -f ./deploy/dev
+	kubectl apply -f ./deploy/samples/demodb.yaml
+	kubectl apply -f ./deploy/samples/kafkadb.yaml
+
+undeploy-dev-environment:
+	kubectl delete $(shell kubectl get kafkatopic.kafka.strimzi.io -o name -n kafka) -n kafka || echo "skipping"
+	kubectl delete $(shell kubectl get strimzi -o name -n kafka) -n kafka || echo "skipping"
+	kubectl delete pvc -l strimzi.io/name=one-kafka -n kafka || echo "skipping"
+	kubectl delete -f "https://strimzi.io/install/latest?namespace=kafka" -n kafka || echo "skipping"
+	kubectl delete -f ./deploy/samples/kafkadb.yaml || echo "skipping"
+	kubectl delete -f ./deploy/samples/demodb.yaml || echo "skipping"
+	kubectl delete -f ./deploy/dev || echo "skipping"
+	kubectl delete -f ./hoptimator-k8s/src/main/resources/ || echo "skipping"
+	kubectl delete namespace kafka || echo "skipping"
+	helm uninstall flink-kubernetes-operator || echo "skipping"
+	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml || echo "skipping"
+
+undeploy: undeploy-dev-environment
+	kubectl delete -f ./deploy || echo "skipping"
+	kubectl delete configmap hoptimator-configmap || echo "skipping"
 
 generate-models:
 	./models/generate-models.sh

--- a/README.md
+++ b/README.md
@@ -39,11 +39,24 @@ Materialized views result in `pipelines`:
 
 Hoptimator requires a Kubernetes cluster. To connect from outside a Kubernetes cluster, make sure your `kubectl` is properly configured.
 
+The below setup will install two local demo DBs, ads and profiles.
+
 ```
   $ make install            # build and install SQL CLI
-  $ make deploy deploy-demo # install CRDs and K8s objects
-  $ kubectl port-forward -n kafka svc/one-kafka-external-0 9092 &
-  $ ./hoptimator
+  $ make deploy deploy-demo # install demo DB CRDs and K8s objects
+  $ ./hoptimator            # start the SQL CLI
+  > !intro
+```
+
+## Set up Kafka & Flink clusters
+
+The below setup will install a Kafka and Flink cluster within Kubernetes.
+
+```
+  $ make install                                                    # build and install SQL CLI
+  $ make deploy-dev-environment                                     # start local Kafka & Flink setups
+  $ kubectl port-forward -n kafka svc/one-kafka-external-0 9092 &   # forward external Kafka port for use by SQL CLI
+  $ ./hoptimator                                                    # start the SQL CLI
   > !intro
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
-
+plugins {
+  id("com.github.spotbugs") version "6.0.26"
+}
 
 subprojects {
+  apply plugin: 'checkstyle'
+  apply plugin: 'com.github.spotbugs'
+
   tasks.withType(JavaCompile) {
     options.release = 8
     options.compilerArgs << '-Xlint:deprecation'
@@ -8,5 +13,13 @@ subprojects {
   }
   tasks.withType(Javadoc) {
     options.addStringOption('Xdoclint:none', '-quiet')
+  }
+
+  spotbugs {
+    ignoreFailures = true
+    showProgress = true
+    reportsDir = file("$buildDir/spotbugs")
+    includeFilter = file("$rootDir/config/spotbugs/include.xml")
+    excludeFilter = file("$rootDir/config/spotbugs/exclude.xml")
   }
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle-Configuration: LinkedIn Style
+    Description:
+LinkedIn Java style.
+-->
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <property name="fileExtensions" value="java"/>
+
+  <module name="TreeWalker">
+    <property name="tabWidth" value="2"/>
+    <module name="SuppressWarningsHolder"/>
+
+    <!-- Allow Checkstyle warnings to be suppressed using trailing comments -->
+    <module name="SuppressWithNearbyCommentFilter"/>
+    <!-- Allow Checkstyle warnings to be suppressed using block comments -->
+    <module name="SuppressionCommentFilter"/>
+
+    <!-- ANNOTATIONS -->
+
+    <!-- No trailing empty parenthesis or commas -->
+    <module name="AnnotationUseStyle">
+      <property name="elementStyle" value="ignore"/>
+    </module>
+    <!-- Ensure @Override is present when {@inheritDoc} Javadoc tag is present -->
+    <module name="MissingOverride"/>
+    <!-- Package level annotations belong in package-info.java -->
+    <module name="PackageAnnotation"/>
+    <!-- Do not allow references to internal tickets -->
+    <module name="Regexp">
+      <property name="format" value="(DDSDBUS|LISAMZA|DATAPIPES)-\d+"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="Referencing internal ticket names is not allowed"/>
+    </module>
+
+    <!-- BLOCKS -->
+
+    <!-- No empty while, try, finally, do, if, else, for, initializer, switch, or synchronized blocks -->
+    <module name="EmptyBlock"/>
+    <!-- Block opening brace on same line -->
+    <module name="LeftCurly">
+      <property name="option" value="eol"/>
+    </module>
+    <!-- Block closing brace for else, catch, finally on same line -->
+    <module name="RightCurly">
+      <property name="option" value="same"/>
+    </module>
+    <!-- Always use braces even if optional -->
+    <module name="NeedBraces"/>
+
+    <!-- CLASS DESIGN -->
+
+    <!-- A class with only private constructors must be declared final -->
+    <module name="FinalClass"/>
+    <!-- Classes containing only static methods should not have a public constructor -->
+    <module name="HideUtilityClassConstructor"/>
+
+    <!-- CODING -->
+
+    <!-- Use Java style array declarations (e.g. String[] names), not C style (e.g. String names[]) -->
+    <module name="ArrayTypeStyle"/>
+    <!-- If covariant equals defined, standard equals must also be defined -->
+    <module name="CovariantEquals"/>
+    <!-- Switch 'default' case must appear last -->
+    <module name="DefaultComesLast"/>
+    <!-- Call equals on string literals to avoid an NPE -->
+    <module name="EqualsAvoidNull"/>
+    <!-- Override equals and hashCode together -->
+    <module name="EqualsHashCode"/>
+    <!-- No fall through in switch cases, even the last one -->
+    <module name="FallThrough">
+      <property name="checkLastCaseGroup" value="true"/>
+    </module>
+    <!-- Do not perform assignments embedded within expressions -->
+    <module name="InnerAssignment"/>
+    <!-- Switch statements must have a 'default' case -->
+    <module name="MissingSwitchDefault"/>
+    <!-- Do not modify the 'for' loop control variable -->
+    <module name="ModifiedControlVariable"/>
+    <!-- Each variable declaration must be on a separate line -->
+    <module name="MultipleVariableDeclarations"/>
+    <!-- Do not use finalize -->
+    <module name="NoFinalizer"/>
+    <!-- Each statement (i.e. code terminated by a semicolon) must be on a separate line -->
+    <module name="OneStatementPerLine"/>
+    <!-- Classes must have an explicit package declaration -->
+    <module name="PackageDeclaration"/>
+    <!-- Do not reassign method parameters -->
+    <module name="ParameterAssignment"/>
+    <!-- Do not test boolean expressions against the values true or false -->
+    <module name="SimplifyBooleanExpression"/>
+    <!-- Do not test for boolean conditions and return the values true or false -->
+    <module name="SimplifyBooleanReturn"/>
+    <!-- Do not use '==' to compare string against a literal; use 'equals' -->
+    <module name="StringLiteralEquality"/>
+    <!-- Use 'L' with long literals -->
+    <module name="UpperEll"/>
+
+    <!-- IMPORTS -->
+
+    <!-- No imports statements using '*' -->
+    <module name="AvoidStarImport"/>
+    <!-- Do not import 'sun' packages -->
+    <module name="IllegalImport"/>
+    <!-- Do not duplicate import statements -->
+    <module name="RedundantImport"/>
+    <!-- Eliminate unused imports -->
+    <module name="UnusedImports"/>
+
+    <!-- Import ordering -->
+    <module name="ImportOrder">
+      <property name="groups" value="/^javax?\./,/^org\./,*,/^com\.linkedin\./"/>
+      <property name="separated" value="true"/>
+      <property name="ordered" value="true"/>
+      <property name="caseSensitive" value="true"/>
+      <property name="sortStaticImportsAlphabetically" value="true"/>
+      <property name="option" value="bottom"/>
+    </module>
+
+    <!-- JAVADOC COMMENTS -->
+
+    <!-- If you have a Javadoc comment, make sure it is properly formed -->
+    <module name="JavadocStyle">
+      <property name="checkFirstSentence" value="false"/>
+    </module>
+
+    <!-- MISCELLANEOUS -->
+
+    <!-- Ensure filename matches outer class name -->
+    <module name="OuterTypeFilename"/>
+
+    <!-- MODIFIERS -->
+
+    <!-- Avoid redundant modifiers such as public in interface method decls, per the Java Language spec -->
+    <module name="RedundantModifier"/>
+
+    <!-- NAMING CONVENTIONS -->
+
+    <!-- Generic parameters for a class must be uppercase letters separated by underscores (e.g. <V>, <NEW>, <KEY_T>) -->
+    <module name="ClassTypeParameterName">
+      <property name="format" value="^[A-Z]+(_[A-Z]+)*$"/>
+    </module>
+    <!-- Constants must be all uppercase letters separated by underscores -->
+    <module name="ConstantName">
+      <property name="format" value="^(_?log)|([A-Z][A-Z0-9]*(_[A-Z0-9]+)*)$"/>
+    </module>
+    <!-- Local variables must be camel case starting with lowercase letter -->
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <!-- Member variables must be camel case starting with an underscore or lowercase letter -->
+    <module name="MemberName">
+      <property name="format" value="^[_a-z][a-zA-Z0-9]*$"/>
+    </module>
+    <!-- Method name must be camel case starting with a lowercase letter -->
+    <module name="MethodName"/>
+    <!-- Generic parameters for a method must be uppercase letters separated by underscores (e.g. <V>, <NEW>, <KEY_T>) -->
+    <module name="MethodTypeParameterName">
+      <property name="format" value="^[A-Z]+(_[A-Z]+)*$"/>
+    </module>
+    <!-- Package name must be all lowercase letters separated by periods -->
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+    </module>
+    <!-- Parameters must be camel case starting with a lowercase letter -->
+    <module name="ParameterName"/>
+    <!-- Static variables must be camel case starting with an underscore or lowercase letter -->
+    <module name="StaticVariableName">
+      <property name="format" value="^[_a-z][a-zA-Z0-9]*$"/>
+    </module>
+    <!-- Type names must be camel case starting with an uppercase letter -->
+    <module name="TypeName"/>
+
+    <!-- WHITESPACE -->
+
+    <module name="GenericWhitespace"/>
+    <module name="MethodParamPad"/>
+    <!-- Do not wrap package and import declarations -->
+    <module name="NoLineWrap"/>
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+    </module>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad">
+      <property name="tokens" value="RPAREN,TYPECAST"/>
+    </module>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+
+    <!-- Do not allow meaningless, IDE generated parameter names -->
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="[\s]+arg[\d]+[,\)]"/>
+      <property name="message" value="Replace argN with a meaningful parameter name"/>
+    </module>
+  </module>
+
+  <!-- LENGTHS -->
+
+  <!-- Desired line length is 120 but allow some overrun beyond that -->
+  <module name="LineLength">
+    <property name="max" value="160"/>
+    <message key="maxLineLen"
+             value="Line is longer than {0,number,integer} characters (found {1,number,integer}). Try to keep lines under 120 characters."/>
+  </module>
+
+  <!-- Do not allow tab characters in source files -->
+  <module name="FileTabCharacter"/>
+
+  <!-- Ensure parameter and exception names are present on @param and @throws tags -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\*[\s]*@(throws|param)[\s]*$"/>
+    <property name="message" value="Missing parameter or exception name"/>
+  </module>
+  <!-- IDE generated code must be reviewed by developer -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\/\/[\s]*TODO[\s]+Auto-generated"/>
+    <property name="message" value="Replace IDE generated code with real implementation"/>
+  </module>
+  <!-- Detect commonly misspelled Javadoc tags -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\*[\s]*@(params|throw|returns)[\s]+"/>
+    <property name="message" value="Correct misspelled Javadoc tag"/>
+  </module>
+
+  <!-- Read checker suppressions from a file -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${config_loc}/suppressions.xml"/>
+  </module>
+
+  <!-- Allow SuppressWarnings annotation to suppress Checkstyle issues -->
+  <module name="SuppressWarningsFilter"/>
+</module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+  <suppress files=".*models.*" checks=".*"/>
+</suppressions>

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Yes, even though this exclusion filter file is used by SpotBugs, the top-level element is still "FindBugsFilter" -->
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+  <Match>
+    <Class name="~.*models.*"/>
+  </Match>
+</FindBugsFilter>

--- a/config/spotbugs/include.xml
+++ b/config/spotbugs/include.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0  https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+  <!-- Only process Java sources -->
+  <Match>
+    <Source name="~.*\.java"/>
+  </Match>
+</FindBugsFilter>
+

--- a/deploy/dev/kafka.yaml
+++ b/deploy/dev/kafka.yaml
@@ -26,6 +26,10 @@ spec:
     version: 3.8.0
     replicas: 1
     listeners:
+      - name: plain
+        port: 9094
+        type: internal
+        tls: false
       - name: tls
         port: 9093
         type: internal

--- a/deploy/subscriptions.crd.yaml
+++ b/deploy/subscriptions.crd.yaml
@@ -1,0 +1,106 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.hoptimator.linkedin.com
+spec:
+  group: hoptimator.linkedin.com
+  names:
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    singular: subscription
+    shortNames:
+    - sub
+    - subs
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: Hoptimator Subscription
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Subscription spec
+              type: object
+              properties:
+                sql:
+                  description: A single SQL query.
+                  type: string
+                database:
+                  description: The database in which to create the output/sink table.
+                  type: string
+                hints:
+                  description: Hints to adapters, which may disregard them.
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+              - sql
+              - database
+            status:
+              description: Filled in by the operator.
+              type: object
+              properties:
+                ready:
+                  description: Whether the subscription is ready to be consumed.
+                  type: boolean
+                failed:
+                  description: Indicates that the operator was unable to deploy a pipeline for this subscription.
+                  type: boolean
+                message:
+                  description: Error or success message, for information only.
+                  type: string
+                sql:
+                  description: The SQL being implemented by this pipeline.
+                  type: string
+                hints:
+                  description: The hints being used by this pipeline.
+                  type: object
+                  additionalProperties:
+                    type: string
+                attributes:
+                  description: Physical attributes of the job and sink/output table.
+                  type: object
+                  additionalProperties:
+                    type: string
+                resources:
+                  description: The yaml generated to implement this pipeline.
+                  type: array
+                  items:
+                    type: string
+                jobResources:
+                  description: The yaml generated to implement the job.
+                  type: array
+                  items:
+                    type: string
+                downstreamResources:
+                  description: The yaml generated to implement the sink/output table.
+                  type: array
+                  items:
+                    type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: STATUS
+        type: string
+        description: Status message from the operator.
+        jsonPath: .status.message
+      - name: DB
+        type: string
+        description: The database where the subscription is materialized.
+        jsonPath: .spec.database
+      - name: SQL
+        type: string
+        description: The SQL query that the subscription materializes.
+        jsonPath: .spec.sql
+

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Catalog.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Catalog.java
@@ -1,12 +1,15 @@
 package com.linkedin.hoptimator;
 
-import java.sql.Wrapper;
 import java.sql.SQLException;
+import java.sql.Wrapper;
+
 
 /** Registers a set of tables, possibly within schemas and sub-schemas. */
 public interface Catalog {
 
   String name();
+
   String description();
+
   void register(Wrapper parentSchema) throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/CatalogProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/CatalogProvider.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator;
 
 import java.util.Collection;
 
+
 public interface CatalogProvider {
 
   Collection<Catalog> catalogs();

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Connector.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Connector.java
@@ -1,9 +1,10 @@
 package com.linkedin.hoptimator;
 
-import java.util.Map;
 import java.sql.SQLException;
+import java.util.Map;
+
 
 public interface Connector<T> {
-  
+
   Map<String, String> configure(T t) throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ConnectorProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ConnectorProvider.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator;
 
 import java.util.Collection;
 
+
 public interface ConnectorProvider {
 
   <T> Collection<Connector<T>> connectors(Class<T> clazz);

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Database.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Database.java
@@ -1,6 +1,6 @@
 package com.linkedin.hoptimator;
 
-/** A collection of tables, as populated by a Catalog. */ 
+/** A collection of tables, as populated by a Catalog. */
 public interface Database {
 
   /** Name of the database. */

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployable.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployable.java
@@ -1,12 +1,15 @@
 package com.linkedin.hoptimator;
 
-import java.util.List;
 import java.sql.SQLException;
+import java.util.List;
+
 
 public interface Deployable {
 
   void create() throws SQLException;
+
   void delete() throws SQLException;
+
   void update() throws SQLException;
 
   /** Render a list of specs, usually YAML. */

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployer.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployer.java
@@ -1,12 +1,16 @@
 package com.linkedin.hoptimator;
 
-import java.util.List;
 import java.sql.SQLException;
+import java.util.List;
+
 
 public interface Deployer<T> {
-  
+
   void create(T t) throws SQLException;
+
   void update(T t) throws SQLException;
+
   void delete(T t) throws SQLException;
+
   List<String> specify(T t) throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator;
 
 import java.util.Collection;
 
+
 public interface DeployerProvider {
 
   <T> Collection<Deployer<T>> deployers(Class<T> clazz);

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Validator.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Validator.java
@@ -3,8 +3,8 @@ package com.linkedin.hoptimator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,7 +12,7 @@ import java.util.function.Function;
 
 
 public interface Validator<T> {
-  
+
   void validate(T t, Issues issues);
 
   static void validateSubdomainName(String s, Issues issues) {
@@ -142,7 +142,7 @@ public interface Validator<T> {
       Collections.reverse(parts);
       return String.join("/", parts);
     }
-        
+
     private String format(int indentLevel) {
       if (empty()) {
         return "";

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ValidatorProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ValidatorProvider.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator;
 
 import java.util.Collection;
 
+
 public interface ValidatorProvider {
 
   <T> Collection<Validator<T>> validators(Class<T> clazz);

--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
@@ -1,19 +1,19 @@
 package com.linkedin.hoptimator.avro;
 
-import org.apache.avro.Schema;
-
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeImpl;
-import org.apache.calcite.rel.type.RelDataTypeSystem;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelProtoDataType;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
-
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.apache.avro.Schema;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+
 
 /** Converts between Avro and Calcite's RelDataType */
 public final class AvroConverter {
@@ -23,41 +23,43 @@ public final class AvroConverter {
 
   public static Schema avro(String namespace, String name, RelDataType dataType) {
     if (dataType.isStruct()) {
-      List<Schema.Field> fields = dataType.getFieldList().stream()
-        .map(x -> new Schema.Field(sanitize(x.getName()), avro(namespace, x.getName(), x.getType()), describe(x), null))
-        .collect(Collectors.toList());
-      return createAvroSchemaWithNullability(Schema.createRecord(sanitize(name), dataType.toString(), namespace, false, fields),
-        dataType.isNullable());
+      List<Schema.Field> fields = dataType.getFieldList()
+          .stream()
+          .map(x -> new Schema.Field(sanitize(x.getName()), avro(namespace, x.getName(), x.getType()), describe(x),
+              null))
+          .collect(Collectors.toList());
+      return createAvroSchemaWithNullability(
+          Schema.createRecord(sanitize(name), dataType.toString(), namespace, false, fields), dataType.isNullable());
     } else {
       switch (dataType.getSqlTypeName()) {
-      case INTEGER:
-        return createAvroTypeWithNullability(Schema.Type.INT, dataType.isNullable());
-      case SMALLINT:
-        return createAvroTypeWithNullability(Schema.Type.INT, dataType.isNullable());
-      case BIGINT:
-        return createAvroTypeWithNullability(Schema.Type.LONG, dataType.isNullable());
-      case VARCHAR:
-        return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
-      case FLOAT:
-        return createAvroTypeWithNullability(Schema.Type.FLOAT, dataType.isNullable());
-      case DOUBLE:
-        return createAvroTypeWithNullability(Schema.Type.DOUBLE, dataType.isNullable());
-      case CHAR:
-        return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
-      case BOOLEAN:
-        return createAvroTypeWithNullability(Schema.Type.BOOLEAN, dataType.isNullable());
-      case ARRAY:
-        return createAvroSchemaWithNullability(Schema.createArray(avro(null, null, dataType.getComponentType())),
-          dataType.isNullable());
-  // TODO support map types
-  // Appears to require a Calcite version bump
-  //    case MAP:
-  //      return createAvroSchemaWithNullability(Schema.createMap(avroPrimitive(dataType.getValueType())), dataType.isNullable());
-      case UNKNOWN:
-      case NULL:
-        return Schema.createUnion(Schema.create(Schema.Type.NULL));
-      default:
-        throw new UnsupportedOperationException("No support yet for " + dataType.getSqlTypeName().toString());
+        case INTEGER:
+          return createAvroTypeWithNullability(Schema.Type.INT, dataType.isNullable());
+        case SMALLINT:
+          return createAvroTypeWithNullability(Schema.Type.INT, dataType.isNullable());
+        case BIGINT:
+          return createAvroTypeWithNullability(Schema.Type.LONG, dataType.isNullable());
+        case VARCHAR:
+          return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
+        case FLOAT:
+          return createAvroTypeWithNullability(Schema.Type.FLOAT, dataType.isNullable());
+        case DOUBLE:
+          return createAvroTypeWithNullability(Schema.Type.DOUBLE, dataType.isNullable());
+        case CHAR:
+          return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
+        case BOOLEAN:
+          return createAvroTypeWithNullability(Schema.Type.BOOLEAN, dataType.isNullable());
+        case ARRAY:
+          return createAvroSchemaWithNullability(Schema.createArray(avro(null, null, dataType.getComponentType())),
+              dataType.isNullable());
+        // TODO support map types
+        // Appears to require a Calcite version bump
+        //    case MAP:
+        //      return createAvroSchemaWithNullability(Schema.createMap(avroPrimitive(dataType.getValueType())), dataType.isNullable());
+        case UNKNOWN:
+        case NULL:
+          return Schema.createUnion(Schema.create(Schema.Type.NULL));
+        default:
+          throw new UnsupportedOperationException("No support yet for " + dataType.getSqlTypeName().toString());
       }
     }
   }
@@ -82,42 +84,43 @@ public final class AvroConverter {
   public static RelDataType rel(Schema schema, RelDataTypeFactory typeFactory) {
     RelDataType unknown = typeFactory.createUnknownType();
     switch (schema.getType()) {
-    case RECORD:
-      return typeFactory.createStructType(schema.getFields().stream()
-        .map(x -> new AbstractMap.SimpleEntry<>(x.name(), rel(x.schema(), typeFactory)))
-        .filter(x -> x.getValue().getSqlTypeName() != SqlTypeName.NULL)
-        .filter(x -> x.getValue().getSqlTypeName() != unknown.getSqlTypeName())
-        .collect(Collectors.toList()));
-    case INT:
-      return createRelType(typeFactory, SqlTypeName.INTEGER);
-    case LONG:
-      return createRelType(typeFactory, SqlTypeName.BIGINT);
-    case ENUM:
-    case FIXED:
-    case STRING:
-      return createRelType(typeFactory, SqlTypeName.VARCHAR);
-    case FLOAT:
-      return createRelType(typeFactory, SqlTypeName.FLOAT);
-    case DOUBLE:
-      return createRelType(typeFactory, SqlTypeName.DOUBLE);
-    case BOOLEAN:
-      return createRelType(typeFactory, SqlTypeName.BOOLEAN);
-    case ARRAY:
-      return typeFactory.createArrayType(rel(schema.getElementType(), typeFactory), -1);
+      case RECORD:
+        return typeFactory.createStructType(schema.getFields()
+            .stream()
+            .map(x -> new AbstractMap.SimpleEntry<>(x.name(), rel(x.schema(), typeFactory)))
+            .filter(x -> x.getValue().getSqlTypeName() != SqlTypeName.NULL)
+            .filter(x -> x.getValue().getSqlTypeName() != unknown.getSqlTypeName())
+            .collect(Collectors.toList()));
+      case INT:
+        return createRelType(typeFactory, SqlTypeName.INTEGER);
+      case LONG:
+        return createRelType(typeFactory, SqlTypeName.BIGINT);
+      case ENUM:
+      case FIXED:
+      case STRING:
+        return createRelType(typeFactory, SqlTypeName.VARCHAR);
+      case FLOAT:
+        return createRelType(typeFactory, SqlTypeName.FLOAT);
+      case DOUBLE:
+        return createRelType(typeFactory, SqlTypeName.DOUBLE);
+      case BOOLEAN:
+        return createRelType(typeFactory, SqlTypeName.BOOLEAN);
+      case ARRAY:
+        return typeFactory.createArrayType(rel(schema.getElementType(), typeFactory), -1);
 //  TODO support map types
 //  Appears to require a Calcite version bump
 //    case MAP:
 //      return typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), rel(schema.getValueType(), typeFactory));
-    case UNION:
-      if (schema.isNullable() && schema.getTypes().size() == 2) {
-        Schema innerType = schema.getTypes().stream().filter(x -> x.getType() != Schema.Type.NULL).findFirst().get();
-        return typeFactory.createTypeWithNullability(rel(innerType, typeFactory), true);
-      } else {
-        // TODO support more elaborate union types
-        return typeFactory.createTypeWithNullability(typeFactory.createUnknownType(), true);
-      }
-    default:
-      return typeFactory.createUnknownType();
+      case UNION:
+        if (schema.isNullable() && schema.getTypes().size() == 2) {
+          Schema innerType = schema.getTypes().stream().filter(x -> x.getType() != Schema.Type.NULL).findFirst().get();
+          return typeFactory.createTypeWithNullability(rel(innerType, typeFactory), true);
+        } else {
+          // TODO support more elaborate union types
+          return typeFactory.createTypeWithNullability(typeFactory.createUnknownType(), true);
+        }
+      default:
+        return typeFactory.createUnknownType();
     }
   }
 

--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroTableValidator.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroTableValidator.java
@@ -1,6 +1,8 @@
 package com.linkedin.hoptimator.avro;
 
-import com.linkedin.hoptimator.Validator;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
@@ -11,16 +13,15 @@ import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import com.linkedin.hoptimator.Validator;
+
 
 /** Validates that tables follow Avro schema evolution rules.  */
 class AvroTableValidator implements Validator<SchemaPlus> {
-  
+
   @Override
   public void validate(SchemaPlus schema, Issues issues) {
     try {
@@ -55,7 +56,7 @@ class AvroTableValidator implements Validator<SchemaPlus> {
         DataFileWriter<Object> dataFileWriter = new DataFileWriter<Object>(datumWriter)) {
       dataFileWriter.create(originalAvroSchema, out);
       for (Object obj : new RandomData(avroSchema, 1)) {
-          dataFileWriter.append(obj);
+        dataFileWriter.append(obj);
       }
     } catch (IOException | RuntimeException e) {
       issues.error("Avro schema evolution error: cannot serialize new records using the existing schema");

--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroValidatorProvider.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroValidatorProvider.java
@@ -1,12 +1,13 @@
 package com.linkedin.hoptimator.avro;
 
-import com.linkedin.hoptimator.Validator;
-import com.linkedin.hoptimator.ValidatorProvider;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.calcite.schema.SchemaPlus;
 
-import java.util.Collection;
-import java.util.Collections;
+import com.linkedin.hoptimator.Validator;
+import com.linkedin.hoptimator.ValidatorProvider;
+
 
 /** Provides AvroValidator. */
 public class AvroValidatorProvider implements ValidatorProvider {

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/AvroConverter.java
@@ -1,19 +1,19 @@
 package com.linkedin.hoptimator.catalog;
 
-import org.apache.avro.Schema;
-
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeImpl;
-import org.apache.calcite.rel.type.RelDataTypeSystem;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelProtoDataType;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
-
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.apache.avro.Schema;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+
 
 /** Converts between Avro and Calcite's RelDataType */
 public final class AvroConverter {
@@ -23,40 +23,40 @@ public final class AvroConverter {
 
   public static Schema avro(String namespace, String name, RelDataType dataType) {
     if (dataType.isStruct()) {
-      List<Schema.Field> fields = dataType.getFieldList().stream()
-        .filter(x -> !x.getName().startsWith("__")) // don't write out hidden fields
-        .map(x -> new Schema.Field(sanitize(x.getName()), avro(namespace, x.getName(), x.getType()), describe(x), null))
-        .collect(Collectors.toList());
-      return createAvroSchemaWithNullability(Schema.createRecord(sanitize(name), dataType.toString(), namespace, false, fields),
-        dataType.isNullable());
+      List<Schema.Field> fields =
+          dataType.getFieldList().stream().filter(x -> !x.getName().startsWith("__")) // don't write out hidden fields
+              .map(x -> new Schema.Field(sanitize(x.getName()), avro(namespace, x.getName(), x.getType()), describe(x),
+                  null)).collect(Collectors.toList());
+      return createAvroSchemaWithNullability(
+          Schema.createRecord(sanitize(name), dataType.toString(), namespace, false, fields), dataType.isNullable());
     } else {
       switch (dataType.getSqlTypeName()) {
-      case INTEGER:
-        return createAvroTypeWithNullability(Schema.Type.INT, dataType.isNullable());
-      case BIGINT:
-        return createAvroTypeWithNullability(Schema.Type.LONG, dataType.isNullable());
-      case VARCHAR:
-        return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
-      case FLOAT:
-        return createAvroTypeWithNullability(Schema.Type.FLOAT, dataType.isNullable());
-      case DOUBLE:
-        return createAvroTypeWithNullability(Schema.Type.DOUBLE, dataType.isNullable());
-      case CHAR:
-        return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
-      case BOOLEAN:
-        return createAvroTypeWithNullability(Schema.Type.BOOLEAN, dataType.isNullable());
-      case ARRAY:
-        return createAvroSchemaWithNullability(Schema.createArray(avro(null, null, dataType.getComponentType())),
-          dataType.isNullable());
-  // TODO support map types
-  // Appears to require a Calcite version bump
-  //    case MAP:
-  //      return createAvroSchemaWithNullability(Schema.createMap(avroPrimitive(dataType.getValueType())), dataType.isNullable());
-      case UNKNOWN:
-      case NULL:
-        return Schema.createUnion(Schema.create(Schema.Type.NULL));
-      default:
-        throw new UnsupportedOperationException("No support yet for " + dataType.getSqlTypeName().toString());
+        case INTEGER:
+          return createAvroTypeWithNullability(Schema.Type.INT, dataType.isNullable());
+        case BIGINT:
+          return createAvroTypeWithNullability(Schema.Type.LONG, dataType.isNullable());
+        case VARCHAR:
+          return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
+        case FLOAT:
+          return createAvroTypeWithNullability(Schema.Type.FLOAT, dataType.isNullable());
+        case DOUBLE:
+          return createAvroTypeWithNullability(Schema.Type.DOUBLE, dataType.isNullable());
+        case CHAR:
+          return createAvroTypeWithNullability(Schema.Type.STRING, dataType.isNullable());
+        case BOOLEAN:
+          return createAvroTypeWithNullability(Schema.Type.BOOLEAN, dataType.isNullable());
+        case ARRAY:
+          return createAvroSchemaWithNullability(Schema.createArray(avro(null, null, dataType.getComponentType())),
+              dataType.isNullable());
+        // TODO support map types
+        // Appears to require a Calcite version bump
+        //    case MAP:
+        //      return createAvroSchemaWithNullability(Schema.createMap(avroPrimitive(dataType.getValueType())), dataType.isNullable());
+        case UNKNOWN:
+        case NULL:
+          return Schema.createUnion(Schema.create(Schema.Type.NULL));
+        default:
+          throw new UnsupportedOperationException("No support yet for " + dataType.getSqlTypeName().toString());
       }
     }
   }
@@ -81,42 +81,43 @@ public final class AvroConverter {
   public static RelDataType rel(Schema schema, RelDataTypeFactory typeFactory) {
     RelDataType unknown = typeFactory.createUnknownType();
     switch (schema.getType()) {
-    case RECORD:
-      return typeFactory.createStructType(schema.getFields().stream()
-        .map(x -> new AbstractMap.SimpleEntry<>(x.name(), rel(x.schema(), typeFactory)))
-        .filter(x -> x.getValue().getSqlTypeName() != SqlTypeName.NULL)
-        .filter(x -> x.getValue().getSqlTypeName() != unknown.getSqlTypeName())
-        .collect(Collectors.toList()));
-    case INT:
-      return createRelType(typeFactory, SqlTypeName.INTEGER);
-    case LONG:
-      return createRelType(typeFactory, SqlTypeName.BIGINT);
-    case ENUM:
-    case FIXED:
-    case STRING:
-      return createRelType(typeFactory, SqlTypeName.VARCHAR);
-    case FLOAT:
-      return createRelType(typeFactory, SqlTypeName.FLOAT);
-    case DOUBLE:
-      return createRelType(typeFactory, SqlTypeName.DOUBLE);
-    case BOOLEAN:
-      return createRelType(typeFactory, SqlTypeName.BOOLEAN);
-    case ARRAY:
-      return typeFactory.createArrayType(rel(schema.getElementType(), typeFactory), -1);
+      case RECORD:
+        return typeFactory.createStructType(schema.getFields()
+            .stream()
+            .map(x -> new AbstractMap.SimpleEntry<>(x.name(), rel(x.schema(), typeFactory)))
+            .filter(x -> x.getValue().getSqlTypeName() != SqlTypeName.NULL)
+            .filter(x -> x.getValue().getSqlTypeName() != unknown.getSqlTypeName())
+            .collect(Collectors.toList()));
+      case INT:
+        return createRelType(typeFactory, SqlTypeName.INTEGER);
+      case LONG:
+        return createRelType(typeFactory, SqlTypeName.BIGINT);
+      case ENUM:
+      case FIXED:
+      case STRING:
+        return createRelType(typeFactory, SqlTypeName.VARCHAR);
+      case FLOAT:
+        return createRelType(typeFactory, SqlTypeName.FLOAT);
+      case DOUBLE:
+        return createRelType(typeFactory, SqlTypeName.DOUBLE);
+      case BOOLEAN:
+        return createRelType(typeFactory, SqlTypeName.BOOLEAN);
+      case ARRAY:
+        return typeFactory.createArrayType(rel(schema.getElementType(), typeFactory), -1);
 //  TODO support map types
 //  Appears to require a Calcite version bump
 //    case MAP:
 //      return typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), rel(schema.getValueType(), typeFactory));
-    case UNION:
-      if (schema.isNullable() && schema.getTypes().size() == 2) {
-        Schema innerType = schema.getTypes().stream().filter(x -> x.getType() != Schema.Type.NULL).findFirst().get();
-        return typeFactory.createTypeWithNullability(rel(innerType, typeFactory), true);
-      } else {
-        // TODO support more elaborate union types
-        return typeFactory.createTypeWithNullability(typeFactory.createUnknownType(), true);
-      }
-    default:
-      return typeFactory.createUnknownType();
+      case UNION:
+        if (schema.isNullable() && schema.getTypes().size() == 2) {
+          Schema innerType = schema.getTypes().stream().filter(x -> x.getType() != Schema.Type.NULL).findFirst().get();
+          return typeFactory.createTypeWithNullability(rel(innerType, typeFactory), true);
+        } else {
+          // TODO support more elaborate union types
+          return typeFactory.createTypeWithNullability(typeFactory.createUnknownType(), true);
+        }
+      default:
+        return typeFactory.createUnknownType();
     }
   }
 

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ConfigProvider.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ConfigProvider.java
@@ -4,8 +4,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
 
 /** Provides key-value properties, e.g. for connector configs. */
 public interface ConfigProvider {
@@ -21,8 +22,7 @@ public interface ConfigProvider {
     if (configs == null) {
       return empty();
     } else {
-      return x -> configs.entrySet().stream()
-        .collect(Collectors.toMap(y -> y.getKey(), y -> y.getValue().toString()));
+      return x -> configs.entrySet().stream().collect(Collectors.toMap(y -> y.getKey(), y -> y.getValue().toString()));
     }
   }
 
@@ -66,7 +66,6 @@ public interface ConfigProvider {
   }
 
   default ConfigProvider withPrefix(String prefix) {
-    return x -> config(x).entrySet().stream()
-      .collect(Collectors.toMap(y -> prefix + y.getKey(), y -> y.getValue()));
+    return x -> config(x).entrySet().stream().collect(Collectors.toMap(y -> prefix + y.getKey(), y -> y.getValue()));
   }
 }

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/DataType.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/DataType.java
@@ -1,5 +1,8 @@
 package com.linkedin.hoptimator.catalog;
 
+import java.util.Collections;
+import java.util.stream.Collectors;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -8,8 +11,6 @@ import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import java.util.Collections;
-import java.util.stream.Collectors;
 
 /** Common data types. Not authoratitive or exhaustive. */
 public enum DataType {
@@ -22,7 +23,7 @@ public enum DataType {
   private final RelProtoDataType protoType;
 
   DataType(RelProtoDataType protoType) {
-    this.protoType = protoType; 
+    this.protoType = protoType;
   }
 
   public RelProtoDataType proto() {
@@ -38,7 +39,7 @@ public enum DataType {
       return null;
     } else {
       return protoType.apply(DEFAULT_TYPE_FACTORY);
-    } 
+    }
   }
 
   public static RelDataTypeFactory.Builder builder() {
@@ -87,9 +88,8 @@ public enum DataType {
       return x -> {
         RelDataType dataType = apply(x);
         RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(x);
-        builder.addAll(dataType.getFieldList().stream()
-          .filter(y -> !y.getName().equals(name))
-          .collect(Collectors.toList()));
+        builder.addAll(
+            dataType.getFieldList().stream().filter(y -> !y.getName().equals(name)).collect(Collectors.toList()));
         return builder.build();
       };
     }
@@ -98,9 +98,10 @@ public enum DataType {
       return x -> {
         RelDataType dataType = apply(x);
         RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(x);
-        builder.addAll(dataType.getFieldList().stream()
-          .filter(y -> y.getType().getSqlTypeName() != SqlTypeName.ROW)
-          .collect(Collectors.toList()));
+        builder.addAll(dataType.getFieldList()
+            .stream()
+            .filter(y -> y.getType().getSqlTypeName() != SqlTypeName.ROW)
+            .collect(Collectors.toList()));
         return builder.build();
       };
     }
@@ -116,7 +117,7 @@ public enum DataType {
           return builder.build();
         }
       };
-    } 
+    }
   }
 }
- 
+

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Database.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Database.java
@@ -1,11 +1,12 @@
 package com.linkedin.hoptimator.catalog;
 
-import org.apache.calcite.rel.type.RelDataType;
-
-import java.util.Map;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
+import org.apache.calcite.rel.type.RelDataType;
+
 
 /** A set of tables with unique names */
 public class Database {
@@ -22,20 +23,18 @@ public class Database {
   }
 
   /** Convenience constructor for simple connector-based tables */
-  public Database(String name, TableLister lister, TableResolver resolver,
-      ConfigProvider configs) {
+  public Database(String name, TableLister lister, TableResolver resolver, ConfigProvider configs) {
     this(name, lister, resolver, TableFactory.connector(configs));
   }
 
   /** Convenience constructor for simple connector-based tables with resources */
-  public Database(String name, TableLister lister, TableResolver resolver,
-      ConfigProvider configs, ResourceProvider resources) {
+  public Database(String name, TableLister lister, TableResolver resolver, ConfigProvider configs,
+      ResourceProvider resources) {
     this(name, lister, resolver, TableFactory.connector(configs, resources));
   }
 
   /** Convenience constructor for a list of connector-based tables */
-  public Database(String name, Collection<String> tables, TableResolver resolver,
-      ConfigProvider configs) {
+  public Database(String name, Collection<String> tables, TableResolver resolver, ConfigProvider configs) {
     this(name, tables, resolver, TableFactory.connector(configs));
   }
 
@@ -46,8 +45,8 @@ public class Database {
 
   /** Convenience constructor for a static table map */
   public Database(String name, Map<String, HopTable> tableMap) {
-    this(name, () -> Collections.unmodifiableCollection(tableMap.keySet()),
-      x -> tableMap.get(x).rowType(), (x, y, z) -> tableMap.get(y));
+    this(name, () -> Collections.unmodifiableCollection(tableMap.keySet()), x -> tableMap.get(x).rowType(),
+        (x, y, z) -> tableMap.get(y));
   }
 
   /** Find a specific table in the database. */

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/DatabaseSchema.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/DatabaseSchema.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.catalog;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /** Exposes a Database to Apache Calcite. */
 public class DatabaseSchema extends AbstractSchema {
@@ -14,8 +15,7 @@ public class DatabaseSchema extends AbstractSchema {
   public DatabaseSchema(Database database) {
     this.database = database;
     try {
-      this.tableMap = database.tables().stream()
-        .collect(Collectors.toMap(x -> x, x -> new ProtoTable(x, database)));
+      this.tableMap = database.tables().stream().collect(Collectors.toMap(x -> x, x -> new ProtoTable(x, database)));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopRel.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopRel.java
@@ -3,6 +3,7 @@ package com.linkedin.hoptimator.catalog;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 
+
 /**
  * Calling convention that ultimately gets converted to a Pipeline or similar.
  *
@@ -11,7 +12,7 @@ import org.apache.calcite.rel.RelNode;
  * and/or Hoptimator may support additional calling conventions (e.g. batch jobs
  * or build-and-push jobs). This calling convention -- and indeed, this entire
  * module -- makes no assumptions about the compute layer.
- *  
+ *
  */
 public interface HopRel extends RelNode {
   Convention CONVENTION = new Convention.Impl("HOP", HopRel.class);

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopTable.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopTable.java
@@ -1,18 +1,19 @@
 package com.linkedin.hoptimator.catalog;
 
-import org.apache.calcite.schema.impl.AbstractTable;
-import org.apache.calcite.schema.TranslatableTable;
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.sql.SqlWriter;
-import org.apache.calcite.sql.pretty.SqlPrettyWriter;
-import org.apache.calcite.plan.RelOptTable;
-import org.apache.calcite.plan.RelOptCluster;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+
 
 /**
  * HopTables can have "baggage", including Resources and arbitrary DDL/SQL.
@@ -22,7 +23,7 @@ import java.util.Map;
  * table can bring along a CDC stream or a cache. Generally, such Resources
  * won't physically exist until they are needed by a pipeline, at which point
  * Hoptimator will orchestrate their deployment.
- */ 
+ */
 public class HopTable extends AbstractTable implements ScriptImplementor, TranslatableTable {
   private final String database;
   private final String name;
@@ -31,9 +32,8 @@ public class HopTable extends AbstractTable implements ScriptImplementor, Transl
   private final Collection<Resource> writeResources;
   private final ScriptImplementor implementor;
 
-  public HopTable(String database, String name, RelDataType rowType,
-      Collection<Resource> readResources, Collection<Resource> writeResources, 
-      ScriptImplementor implementor) {
+  public HopTable(String database, String name, RelDataType rowType, Collection<Resource> readResources,
+      Collection<Resource> writeResources, ScriptImplementor implementor) {
     this.database = database;
     this.name = name;
     this.rowType = rowType;
@@ -43,11 +43,10 @@ public class HopTable extends AbstractTable implements ScriptImplementor, Transl
   }
 
   /** Convenience constructor for HopTables that only need a connector config. */
-  public HopTable(String database, String name, RelDataType rowType,
-      Collection<Resource> readResources, Collection<Resource> writeResources,
-      Map<String, String> connectorConfig) {
+  public HopTable(String database, String name, RelDataType rowType, Collection<Resource> readResources,
+      Collection<Resource> writeResources, Map<String, String> connectorConfig) {
     this(database, name, rowType, readResources, writeResources,
-      new ScriptImplementor.ConnectorImplementor(database, name, rowType, connectorConfig));
+        new ScriptImplementor.ConnectorImplementor(database, name, rowType, connectorConfig));
   }
 
   /** Convenience constructor for HopTables that only need a connector config. */
@@ -56,10 +55,8 @@ public class HopTable extends AbstractTable implements ScriptImplementor, Transl
     this(database, name, rowType, resources, resources, connectorConfig);
   }
 
-
   /** Convenience constructor for HopTables that only need a connector config. */
-  public HopTable(String database, String name, RelDataType rowType,
-      Map<String, String> connectorConfig) {
+  public HopTable(String database, String name, RelDataType rowType, Map<String, String> connectorConfig) {
     this(database, name, rowType, Collections.emptyList(), connectorConfig);
   }
 

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopTableScan.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopTableScan.java
@@ -1,12 +1,13 @@
 package com.linkedin.hoptimator.catalog;
 
-import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.plan.RelOptTable;
+import java.util.Collections;
+
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.TableScan;
 
-import java.util.Collections;
 
 /** Internal. */
 public final class HopTableScan extends TableScan implements HopRel {

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopTableScanRule.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/HopTableScanRule.java
@@ -1,20 +1,18 @@
 package com.linkedin.hoptimator.catalog;
 
 import org.apache.calcite.plan.Convention;
-import org.apache.calcite.plan.RelOptPlanner;
-import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 
+
 class HopTableScanRule extends ConverterRule {
-  public static final HopTableScanRule INSTANCE = Config.INSTANCE
-    .withConversion(LogicalTableScan.class, Convention.NONE,
-        HopRel.CONVENTION, "HopTableScanRule")
-    .withRuleFactory(HopTableScanRule::new)
-    .as(Config.class)
-    .toRule(HopTableScanRule.class);
+  public static final HopTableScanRule INSTANCE =
+      Config.INSTANCE.withConversion(LogicalTableScan.class, Convention.NONE, HopRel.CONVENTION, "HopTableScanRule")
+          .withRuleFactory(HopTableScanRule::new)
+          .as(Config.class)
+          .toRule(HopTableScanRule.class);
 
   protected HopTableScanRule(Config config) {
     super(config);

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Names.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Names.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.catalog;
 
 import java.util.Locale;
 
+
 public final class Names {
 
   private Names() {
@@ -10,10 +11,9 @@ public final class Names {
   /** Attempt to format s as a K8s object name, or part of one. */
   public static String canonicalize(String s) {
     return s.toLowerCase(Locale.ROOT)
-      .replaceAll("[^a-z0-9\\-]+", "-")
-      .replaceAll("^[^a-z0-9]*", "")
-      .replaceAll("[^a-z0-9]*$", "")
-      .replaceAll("\\-+", "-");
+        .replaceAll("[^a-z0-9\\-]+", "-")
+        .replaceAll("^[^a-z0-9]*", "")
+        .replaceAll("[^a-z0-9]*$", "")
+        .replaceAll("\\-+", "-");
   }
-
 }

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ProtoTable.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ProtoTable.java
@@ -1,14 +1,15 @@
 package com.linkedin.hoptimator.catalog;
 
-import org.apache.calcite.schema.TranslatableTable;
-import org.apache.calcite.schema.impl.AbstractTable;
-import org.apache.calcite.plan.RelOptTable;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
 
-import java.util.concurrent.ExecutionException;
 
 /** Enables lazy-loading of HopTables */
 public class ProtoTable extends AbstractTable implements TranslatableTable {

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Resource.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/Resource.java
@@ -1,8 +1,8 @@
 package com.linkedin.hoptimator.catalog;
 
-import java.io.InputStream;
 import java.io.IOException;
-import java.util.Arrays;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -11,16 +11,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.UUID;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.net.URL;
+
 
 /**
  * Represents something required by a Table.
@@ -77,8 +76,8 @@ public abstract class Resource {
 
   /** Export a map of values */
   protected void export(String key, Map<String, String> values) {
-    export(key, values.entrySet().stream().map(x -> x.getKey() + ": " + x.getValue())
-      .collect(Collectors.joining("\n")));
+    export(key,
+        values.entrySet().stream().map(x -> x.getKey() + ": " + x.getValue()).collect(Collectors.joining("\n")));
   }
 
   /** Export a list of values */
@@ -124,7 +123,7 @@ public abstract class Resource {
   @Override
   public int hashCode() {
     return toString().hashCode();
-  } 
+  }
 
   @Override
   public String toString() {
@@ -199,7 +198,7 @@ public abstract class Resource {
       Map<String, String> newVars = new HashMap<>();
       newVars.putAll(vars);
       newVars.put(key, value);
-      return new SimpleEnvironment(){{
+      return new SimpleEnvironment() {{
         exportAll(newVars);
       }};
     }
@@ -300,12 +299,12 @@ public abstract class Resource {
       this.env = env;
       this.template = template;
     }
-        
+
     @Override
     public String render(Resource resource) {
       StringBuffer sb = new StringBuffer();
-      Pattern p = Pattern.compile(
-        "([\\s\\-\\#]*)\\{\\{\\s*([\\w_\\-\\.]+)\\s*(:([\\w_\\-\\.]+))?\\s*((\\w+\\s*)*)\\s*\\}\\}");
+      Pattern p =
+          Pattern.compile("([\\s\\-\\#]*)\\{\\{\\s*([\\w_\\-\\.]+)\\s*(:([\\w_\\-\\.]+))?\\s*((\\w+\\s*)*)\\s*\\}\\}");
       Matcher m = p.matcher(template);
       while (m.find()) {
         String prefix = m.group(1);
@@ -325,7 +324,7 @@ public abstract class Resource {
         String replacement = quotedPrefix + quotedValue.replaceAll("\\n", quotedPrefix);
         m.appendReplacement(sb, replacement);
       }
-      m.appendTail(sb); 
+      m.appendTail(sb);
       return sb.toString();
     }
 
@@ -334,18 +333,18 @@ public abstract class Resource {
       String[] funcs = transform.split("\\W+");
       for (String f : funcs) {
         switch (f) {
-        case "toLowerCase":
-          res = res.toLowerCase(Locale.ROOT);
-          break;
-        case "toUpperCase":
-          res = res.toUpperCase(Locale.ROOT);
-          break;
-        case "toName":
-          res = canonicalizeName(res);
-          break;
-        case "concat":
-          res = res.replace("\n", "");
-          break;
+          case "toLowerCase":
+            res = res.toLowerCase(Locale.ROOT);
+            break;
+          case "toUpperCase":
+            res = res.toUpperCase(Locale.ROOT);
+            break;
+          case "toName":
+            res = canonicalizeName(res);
+            break;
+          case "concat":
+            res = res.replace("\n", "");
+            break;
         }
       }
       return res;
@@ -362,12 +361,11 @@ public abstract class Resource {
     Collection<Template> find(Resource resource) throws IOException;
 
     default Collection<String> render(Resource resource) throws IOException {
-      return find(resource).stream().map(x -> x.render(resource))
-        .collect(Collectors.toList());
+      return find(resource).stream().map(x -> x.render(resource)).collect(Collectors.toList());
     }
   }
- 
-  /** Finds Templates for a given Resource by looking for resource files in the classpath. */ 
+
+  /** Finds Templates for a given Resource by looking for resource files in the classpath. */
   public static class SimpleTemplateFactory implements TemplateFactory {
     private final Environment env;
 
@@ -380,7 +378,7 @@ public abstract class Resource {
       String template = resource.template();
       List<Template> res = new ArrayList<>();
       for (Enumeration<URL> e = getClass().getClassLoader().getResources(template + ".yaml.template");
-          e.hasMoreElements();) {
+          e.hasMoreElements(); ) {
         InputStream in = e.nextElement().openStream();
         StringBuilder sb = new StringBuilder();
         Scanner scanner = new Scanner(in);

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ResourceProvider.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/ResourceProvider.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+
 /**
  * Enables an adapter to emit arbitrary Resources for a given table.
  *
@@ -20,16 +21,12 @@ public interface ResourceProvider {
 
   /** Resources required when reading from the table */
   default Collection<Resource> readResources(String tableName) {
-    return resources(tableName).stream()
-      .filter(x -> !(x instanceof WriteResource))
-      .collect(Collectors.toList());
+    return resources(tableName).stream().filter(x -> !(x instanceof WriteResource)).collect(Collectors.toList());
   }
 
   /** Resources required when writing to the table */
   default Collection<Resource> writeResources(String tableName) {
-    return resources(tableName).stream()
-      .filter(x -> !(x instanceof ReadResource))
-      .collect(Collectors.toList());
+    return resources(tableName).stream().filter(x -> !(x instanceof ReadResource)).collect(Collectors.toList());
   }
 
   /**
@@ -59,15 +56,14 @@ public interface ResourceProvider {
       combined.addAll(sources);
 
       // remove all non-leaf-node upstream Resources
-      sources.removeAll(sources.stream().flatMap(y -> y.inputs().stream())
-        .collect(Collectors.toList()));
+      sources.removeAll(sources.stream().flatMap(y -> y.inputs().stream()).collect(Collectors.toList()));
 
       // remove all read/write-only upstream Resources
       sources.removeAll(sources.stream()
-        .filter(y -> y instanceof ReadResource || y instanceof WriteResource)
-        .collect(Collectors.toList()));
+          .filter(y -> y instanceof ReadResource || y instanceof WriteResource)
+          .collect(Collectors.toList()));
 
-      // link all sources to all sinks       
+      // link all sources to all sinks
       sink.resources(x).forEach(y -> {
         combined.add(new Resource(y) {{
           if (!(y instanceof ReadResource || y instanceof WriteResource)) {
@@ -115,9 +111,8 @@ public interface ResourceProvider {
     return x -> {
       List<Resource> combined = new ArrayList<>();
       combined.addAll(resources(x));
-      combined.addAll(readResourceProvider.resources(x).stream()
-        .map(y -> new ReadResource(y))
-        .collect(Collectors.toList()));
+      combined.addAll(
+          readResourceProvider.resources(x).stream().map(y -> new ReadResource(y)).collect(Collectors.toList()));
       return combined;
     };
   }
@@ -127,9 +122,8 @@ public interface ResourceProvider {
     return x -> {
       List<Resource> combined = new ArrayList<>();
       combined.addAll(resources(x));
-      combined.addAll(writeResourceProvider.resources(x).stream()
-        .map(y -> new WriteResource(y))
-        .collect(Collectors.toList()));
+      combined.addAll(
+          writeResourceProvider.resources(x).stream().map(y -> new WriteResource(y)).collect(Collectors.toList()));
       return combined;
     };
   }
@@ -167,15 +161,15 @@ public interface ResourceProvider {
   }
 
   /** A Resource that shouldn't be provided when reading from the table. */
-  static class ReadResource extends Resource {
+  class ReadResource extends Resource {
 
     public ReadResource(Resource resource) {
       super(resource);
     }
   }
 
-  /** A Resource that shouldn't be provided when wriring to the table. */
-  static class WriteResource extends Resource {
+  /** A Resource that shouldn't be provided when wiring to the table. */
+  class WriteResource extends Resource {
 
     public WriteResource(Resource resource) {
       super(resource);

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/RuleProvider.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/RuleProvider.java
@@ -1,8 +1,9 @@
 package com.linkedin.hoptimator.catalog;
 
+import java.util.Collection;
+
 import org.apache.calcite.plan.RelOptRule;
 
-import java.util.Collection;
 
 /** Service Provider Interface to enable dynamically loading planner rules. */
 public interface RuleProvider {

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/RuleService.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/RuleService.java
@@ -1,14 +1,18 @@
 package com.linkedin.hoptimator.catalog;
 
-import org.apache.calcite.plan.RelOptRule;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
+import org.apache.calcite.plan.RelOptRule;
+
+
 public final class RuleService {
+
+  private RuleService() {
+  }
 
   public static Collection<RuleProvider> providers() {
     ServiceLoader<RuleProvider> loader = ServiceLoader.load(RuleProvider.class);
@@ -18,7 +22,6 @@ public final class RuleService {
   }
 
   public static Collection<RelOptRule> rules() {
-    return providers().stream().flatMap(x -> x.rules().stream())
-      .collect(Collectors.toList());
+    return providers().stream().flatMap(x -> x.rules().stream()).collect(Collectors.toList());
   }
 }

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableFactory.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableFactory.java
@@ -1,8 +1,9 @@
 package com.linkedin.hoptimator.catalog;
 
+import java.util.Collections;
+
 import org.apache.calcite.rel.type.RelDataType;
 
-import java.util.Collections;
 
 /** Constructs a HopTable */
 public interface TableFactory {
@@ -35,8 +36,8 @@ public interface TableFactory {
     @Override
     public HopTable table(String database, String name, RelDataType rowType) {
       return new HopTable(database, name, rowType, resourceProvider.readResources(name),
-        resourceProvider.writeResources(name),
-        ScriptImplementor.empty().connector(database, name, rowType, configProvider.config(name)));
+          resourceProvider.writeResources(name),
+          ScriptImplementor.empty().connector(database, name, rowType, configProvider.config(name)));
     }
   }
 }

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableLister.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableLister.java
@@ -3,6 +3,7 @@ package com.linkedin.hoptimator.catalog;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 
+
 /** Lists tables within a database */
 public interface TableLister {
   Collection<String> list() throws InterruptedException, ExecutionException;

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableResolver.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/TableResolver.java
@@ -1,11 +1,11 @@
 package com.linkedin.hoptimator.catalog;
 
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelProtoDataType;
-
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+
 
 /** Resolves a table name into a concrete row type. Usually involves a network call. */
 public interface TableResolver {

--- a/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/builtin/DatagenSchemaFactory.java
+++ b/hoptimator-catalog/src/main/java/com/linkedin/hoptimator/catalog/builtin/DatagenSchemaFactory.java
@@ -1,23 +1,21 @@
 package com.linkedin.hoptimator.catalog.builtin;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaFactory;
+import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.schema.Schema;
-import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.schema.SchemaFactory;
 
 import com.linkedin.hoptimator.catalog.ConfigProvider;
 import com.linkedin.hoptimator.catalog.Database;
 import com.linkedin.hoptimator.catalog.DatabaseSchema;
 import com.linkedin.hoptimator.catalog.HopTable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /** Provides built-in DATAGEN databases */
 public class DatagenSchemaFactory implements SchemaFactory {
@@ -26,15 +24,26 @@ public class DatagenSchemaFactory implements SchemaFactory {
   public Schema create(SchemaPlus parentSchema, String name, Map<String, Object> operand) {
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     Map<String, HopTable> datagenTables = new HashMap<>();
-    datagenTables.put("PERSON", new HopTable("DATAGEN", "PERSON", (new RelDataTypeFactory.Builder(typeFactory))
-      .add("NAME", SqlTypeName.VARCHAR).add("AGE", SqlTypeName.INTEGER)
-      .add("EMPID", SqlTypeName.BIGINT).build(), ConfigProvider.empty()
-      .with("connector", "datagen").with("number-of-rows", "10").with("fields.AGE.min", "0")
-      .with("fields.AGE.max", "100").with("fields.NAME.length", "5").config("PERSON")));
-    datagenTables.put("COMPANY", new HopTable("DATAGEN", "COMPANY", (new RelDataTypeFactory.Builder(typeFactory))
-      .add("NAME", SqlTypeName.VARCHAR).add("CEO", SqlTypeName.VARCHAR).build(), ConfigProvider.empty()
-      .with("connector", "datagen").with("number-of-rows", "10").with("fields.NAME.length", "5")
-      .with("fields.CEO.length", "5").config("COMPANY")));
+    datagenTables.put("PERSON", new HopTable("DATAGEN", "PERSON",
+        (new RelDataTypeFactory.Builder(typeFactory)).add("NAME", SqlTypeName.VARCHAR)
+            .add("AGE", SqlTypeName.INTEGER)
+            .add("EMPID", SqlTypeName.BIGINT)
+            .build(), ConfigProvider.empty()
+        .with("connector", "datagen")
+        .with("number-of-rows", "10")
+        .with("fields.AGE.min", "0")
+        .with("fields.AGE.max", "100")
+        .with("fields.NAME.length", "5")
+        .config("PERSON")));
+    datagenTables.put("COMPANY", new HopTable("DATAGEN", "COMPANY",
+        (new RelDataTypeFactory.Builder(typeFactory)).add("NAME", SqlTypeName.VARCHAR)
+            .add("CEO", SqlTypeName.VARCHAR)
+            .build(), ConfigProvider.empty()
+        .with("connector", "datagen")
+        .with("number-of-rows", "10")
+        .with("fields.NAME.length", "5")
+        .with("fields.CEO.length", "5")
+        .config("COMPANY")));
     return new DatabaseSchema(new Database(name, datagenTables));
   }
 }

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/AvroConverterTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/AvroConverterTest.java
@@ -1,19 +1,23 @@
 package com.linkedin.hoptimator.catalog;
 
+import org.apache.avro.Schema;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.util.Litmus;
-import org.apache.avro.Schema;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+
 
 public class AvroConverterTest {
 
   @Test
   public void convertsNestedSchemas() {
-    String schemaString = "{\"type\":\"record\",\"name\":\"E\",\"namespace\":\"ns\",\"fields\":[{\"name\":\"h\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"H\",\"namespace\":\"ns\",\"fields\":[{\"name\":\"A\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"A\",\"fields\":[]}]}]}]}]}";
+    // CHECKSTYLE:OFF
+    String schemaString =
+        "{\"type\":\"record\",\"name\":\"E\",\"namespace\":\"ns\",\"fields\":[{\"name\":\"h\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"H\",\"namespace\":\"ns\",\"fields\":[{\"name\":\"A\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"A\",\"fields\":[]}]}]}]}]}";
+    // CHECKSTYLE:ON
 
     Schema avroSchema1 = (new Schema.Parser()).parse(schemaString);
     RelDataType rel1 = AvroConverter.rel(avroSchema1);

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/DataTypeTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/DataTypeTest.java
@@ -1,16 +1,17 @@
 package com.linkedin.hoptimator.catalog;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+
 
 public class DataTypeTest {
 
   @Test
   public void skipsNestedRows() {
-    DataType.Struct struct = DataType.struct().with("one", DataType.VARCHAR)
-        .with("two", DataType.struct().with("three", DataType.VARCHAR));
+    DataType.Struct struct =
+        DataType.struct().with("one", DataType.VARCHAR).with("two", DataType.struct().with("three", DataType.VARCHAR));
     RelDataType row1 = struct.rel();
     assertTrue(row1.toString(), row1.getFieldCount() == 2);
     assertTrue(row1.toString(), row1.getField("one", false, false) != null);

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ResourceTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ResourceTest.java
@@ -1,11 +1,11 @@
 package com.linkedin.hoptimator.catalog;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
+import java.util.function.Function;
+
 import org.junit.Test;
 
-import java.util.function.Function;
+import static org.junit.Assert.assertEquals;
+
 
 public class ResourceTest {
 

--- a/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
+++ b/hoptimator-catalog/src/test/java/com/linkedin/hoptimator/catalog/ScriptImplementorTest.java
@@ -1,26 +1,27 @@
 package com.linkedin.hoptimator.catalog;
 
+import org.apache.avro.Schema;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.avro.Schema;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 
 public class ScriptImplementorTest {
 
   @Test
   public void implementsFlinkCreateTableDDL() {
     String schemaString = "{\"type\" : \"record\", \"namespace\": \"foo\", \"name\": \"bar\","
-      + "\"fields\" : [ {\"name\" : \"idValue1\",\"type\" : \"string\", \"doc\" : \"idValue1 VARCHAR NOT NULL\" } ]}";
+        + "\"fields\" : [ {\"name\" : \"idValue1\",\"type\" : \"string\", \"doc\" : \"idValue1 VARCHAR NOT NULL\" } ]}";
     Schema avroSchema = (new Schema.Parser()).parse(schemaString);
     RelDataType rowType = AvroConverter.rel(avroSchema);
     ConfigProvider configProvider = ConfigProvider.empty()
-      .with("connector", "kafka")
-      .with("properties.bootstrap.servers", "localhost:9092")
-      .with("topic", x -> x);
+        .with("connector", "kafka")
+        .with("properties.bootstrap.servers", "localhost:9092")
+        .with("topic", x -> x);
     HopTable table = new HopTable("DATABASE", "TABLE1", rowType, configProvider.config("topic1"));
     SqlWriter w = new SqlPrettyWriter();
     table.implement(w);
@@ -38,8 +39,7 @@ public class ScriptImplementorTest {
   @Test
   public void magicPrimaryKey() {
     SqlWriter w = new SqlPrettyWriter();
-    RelDataType rowType = DataType.struct().with("F1", DataType.VARCHAR)
-        .with("PRIMARY_KEY", DataType.VARCHAR).rel();
+    RelDataType rowType = DataType.struct().with("F1", DataType.VARCHAR).with("PRIMARY_KEY", DataType.VARCHAR).rel();
     HopTable table = new HopTable("DATABASE", "TABLE1", rowType, ConfigProvider.empty().config("x"));
     table.implement(w);
     String out = w.toString();
@@ -49,8 +49,7 @@ public class ScriptImplementorTest {
   @Test
   public void magicNullFields() {
     SqlWriter w = new SqlPrettyWriter();
-    RelDataType rowType = DataType.struct().with("F1", DataType.VARCHAR)
-        .with("KEY", DataType.NULL).rel();
+    RelDataType rowType = DataType.struct().with("F1", DataType.VARCHAR).with("KEY", DataType.NULL).rel();
     HopTable table = new HopTable("DATABASE", "TABLE1", rowType, ConfigProvider.empty().config("x"));
     table.implement(w);
     String out = w.toString();

--- a/hoptimator-cli/src/main/java/sqlline/HoptimatorAppConfig.java
+++ b/hoptimator-cli/src/main/java/sqlline/HoptimatorAppConfig.java
@@ -1,35 +1,33 @@
 package sqlline;
 
-import com.linkedin.hoptimator.jdbc.HoptimatorDriver;
-import com.linkedin.hoptimator.util.DeploymentService;
-import com.linkedin.hoptimator.util.Sink;
-import com.linkedin.hoptimator.util.planner.PipelineRel;
-
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.jdbc.CalciteConnection;
-import org.apache.calcite.sql.dialect.AnsiSqlDialect;
-
-import org.jline.reader.Completer;
-
-import java.util.Arrays;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;
-import java.sql.SQLException;
+
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.jline.reader.Completer;
+
+import com.linkedin.hoptimator.jdbc.HoptimatorDriver;
+import com.linkedin.hoptimator.util.DeploymentService;
+import com.linkedin.hoptimator.util.planner.PipelineRel;
+
 
 public class HoptimatorAppConfig extends Application {
 
   public String getInfoMessage() {
-    Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader()
-        .getResourceAsStream("welcome.txt"), "utf-8");
+    Scanner scanner =
+        new Scanner(Thread.currentThread().getContextClassLoader().getResourceAsStream("welcome.txt"), "utf-8");
     StringBuilder sb = new StringBuilder();
     while (scanner.hasNext()) {
       sb.append(scanner.nextLine());
       sb.append("\n");
     }
-    return sb.toString(); 
+    return sb.toString();
   }
 
   public Collection<CommandHandler> getCommandHandlers(SqlLine sqlline) {
@@ -95,7 +93,7 @@ public class HoptimatorAppConfig extends Application {
       } catch (SQLException e) {
         sqlline.error(e);
         dispatchCallback.setToFailure();
-        return; 
+        return;
       }
     }
 
@@ -109,7 +107,6 @@ public class HoptimatorAppConfig extends Application {
       return false;
     }
   }
-
 
   private static final class SpecifyCommandHandler implements CommandHandler {
 
@@ -165,7 +162,7 @@ public class HoptimatorAppConfig extends Application {
       } catch (SQLException e) {
         sqlline.error(e);
         dispatchCallback.setToFailure();
-        return; 
+        return;
       }
     }
 
@@ -214,7 +211,8 @@ public class HoptimatorAppConfig extends Application {
 
     @Override
     public void execute(String line, DispatchCallback dispatchCallback) {
-      Scanner scanner = new Scanner(Thread.currentThread().getContextClassLoader().getResourceAsStream("intro.txt"), "utf-8");
+      Scanner scanner =
+          new Scanner(Thread.currentThread().getContextClassLoader().getResourceAsStream("intro.txt"), "utf-8");
       while (scanner.hasNext()) {
         sqlline.output(scanner.nextLine());
       }

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/AdClickTable.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/AdClickTable.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.demodb;
 
 import com.linkedin.hoptimator.util.ArrayTable;
 
+
 public class AdClickTable extends ArrayTable<AdClickTable.Row> {
 
   // CHECKSTYLE:OFF

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/AdsSchema.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/AdsSchema.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.demodb;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
-import java.util.HashMap;
-import java.util.Map;
 
 public class AdsSchema extends AbstractSchema {
 

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/CampaignTable.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/CampaignTable.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.demodb;
 
 import com.linkedin.hoptimator.util.ArrayTable;
 
+
 public class CampaignTable extends ArrayTable<CampaignTable.Row> {
 
   // CHECKSTYLE:OFF

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/CompanyTable.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/CompanyTable.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.demodb;
 
 import com.linkedin.hoptimator.util.ArrayTable;
 
+
 public class CompanyTable extends ArrayTable<CompanyTable.Row> {
 
   // CHECKSTYLE:OFF

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/DemoDriver.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/DemoDriver.java
@@ -1,11 +1,5 @@
 package com.linkedin.hoptimator.demodb;
 
-import org.apache.calcite.avatica.DriverVersion;
-import org.apache.calcite.jdbc.CalciteConnection;
-import org.apache.calcite.jdbc.Driver;
-import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.schema.impl.AbstractSchema;
-
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -14,6 +8,13 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.calcite.avatica.DriverVersion;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.Driver;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractSchema;
+
 
 /** JDBC driver with fake in-memory data. */
 public class DemoDriver extends Driver {
@@ -38,10 +39,12 @@ public class DemoDriver extends Driver {
       return null;
     }
     String params = url.substring(getConnectStringPrefix().length());
-    Set<String> schemas = Arrays.asList(params.split(",")).stream()
+    Set<String> schemas = Arrays.asList(params.split(","))
+        .stream()
         .map(x -> x.trim())
         .filter(x -> !x.isEmpty())
-        .map(x -> x.toUpperCase(Locale.ROOT)).collect(Collectors.toSet());
+        .map(x -> x.toUpperCase(Locale.ROOT))
+        .collect(Collectors.toSet());
     try {
       Connection connection = super.connect(url, props);
       if (connection == null) {

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/MemberTable.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/MemberTable.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.demodb;
 
 import com.linkedin.hoptimator.util.ArrayTable;
 
+
 public class MemberTable extends ArrayTable<MemberTable.Row> {
 
   // CHECKSTYLE:OFF

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/PageViewTable.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/PageViewTable.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.demodb;
 
 import com.linkedin.hoptimator.util.ArrayTable;
 
+
 public class PageViewTable extends ArrayTable<PageViewTable.Row> {
 
   // CHECKSTYLE:OFF

--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/ProfileSchema.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/ProfileSchema.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.demodb;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
-import java.util.HashMap;
-import java.util.Map;
 
 public class ProfileSchema extends AbstractSchema {
 

--- a/hoptimator-flink-adapter/src/main/java/com/linkedin/hoptimator/catalog/flink/FlinkStreamingSqlJob.java
+++ b/hoptimator-flink-adapter/src/main/java/com/linkedin/hoptimator/catalog/flink/FlinkStreamingSqlJob.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.catalog.flink;
 
 import com.linkedin.hoptimator.catalog.Resource;
 
+
 public class FlinkStreamingSqlJob extends Resource {
 
   public FlinkStreamingSqlJob(String namespace, String name, String sql) {

--- a/hoptimator-flink-adapter/src/main/java/com/linkedin/hoptimator/operator/flink/FlinkControllerProvider.java
+++ b/hoptimator-flink-adapter/src/main/java/com/linkedin/hoptimator/operator/flink/FlinkControllerProvider.java
@@ -12,24 +12,24 @@ import io.kubernetes.client.extended.controller.reconciler.Reconciler;
 import java.util.Collection;
 import java.util.Collections;
 
+
 /** A bridge to flink-kubernetes-operator */
 public class FlinkControllerProvider implements ControllerProvider {
 
   @Override
   public Collection<Controller> controllers(Operator operator) {
-    operator.registerApi("FlinkDeployment", "flinkdeployment", "flinkdeployments",
-      "flink.apache.org", "v1beta1");
+    operator.registerApi("FlinkDeployment", "flinkdeployment", "flinkdeployments", "flink.apache.org", "v1beta1");
 
-    operator.registerApi("SqlJob", "sqljob", "sqljobs",
-      "hoptimator.linkedin.com", "v1alpha1", V1alpha1SqlJob.class, V1alpha1SqlJobList.class);
+    operator.registerApi("SqlJob", "sqljob", "sqljobs", "hoptimator.linkedin.com", "v1alpha1", V1alpha1SqlJob.class,
+        V1alpha1SqlJobList.class);
 
     Reconciler reconciler = new FlinkStreamingSqlJobReconciler(operator);
     Controller controller = ControllerBuilder.defaultBuilder(operator.informerFactory())
-      .withReconciler(reconciler)
-      .withName("flink-streaming-sql-job-controller")
-      .withWorkerCount(1)
-      .watch(x -> ControllerBuilder.controllerWatchBuilder(V1alpha1SqlJob.class, x).build())
-      .build();
+        .withReconciler(reconciler)
+        .withName("flink-streaming-sql-job-controller")
+        .withWorkerCount(1)
+        .watch(x -> ControllerBuilder.controllerWatchBuilder(V1alpha1SqlJob.class, x).build())
+        .build();
 
     return Collections.singleton(controller);
   }

--- a/hoptimator-flink-adapter/src/main/java/com/linkedin/hoptimator/operator/flink/FlinkStreamingSqlJobReconciler.java
+++ b/hoptimator-flink-adapter/src/main/java/com/linkedin/hoptimator/operator/flink/FlinkStreamingSqlJobReconciler.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.stream.Collectors;
 
+
 /**
  * Manifests streaming SqlJobs as Flink jobs.
  *
@@ -55,7 +56,7 @@ public class FlinkStreamingSqlJobReconciler implements Reconciler {
 
       List<String> sql = object.getSpec().getSql();
       String script = sql.stream().collect(Collectors.joining(";\n"));
- 
+
       DialectEnum dialect = object.getSpec().getDialect();
       if (!DialectEnum.FLINK.equals(dialect)) {
         log.info("Not Flink SQL. Skipping.");
@@ -73,7 +74,7 @@ public class FlinkStreamingSqlJobReconciler implements Reconciler {
       boolean allReady = true;
       boolean anyFailed = false;
       for (String yaml : sqlJob.render(templateFactory)) {
-        operator.apply(yaml, object); 
+        operator.apply(yaml, object);
         if (!operator.isReady(yaml)) {
           allReady = false;
         }
@@ -95,10 +96,10 @@ public class FlinkStreamingSqlJobReconciler implements Reconciler {
         result = new Result(false); // done
       }
 
-      operator.apiFor(SQLJOB).updateStatus(object, x -> object.getStatus())
+      operator.apiFor(SQLJOB)
+          .updateStatus(object, x -> object.getStatus())
           .onFailure((x, y) -> log.error("Failed to update status of SqlJob {}: {}.", name, y.getMessage()))
           .throwsApiException();
- 
     } catch (Exception e) {
       log.error("Encountered exception while reconciling Flink streaming SqlJob {}/{}", namespace, name, e);
       return new Result(true, operator.failureRetryDuration());

--- a/hoptimator-flink-runner/src/main/java/com/linkedin/hoptimator/flink/runner/FlinkRunner.java
+++ b/hoptimator-flink-runner/src/main/java/com/linkedin/hoptimator/flink/runner/FlinkRunner.java
@@ -1,11 +1,11 @@
 package com.linkedin.hoptimator.flink.runner;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
-
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /** Runs SQL from command-line args. */
 public final class FlinkRunner {
@@ -13,12 +13,12 @@ public final class FlinkRunner {
 
   private FlinkRunner() {
   }
- 
-  public static void main(String []args) {
+
+  public static void main(String[] args) {
     EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
-        
+
     for (int i = 0; i < args.length; i++) {
       String stmt = args[i].replaceAll("\\n", "").trim();
       if (!stmt.isEmpty() && !stmt.startsWith("--")) {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/BackwardCompatibilityValidator.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/BackwardCompatibilityValidator.java
@@ -7,9 +7,10 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 
+
 /** Validates that tables follow backwards-compatible schema evolution rules.  */
 class BackwardCompatibilityValidator extends CompatibilityValidatorBase {
-  
+
   @Override
   protected void validate(Table table, Table originalTable, Issues issues) {
     RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
@@ -23,8 +24,8 @@ class BackwardCompatibilityValidator extends CompatibilityValidatorBase {
       if (existingField != null && !SqlTypeUtil.canAssignFrom(existingField.getType(), field.getType())) {
         String fromTypeName = existingField.getType().getSqlTypeName().getName();
         String toTypeName = field.getType().getSqlTypeName().getName();
-        issues.child(field.getName()).error("Backwards-incompatible change: cannot assign to "
-            + toTypeName + " from " + fromTypeName);
+        issues.child(field.getName())
+            .error("Backwards-incompatible change: cannot assign to " + toTypeName + " from " + fromTypeName);
       }
     }
   }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/BuiltinCatalogProvider.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/BuiltinCatalogProvider.java
@@ -1,11 +1,12 @@
 package com.linkedin.hoptimator.jdbc;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import com.linkedin.hoptimator.Catalog;
 import com.linkedin.hoptimator.CatalogProvider;
 import com.linkedin.hoptimator.jdbc.schema.UtilityCatalog;
 
-import java.util.Collection;
-import java.util.Collections;
 
 public class BuiltinCatalogProvider implements CatalogProvider {
 

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CatalogService.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CatalogService.java
@@ -1,14 +1,15 @@
 package com.linkedin.hoptimator.jdbc;
 
-import com.linkedin.hoptimator.Catalog;
-import com.linkedin.hoptimator.CatalogProvider;
-import com.linkedin.hoptimator.util.Api;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
+
+import com.linkedin.hoptimator.Catalog;
+import com.linkedin.hoptimator.CatalogProvider;
+import com.linkedin.hoptimator.util.Api;
+
 
 public final class CatalogService {
 
@@ -26,13 +27,13 @@ public final class CatalogService {
   }
 
   public static Collection<Catalog> catalogs() {
-    return providers().stream().flatMap(x -> x.catalogs().stream())
-        .collect(Collectors.toList());
+    return providers().stream().flatMap(x -> x.catalogs().stream()).collect(Collectors.toList());
   }
 
   /** Load a specific catalog */
   public static Catalog catalog(String name) {
-    return providers().stream().flatMap(x -> x.catalogs().stream())
+    return providers().stream()
+        .flatMap(x -> x.catalogs().stream())
         .filter(x -> name.equalsIgnoreCase(x.name()))
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException("Catalog " + name + " not found."));

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorBase.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorBase.java
@@ -1,14 +1,15 @@
 package com.linkedin.hoptimator.jdbc;
 
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+
 import com.linkedin.hoptimator.Validator;
 
-import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.schema.Table;
-import org.apache.calcite.schema.SchemaPlus;
 
 /** Base class for shared schema evolution validators.  */
 abstract class CompatibilityValidatorBase implements Validator<SchemaPlus> {
-  
+
   @Override
   public void validate(SchemaPlus schema, Issues issues) {
     try {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorProvider.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorProvider.java
@@ -1,13 +1,14 @@
 package com.linkedin.hoptimator.jdbc;
 
-import com.linkedin.hoptimator.Validator;
-import com.linkedin.hoptimator.ValidatorProvider;
-
-import org.apache.calcite.schema.SchemaPlus;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+
+import org.apache.calcite.schema.SchemaPlus;
+
+import com.linkedin.hoptimator.Validator;
+import com.linkedin.hoptimator.ValidatorProvider;
+
 
 /** Provides BackwardCompatibilityValidator and ForwardCompatibilityValidator. */
 public class CompatibilityValidatorProvider implements ValidatorProvider {
@@ -16,8 +17,7 @@ public class CompatibilityValidatorProvider implements ValidatorProvider {
   @Override
   public <T> Collection<Validator<T>> validators(Class<T> clazz) {
     if (SchemaPlus.class.isAssignableFrom(clazz)) {
-      return Arrays.asList(new Validator[]{
-          (Validator<T>) new BackwardCompatibilityValidator(),
+      return Arrays.asList(new Validator[]{(Validator<T>) new BackwardCompatibilityValidator(),
           (Validator<T>) new ForwardCompatibilityValidator()});
     } else {
       return Collections.emptyList();

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DefaultValidatorProvider.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DefaultValidatorProvider.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.jdbc;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import com.linkedin.hoptimator.Validator;
 import com.linkedin.hoptimator.ValidatorProvider;
 
-import java.util.Collection;
-import java.util.Collections;
 
 /** Provides DefaultValidator. */
 public class DefaultValidatorProvider implements ValidatorProvider {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ForwardCompatibilityValidator.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ForwardCompatibilityValidator.java
@@ -7,9 +7,10 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 
+
 /** Validates that tables follow forwards-compatible schema evolution rules.  */
 class ForwardCompatibilityValidator extends CompatibilityValidatorBase {
-  
+
   @Override
   protected void validate(Table table, Table originalTable, Issues issues) {
     RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
@@ -23,8 +24,8 @@ class ForwardCompatibilityValidator extends CompatibilityValidatorBase {
       if (newField != null && !SqlTypeUtil.canAssignFrom(newField.getType(), field.getType())) {
         String fromTypeName = newField.getType().getSqlTypeName().getName();
         String toTypeName = field.getType().getSqlTypeName().getName();
-        issues.child(field.getName()).error("Forwards-incompatible change: cannot assign to "
-            + toTypeName + " from " + fromTypeName);
+        issues.child(field.getName())
+            .error("Forwards-incompatible change: cannot assign to " + toTypeName + " from " + fromTypeName);
       }
     }
   }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
@@ -1,7 +1,9 @@
 package com.linkedin.hoptimator.jdbc;
 
-import com.linkedin.hoptimator.Catalog;
-import com.linkedin.hoptimator.util.WrappedSchemaPlus;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
 
 import org.apache.calcite.avatica.DriverVersion;
 import org.apache.calcite.jdbc.CalciteConnection;
@@ -13,10 +15,9 @@ import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParser;
 
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Properties;
+import com.linkedin.hoptimator.Catalog;
+import com.linkedin.hoptimator.util.WrappedSchemaPlus;
+
 
 /** Driver for :jdbc:hoptimator:// connections. */
 public class HoptimatorDriver extends Driver {
@@ -93,7 +94,7 @@ public class HoptimatorDriver extends Driver {
     @Override
     protected SqlParser.Config parserConfig() {
       return SqlParser.config().withParserFactory(HoptimatorDdlExecutor.PARSER_FACTORY);
-    }  
+    }
 
     @Override
     public void executeDdl(Context context, SqlNode node) {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/MaterializedViewTable.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/MaterializedViewTable.java
@@ -1,5 +1,9 @@
 package com.linkedin.hoptimator.jdbc;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -8,10 +12,7 @@ import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
-import org.apache.calcite.plan.RelOptTable;
 
-import java.util.Collections;
-import java.util.List;
 
 public class MaterializedViewTable extends AbstractTable implements TranslatableTable {
 

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ValidationService.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ValidationService.java
@@ -1,19 +1,20 @@
 package com.linkedin.hoptimator.jdbc;
 
-import com.linkedin.hoptimator.Validator;
-import com.linkedin.hoptimator.ValidatorProvider;
-
-import org.apache.calcite.jdbc.CalciteConnection;
-import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.schema.Table;
-
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
-import java.sql.SQLException;
+
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+
+import com.linkedin.hoptimator.Validator;
+import com.linkedin.hoptimator.ValidatorProvider;
+
 
 public final class ValidationService {
 
@@ -64,7 +65,6 @@ public final class ValidationService {
   }
 
   public static <T> Collection<Validator<? super T>> validators(Class<? super T> clazz) {
-    return providers().stream().flatMap(x -> x.validators(clazz).stream())
-        .collect(Collectors.toList());
+    return providers().stream().flatMap(x -> x.validators(clazz).stream()).collect(Collectors.toList());
   }
 }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/schema/CatalogTable.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/schema/CatalogTable.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.jdbc.schema;
 
+import org.apache.calcite.schema.Schema;
+
 import com.linkedin.hoptimator.Catalog;
 import com.linkedin.hoptimator.jdbc.CatalogService;
 import com.linkedin.hoptimator.util.RemoteTable;
 
-import org.apache.calcite.schema.Schema;
 
 /** A table populated with all available Catlaogs. */
 public class CatalogTable extends RemoteTable<Catalog, CatalogTable.Row> {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/schema/PrintTable.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/schema/PrintTable.java
@@ -1,14 +1,15 @@
 package com.linkedin.hoptimator.jdbc.schema;
 
-import com.linkedin.hoptimator.util.Api;
-import com.linkedin.hoptimator.util.RemoteTable;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import java.util.Collection;
-import java.util.Collections;
+import com.linkedin.hoptimator.util.Api;
+import com.linkedin.hoptimator.util.RemoteTable;
+
 
 /** A table prints whatever you INSERT into it. */
 public class PrintTable extends RemoteTable<String, Object> {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/schema/UtilityCatalog.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/schema/UtilityCatalog.java
@@ -1,15 +1,16 @@
 package com.linkedin.hoptimator.jdbc.schema;
 
-import com.linkedin.hoptimator.Catalog;
+import java.sql.SQLException;
+import java.sql.Wrapper;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
-import java.util.Map;
-import java.util.HashMap;
-import java.sql.Wrapper;
-import java.sql.SQLException;
+import com.linkedin.hoptimator.Catalog;
+
 
 /** Built-in utility tables. */
 public class UtilityCatalog extends AbstractSchema implements Catalog {

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/JdbcTestBase.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/JdbcTestBase.java
@@ -1,18 +1,17 @@
 package com.linkedin.hoptimator.jdbc;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.sql.SQLException;
 
 public abstract class JdbcTestBase {
 

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
@@ -1,7 +1,7 @@
 package com.linkedin.hoptimator.jdbc;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 
 public class TestBasicSql extends JdbcTestBase {
 

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestSqlScripts.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestSqlScripts.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.jdbc;
 
 import org.junit.jupiter.api.Test;
 
+
 public class TestSqlScripts extends QuidemTestBase {
 
   @Test

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
@@ -1,6 +1,8 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.Api;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Collections;
 
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
@@ -8,9 +10,8 @@ import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.options.ListOptions;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.sql.SQLException;
+import com.linkedin.hoptimator.util.Api;
+
 
 public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> implements Api<T> {
 
@@ -34,16 +35,16 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
   public T get(String name) throws SQLException {
     final KubernetesApiResponse<T> resp;
     if (endpoint.clusterScoped()) {
-      resp = context.<T, U>generic(endpoint).get(name); 
+      resp = context.<T, U>generic(endpoint).get(name);
     } else {
-      resp = context.<T, U>generic(endpoint).get(context.namespace(), name); 
+      resp = context.<T, U>generic(endpoint).get(context.namespace(), name);
     }
     checkResponse(resp);
     return resp.getObject();
   }
 
   public T get(String namespace, String name) throws SQLException {
-    KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).get(namespace, name); 
+    KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).get(namespace, name);
     checkResponse(resp);
     return resp.getObject();
   }
@@ -80,8 +81,8 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     if (obj.getMetadata().getNamespace() == null && !endpoint.clusterScoped()) {
       obj.getMetadata().namespace(context.namespace());
     }
-    KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).delete(
-        obj.getMetadata().getNamespace(), obj.getMetadata().getName());
+    KubernetesApiResponse<T> resp =
+        context.<T, U>generic(endpoint).delete(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
     checkResponse(resp);
   }
 
@@ -94,8 +95,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     if (endpoint.clusterScoped()) {
       existing = context.<T, U>generic(endpoint).get(obj.getMetadata().getName());
     } else {
-      existing = context.<T, U>generic(endpoint).get(obj.getMetadata().getNamespace(),
-          obj.getMetadata().getName());
+      existing = context.<T, U>generic(endpoint).get(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
     }
     final KubernetesApiResponse<T> resp;
     if (existing.isSuccess()) {
@@ -111,11 +111,9 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     if (!endpoint.clusterScoped()) {
       obj.getMetadata().namespace(context.namespace());
     }
-    KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).updateStatus(obj,
-        x -> status);
+    KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).updateStatus(obj, x -> status);
     checkResponse(resp);
   }
-
 
   private void checkResponse(KubernetesApiResponse<?> resp) throws SQLException {
     if (!resp.isSuccess()) {

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApiEndpoint.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApiEndpoint.java
@@ -1,7 +1,8 @@
 package com.linkedin.hoptimator.k8s;
 
-import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+
 
 public class K8sApiEndpoint<T extends KubernetesObject, U extends KubernetesListObject> {
 
@@ -14,8 +15,8 @@ public class K8sApiEndpoint<T extends KubernetesObject, U extends KubernetesList
   private final Class<U> u;
   private final String apiVersion;
 
-  public K8sApiEndpoint(String kind, String group, String version, String plural,
-      boolean clusterScoped, Class<T> t, Class<U> u) {
+  public K8sApiEndpoint(String kind, String group, String version, String plural, boolean clusterScoped, Class<T> t,
+      Class<U> u) {
     this.kind = kind;
     this.group = group;
     this.version = version;

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApiEndpoints.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApiEndpoints.java
@@ -1,45 +1,46 @@
 package com.linkedin.hoptimator.k8s;
 
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1NamespaceList;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1SecretList;
+
 import com.linkedin.hoptimator.k8s.models.V1alpha1Database;
 import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseList;
 import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplate;
 import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplateList;
 import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
 import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineList;
-import com.linkedin.hoptimator.k8s.models.V1alpha1View;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
 import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplate;
 import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplateList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1View;
+import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
 
-import io.kubernetes.client.openapi.models.V1Namespace;
-import io.kubernetes.client.openapi.models.V1NamespaceList;
-import io.kubernetes.client.openapi.models.V1Secret;
-import io.kubernetes.client.openapi.models.V1SecretList;
 
 public final class K8sApiEndpoints {
 
   // Native K8s endpoints
-  public static final K8sApiEndpoint<V1Namespace, V1NamespaceList> NAMESPACES = new K8sApiEndpoint<>(
-      "Namespace", "", "v1", "namespaces", true, V1Namespace.class, V1NamespaceList.class);
-  public static final K8sApiEndpoint<V1Secret, V1SecretList> SECRETS = new K8sApiEndpoint<>(
-      "Secret", "", "v1", "secrets", false, V1Secret.class, V1SecretList.class);
+  public static final K8sApiEndpoint<V1Namespace, V1NamespaceList> NAMESPACES =
+      new K8sApiEndpoint<>("Namespace", "", "v1", "namespaces", true, V1Namespace.class, V1NamespaceList.class);
+  public static final K8sApiEndpoint<V1Secret, V1SecretList> SECRETS =
+      new K8sApiEndpoint<>("Secret", "", "v1", "secrets", false, V1Secret.class, V1SecretList.class);
 
   // Hoptimator custom resources
   public static final K8sApiEndpoint<V1alpha1Database, V1alpha1DatabaseList> DATABASES =
       new K8sApiEndpoint<>("Database", "hoptimator.linkedin.com", "v1alpha1", "databases", false,
-      V1alpha1Database.class, V1alpha1DatabaseList.class);
+          V1alpha1Database.class, V1alpha1DatabaseList.class);
   public static final K8sApiEndpoint<V1alpha1Pipeline, V1alpha1PipelineList> PIPELINES =
       new K8sApiEndpoint<>("Pipeline", "hoptimator.linkedin.com", "v1alpha1", "pipelines", false,
-      V1alpha1Pipeline.class, V1alpha1PipelineList.class);
+          V1alpha1Pipeline.class, V1alpha1PipelineList.class);
   public static final K8sApiEndpoint<V1alpha1View, V1alpha1ViewList> VIEWS =
-      new K8sApiEndpoint<>("View", "hoptimator.linkedin.com", "v1alpha1", "views", false,
-      V1alpha1View.class, V1alpha1ViewList.class);
+      new K8sApiEndpoint<>("View", "hoptimator.linkedin.com", "v1alpha1", "views", false, V1alpha1View.class,
+          V1alpha1ViewList.class);
   public static final K8sApiEndpoint<V1alpha1TableTemplate, V1alpha1TableTemplateList> TABLE_TEMPLATES =
       new K8sApiEndpoint<>("TableTemplate", "hoptimator.linkedin.com", "v1alpha1", "tabletemplates", false,
-      V1alpha1TableTemplate.class, V1alpha1TableTemplateList.class);
+          V1alpha1TableTemplate.class, V1alpha1TableTemplateList.class);
   public static final K8sApiEndpoint<V1alpha1JobTemplate, V1alpha1JobTemplateList> JOB_TEMPLATES =
       new K8sApiEndpoint<>("JobTemplate", "hoptimator.linkedin.com", "v1alpha1", "jobtemplates", false,
-      V1alpha1JobTemplate.class, V1alpha1JobTemplateList.class);
+          V1alpha1JobTemplate.class, V1alpha1JobTemplateList.class);
 
   private K8sApiEndpoints() {
   }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sCatalog.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sCatalog.java
@@ -1,14 +1,14 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.Catalog;
+import java.sql.SQLException;
+import java.sql.Wrapper;
 
 import org.apache.calcite.schema.SchemaPlus;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.SQLException;
-import java.sql.Wrapper;
+import com.linkedin.hoptimator.Catalog;
+
 
 /** The k8s catalog. */
 class K8sCatalog implements Catalog {

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sCatalogProvider.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sCatalogProvider.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.k8s;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import com.linkedin.hoptimator.Catalog;
 import com.linkedin.hoptimator.CatalogProvider;
 
-import java.util.Collection;
-import java.util.Collections;
 
 /** Provides the `k8s` catalog and related metadata tables. */
 public class K8sCatalogProvider implements CatalogProvider {

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
@@ -1,21 +1,20 @@
 package com.linkedin.hoptimator.k8s;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
 import com.linkedin.hoptimator.Connector;
-import com.linkedin.hoptimator.util.Source;
-import com.linkedin.hoptimator.util.Template;
 import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplate;
 import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplateList;
-import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplateSpec;
+import com.linkedin.hoptimator.util.Source;
+import com.linkedin.hoptimator.util.Template;
 
-import java.io.StringReader;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.sql.SQLException;
-import java.util.Locale;
-import java.util.Properties;
 
 /** Configures an abstract Source/Sink by applying TableTemplates */
 class K8sConnector implements Connector<Source> {
@@ -28,18 +27,20 @@ class K8sConnector implements Connector<Source> {
 
   @Override
   public Map<String, String> configure(Source source) throws SQLException {
-    Template.Environment env = Template.Environment.EMPTY
-        .with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
-        .with("database", source.database())
-        .with("table", source.table())
-        .with(source.options());
-    String configs = tableTemplateApi.list().stream()
+    Template.Environment env =
+        Template.Environment.EMPTY.with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
+            .with("database", source.database())
+            .with("table", source.table())
+            .with(source.options());
+    String configs = tableTemplateApi.list()
+        .stream()
         .map(x -> x.getSpec())
         .filter(x -> x.getDatabases() == null || x.getDatabases().contains(source.database()))
         .filter(x -> x.getMethods() == null || x.getMethods().contains(K8sUtils.method(source)))
         .filter(x -> x.getConnector() != null)
         .map(x -> x.getConnector())
-        .map(x -> new Template.SimpleTemplate(x).render(env)).collect(Collectors.joining("\n"));
+        .map(x -> new Template.SimpleTemplate(x).render(env))
+        .collect(Collectors.joining("\n"));
     Properties props = new Properties();
     try {
       props.load(new StringReader(configs));

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnectorProvider.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnectorProvider.java
@@ -1,14 +1,13 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.Source;
-import com.linkedin.hoptimator.util.Sink;
-import com.linkedin.hoptimator.Connector;
-import com.linkedin.hoptimator.ConnectorProvider;
-import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplateSpec;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import com.linkedin.hoptimator.Connector;
+import com.linkedin.hoptimator.ConnectorProvider;
+import com.linkedin.hoptimator.util.Source;
+
 
 public class K8sConnectorProvider implements ConnectorProvider {
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sContext.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sContext.java
@@ -1,22 +1,23 @@
 package com.linkedin.hoptimator.k8s;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Optional;
+
 import io.kubernetes.client.apimachinery.GroupVersion;
-import io.kubernetes.client.informer.SharedInformerFactory;
-import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
-import io.kubernetes.client.openapi.ApiClient;
 
-import java.io.IOException;
-import java.io.File;
-import java.io.Reader;
-import java.util.Optional;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.time.Duration;
 
 public class K8sContext {
 
@@ -68,13 +69,15 @@ public class K8sContext {
     return dynamic(endpoint.group(), endpoint.version(), endpoint.plural());
   }
 
-  public <T extends KubernetesObject, U extends KubernetesListObject> GenericKubernetesApi<T, U> generic(Class<T> t, Class<U> u,
-      String group, String version, String plural) {
+  public <T extends KubernetesObject, U extends KubernetesListObject> GenericKubernetesApi<T, U> generic(Class<T> t,
+      Class<U> u, String group, String version, String plural) {
     return new GenericKubernetesApi<T, U>(t, u, group, version, plural, apiClient);
   }
 
-  public <T extends KubernetesObject, U extends KubernetesListObject> GenericKubernetesApi<T, U> generic(K8sApiEndpoint<T, U> endpoint) {
-    return generic(endpoint.elementType(), endpoint.listType(), endpoint.group(), endpoint.version(), endpoint.plural());
+  public <T extends KubernetesObject, U extends KubernetesListObject> GenericKubernetesApi<T, U> generic(
+      K8sApiEndpoint<T, U> endpoint) {
+    return generic(endpoint.elementType(), endpoint.listType(), endpoint.group(), endpoint.version(),
+        endpoint.plural());
   }
 
   @Override

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDatabaseTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDatabaseTable.java
@@ -1,9 +1,8 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.k8s.models.V1alpha1Database;
-import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseList;
-import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseSpec;
-import com.linkedin.hoptimator.util.HoptimatorJdbcSchema;
+import java.util.Locale;
+import java.util.Optional;
+import javax.sql.DataSource;
 
 import org.apache.calcite.adapter.jdbc.JdbcSchema;
 import org.apache.calcite.schema.Schema;
@@ -15,12 +14,13 @@ import org.apache.calcite.sql.dialect.MysqlSqlDialect;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
-import java.util.Locale;
-import java.util.Optional;
-import javax.sql.DataSource;
+import com.linkedin.hoptimator.k8s.models.V1alpha1Database;
+import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseSpec;
+import com.linkedin.hoptimator.util.HoptimatorJdbcSchema;
 
-public class K8sDatabaseTable extends
-    K8sTable<V1alpha1Database, V1alpha1DatabaseList, K8sDatabaseTable.Row> {
+
+public class K8sDatabaseTable extends K8sTable<V1alpha1Database, V1alpha1DatabaseList, K8sDatabaseTable.Row> {
 
   // CHECKSTYLE:OFF
   public static class Row {
@@ -46,8 +46,8 @@ public class K8sDatabaseTable extends
 
   public void addDatabases(SchemaPlus parentSchema) {
     for (Row row : rows()) {
-      parentSchema.add(schemaName(row), HoptimatorJdbcSchema.create(row.NAME, null,
-          row.SCHEMA, dataSource(row), parentSchema, dialect(row)));
+      parentSchema.add(schemaName(row),
+          HoptimatorJdbcSchema.create(row.NAME, null, row.SCHEMA, dataSource(row), parentSchema, dialect(row)));
     }
   }
 
@@ -64,8 +64,10 @@ public class K8sDatabaseTable extends
     return new V1alpha1Database().kind(K8sApiEndpoints.DATABASES.kind())
         .apiVersion(K8sApiEndpoints.DATABASES.apiVersion())
         .metadata(new V1ObjectMeta().name(row.NAME))
-        .spec(new V1alpha1DatabaseSpec().url(row.URL).schema(row.SCHEMA).driver(row.DRIVER)
-        .dialect(V1alpha1DatabaseSpec.DialectEnum.fromValue(row.DIALECT)));
+        .spec(new V1alpha1DatabaseSpec().url(row.URL)
+            .schema(row.SCHEMA)
+            .driver(row.DRIVER)
+            .dialect(V1alpha1DatabaseSpec.DialectEnum.fromValue(row.DIALECT)));
   }
 
   private static String schemaName(Row row) {
@@ -86,12 +88,12 @@ public class K8sDatabaseTable extends
       return null;
     }
     switch (row.DIALECT) {
-    case "ANSI":
-      return AnsiSqlDialect.DEFAULT;
-    case "MySQL":
-      return MysqlSqlDialect.DEFAULT; 
-    default:
-      return CalciteSqlDialect.DEFAULT;
+      case "ANSI":
+        return AnsiSqlDialect.DEFAULT;
+      case "MySQL":
+        return MysqlSqlDialect.DEFAULT;
+      default:
+        return CalciteSqlDialect.DEFAULT;
     }
   }
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployer.java
@@ -1,16 +1,18 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.Deployer;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
 
-import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.util.Yaml;
 
-import java.util.List;
-import java.util.Collections;
-import java.sql.SQLException;
+import com.linkedin.hoptimator.Deployer;
 
-public abstract class K8sDeployer<T, U extends KubernetesObject, V extends KubernetesListObject> implements Deployer<T> {
+
+public abstract class K8sDeployer<T, U extends KubernetesObject, V extends KubernetesListObject>
+    implements Deployer<T> {
 
   private K8sApi<U, V> api;
 
@@ -38,5 +40,5 @@ public abstract class K8sDeployer<T, U extends KubernetesObject, V extends Kuber
     return Collections.singletonList(Yaml.dump(toK8sObject(t)));
   }
 
-  protected abstract U toK8sObject(T t) throws SQLException; 
+  protected abstract U toK8sObject(T t) throws SQLException;
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployerProvider.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployerProvider.java
@@ -1,18 +1,17 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.Sink;
-import com.linkedin.hoptimator.util.Source;
-import com.linkedin.hoptimator.util.Job;
-
-import com.linkedin.hoptimator.Deployer;
-import com.linkedin.hoptimator.DeployerProvider;
-import com.linkedin.hoptimator.util.MaterializedView;
-
-import org.apache.calcite.schema.impl.ViewTable;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import org.apache.calcite.schema.impl.ViewTable;
+
+import com.linkedin.hoptimator.Deployer;
+import com.linkedin.hoptimator.DeployerProvider;
+import com.linkedin.hoptimator.util.Job;
+import com.linkedin.hoptimator.util.MaterializedView;
+import com.linkedin.hoptimator.util.Source;
+
 
 public class K8sDeployerProvider implements DeployerProvider {
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -1,22 +1,21 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.Job;
-import com.linkedin.hoptimator.util.Template;
-import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplate;
-import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplateList;
-
-import org.apache.calcite.sql.SqlDialect;
-import org.apache.calcite.sql.dialect.AnsiSqlDialect;
-import org.apache.calcite.sql.dialect.MysqlSqlDialect;
-import org.apache.calcite.sql.dialect.CalciteSqlDialect;
-
-import java.util.Collection;
-import java.util.Collections;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.sql.SQLException;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.dialect.MysqlSqlDialect;
+
+import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplate;
+import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplateList;
+import com.linkedin.hoptimator.util.Job;
+import com.linkedin.hoptimator.util.Template;
+
 
 /** Specifies an abstract Job with concrete YAML by applying JobTemplates. */
 class K8sJobDeployer extends K8sYamlDeployer<Job> {
@@ -31,8 +30,8 @@ class K8sJobDeployer extends K8sYamlDeployer<Job> {
   @Override
   public List<String> specify(Job job) throws SQLException {
     Function<SqlDialect, String> sql = job.sql();
-    Template.Environment env = Template.Environment.EMPTY
-        .with("name", job.sink().database() + "-" + job.sink().table().toLowerCase(Locale.ROOT))
+    Template.Environment env = Template.Environment.EMPTY.with("name",
+            job.sink().database() + "-" + job.sink().table().toLowerCase(Locale.ROOT))
         .with("database", job.sink().database())
         .with("schema", job.sink().schema())
         .with("table", job.sink().table())
@@ -40,7 +39,8 @@ class K8sJobDeployer extends K8sYamlDeployer<Job> {
         .with("ansisql", sql.apply(AnsiSqlDialect.DEFAULT))
         .with("calcitesql", sql.apply(CalciteSqlDialect.DEFAULT))
         .with(job.sink().options());
-    return jobTemplateApi.list().stream()
+    return jobTemplateApi.list()
+        .stream()
         .map(x -> x.getSpec())
         .filter(x -> x.getDatabases() == null || x.getDatabases().contains(job.sink().database()))
         .filter(x -> x.getYaml() != null)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
@@ -1,14 +1,14 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.MaterializedView;
-
-import com.linkedin.hoptimator.k8s.models.V1alpha1View;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
+import java.util.LinkedList;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
-import java.util.LinkedList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1View;
+import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
+import com.linkedin.hoptimator.util.MaterializedView;
+
 
 class K8sMaterializedViewDeployer extends K8sDeployer<MaterializedView, V1alpha1View, V1alpha1ViewList> {
 
@@ -23,8 +23,6 @@ class K8sMaterializedViewDeployer extends K8sDeployer<MaterializedView, V1alpha1
     return new V1alpha1View().kind(K8sApiEndpoints.VIEWS.kind())
         .apiVersion(K8sApiEndpoints.VIEWS.apiVersion())
         .metadata(new V1ObjectMeta().name(name))
-        .spec(new V1alpha1ViewSpec()
-            .view(q.pollLast()).schema(q.pollLast())
-            .sql(view.viewSql()).materialized(true));
+        .spec(new V1alpha1ViewSpec().view(q.pollLast()).schema(q.pollLast()).sql(view.viewSql()).materialized(true));
   }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMetadata.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMetadata.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.k8s;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 
-import java.util.HashMap;
-import java.util.Map;
 
 /** Built-in K8s metadata tables */
 public class K8sMetadata extends AbstractSchema {
@@ -12,7 +13,7 @@ public class K8sMetadata extends AbstractSchema {
   private final Map<String, Table> tableMap = new HashMap<>();
   private final K8sDatabaseTable databaseTable;
   private final K8sViewTable viewTable;
- 
+
   public K8sMetadata(K8sContext context) {
     this.databaseTable = new K8sDatabaseTable(context);
     this.viewTable = new K8sViewTable(context);

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineDeployer.java
@@ -1,22 +1,17 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.jdbc.HoptimatorDriver;
-import com.linkedin.hoptimator.util.DeploymentService;
-import com.linkedin.hoptimator.util.MaterializedView;
-import com.linkedin.hoptimator.util.Sink;
-import com.linkedin.hoptimator.util.planner.PipelineRel;
+import java.sql.SQLException;
+import java.util.stream.Collectors;
 
-import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
-import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineSpec;
-import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineList;
-
-import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
-import java.util.stream.Collectors;
-import java.sql.SQLException;
+import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
+import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineSpec;
+import com.linkedin.hoptimator.util.MaterializedView;
+
 
 /** Deploys the Pipeline behind a MaterializedView. */
 class K8sPipelineDeployer extends K8sDeployer<MaterializedView, V1alpha1Pipeline, V1alpha1PipelineList> {
@@ -28,8 +23,7 @@ class K8sPipelineDeployer extends K8sDeployer<MaterializedView, V1alpha1Pipeline
   @Override
   protected V1alpha1Pipeline toK8sObject(MaterializedView view) throws SQLException {
     String name = K8sUtils.canonicalizeName(view.path());
-    String yaml = view.pipeline().specify().stream()
-        .collect(Collectors.joining("\n---\n"));
+    String yaml = view.pipeline().specify().stream().collect(Collectors.joining("\n---\n"));
     String sql = view.pipelineSql().apply(AnsiSqlDialect.DEFAULT);
     return new V1alpha1Pipeline().kind(K8sApiEndpoints.PIPELINES.kind())
         .apiVersion(K8sApiEndpoints.PIPELINES.apiVersion())

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSourceDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSourceDeployer.java
@@ -1,16 +1,15 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.Source;
-import com.linkedin.hoptimator.util.Template;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
 import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplate;
 import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplateList;
+import com.linkedin.hoptimator.util.Source;
+import com.linkedin.hoptimator.util.Template;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.sql.SQLException;
-import java.util.Locale;
 
 /** Specifies an abstract Source with concrete YAML by applying TableTemplates. */
 class K8sSourceDeployer extends K8sYamlDeployer<Source> {
@@ -24,13 +23,14 @@ class K8sSourceDeployer extends K8sYamlDeployer<Source> {
 
   @Override
   public List<String> specify(Source source) throws SQLException {
-    Template.Environment env = Template.Environment.EMPTY
-        .with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
-        .with("database", source.database())
-        .with("schema", source.schema())
-        .with("table", source.table())
-        .with(source.options());
-    return tableTemplateApi.list().stream()
+    Template.Environment env =
+        Template.Environment.EMPTY.with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
+            .with("database", source.database())
+            .with("schema", source.schema())
+            .with("table", source.table())
+            .with(source.options());
+    return tableTemplateApi.list()
+        .stream()
         .map(x -> x.getSpec())
         .filter(x -> x.getDatabases() == null || x.getDatabases().contains(source.database()))
         .filter(x -> x.getMethods() == null || x.getMethods().contains(K8sUtils.method(source)))

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTable.java
@@ -1,9 +1,10 @@
 package com.linkedin.hoptimator.k8s;
 
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+
 import com.linkedin.hoptimator.util.RemoteTable;
 
-import io.kubernetes.client.common.KubernetesObject;
-import io.kubernetes.client.common.KubernetesListObject;
 
 public abstract class K8sTable<T extends KubernetesObject, U extends KubernetesListObject, V>
     extends RemoteTable<T, V> {

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
@@ -1,15 +1,15 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.Source;
-import com.linkedin.hoptimator.util.Sink;
-import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplateSpec.MethodsEnum;
-
-import io.kubernetes.client.common.KubernetesType;
-import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
-
 import java.util.Collection;
 import java.util.Locale;
 import java.util.stream.Collectors;
+
+import io.kubernetes.client.common.KubernetesType;
+
+import com.linkedin.hoptimator.k8s.models.V1alpha1TableTemplateSpec.MethodsEnum;
+import com.linkedin.hoptimator.util.Sink;
+import com.linkedin.hoptimator.util.Source;
+
 
 public final class K8sUtils {
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sViewDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sViewDeployer.java
@@ -1,14 +1,15 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.k8s.models.V1alpha1View;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
+import java.util.LinkedList;
 
 import org.apache.calcite.schema.impl.ViewTable;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
-import java.util.LinkedList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1View;
+import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
+
 
 class K8sViewDeployer extends K8sDeployer<ViewTable, V1alpha1View, V1alpha1ViewList> {
 
@@ -23,8 +24,7 @@ class K8sViewDeployer extends K8sDeployer<ViewTable, V1alpha1View, V1alpha1ViewL
     return new V1alpha1View().kind(K8sApiEndpoints.VIEWS.kind())
         .apiVersion(K8sApiEndpoints.VIEWS.apiVersion())
         .metadata(new V1ObjectMeta().name(name))
-        .spec(new V1alpha1ViewSpec()
-            .view(q.pollLast()).schema(q.pollLast())
-            .sql(view.getViewSql()).materialized(false));
+        .spec(
+            new V1alpha1ViewSpec().view(q.pollLast()).schema(q.pollLast()).sql(view.getViewSql()).materialized(false));
   }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sViewTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sViewTable.java
@@ -1,27 +1,28 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.Validated;
-import com.linkedin.hoptimator.Validator;
-import com.linkedin.hoptimator.k8s.models.V1alpha1View;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
-import com.linkedin.hoptimator.jdbc.MaterializedViewTable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
-import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import com.linkedin.hoptimator.Validated;
+import com.linkedin.hoptimator.Validator;
+import com.linkedin.hoptimator.jdbc.MaterializedViewTable;
+import com.linkedin.hoptimator.k8s.models.V1alpha1View;
+import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
+
 
 public class K8sViewTable extends K8sTable<V1alpha1View, V1alpha1ViewList, K8sViewTable.Row> implements Validated {
-  
+
   // CHECKSTYLE:OFF
   public static class Row {
     public String NAME;
@@ -60,7 +61,7 @@ public class K8sViewTable extends K8sTable<V1alpha1View, V1alpha1ViewList, K8sVi
         return VIEW;
       } else {
         return NAME;
-      } 
+      }
     }
 
     @Override
@@ -96,8 +97,10 @@ public class K8sViewTable extends K8sTable<V1alpha1View, V1alpha1ViewList, K8sVi
   }
 
   public Row find(String name) {
-    return rows().stream().filter(x -> x.NAME.equals(name)).findFirst()
-      .orElseThrow(() -> new IllegalArgumentException("Table " + name + " not found."));
+    return rows().stream()
+        .filter(x -> x.NAME.equals(name))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Table " + name + " not found."));
   }
 
   public void remove(String name) {
@@ -105,8 +108,7 @@ public class K8sViewTable extends K8sTable<V1alpha1View, V1alpha1ViewList, K8sVi
   }
 
   private Table makeView(SchemaPlus parentSchema, Row row) {
-    ViewTableMacro viewTableMacro = ViewTable.viewMacro(parentSchema, row.SQL,
-        row.schemaPath(), row.viewPath(), false);
+    ViewTableMacro viewTableMacro = ViewTable.viewMacro(parentSchema, row.SQL, row.schemaPath(), row.viewPath(), false);
     if (row.MATERIALIZED) {
       return new MaterializedViewTable(viewTableMacro);
     } else {

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
@@ -1,14 +1,15 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.Api;
+import java.sql.SQLException;
+import java.util.Collection;
 
+import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 import io.kubernetes.client.util.generic.dynamic.Dynamics;
-import io.kubernetes.client.openapi.ApiException;
 
-import java.util.Collection;
-import java.sql.SQLException;
+import com.linkedin.hoptimator.util.Api;
+
 
 public class K8sYamlApi implements Api<String> {
 
@@ -26,38 +27,36 @@ public class K8sYamlApi implements Api<String> {
   @Override
   public void create(String yaml) throws SQLException {
     DynamicKubernetesObject obj = objFromYaml(yaml);
-    KubernetesApiResponse<DynamicKubernetesObject> resp = context.dynamic(obj.getApiVersion(),
-        K8sUtils.guessPlural(obj)).create(obj);
+    KubernetesApiResponse<DynamicKubernetesObject> resp =
+        context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj);
     checkResponse(yaml, resp);
   }
 
   @Override
   public void delete(String yaml) throws SQLException {
     DynamicKubernetesObject obj = objFromYaml(yaml);
-    KubernetesApiResponse<DynamicKubernetesObject> resp = context.dynamic(obj.getApiVersion(),
-        K8sUtils.guessPlural(obj)).delete(obj.getMetadata().getNamespace(),
-        obj.getMetadata().getName());
+    KubernetesApiResponse<DynamicKubernetesObject> resp =
+        context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj))
+            .delete(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
     checkResponse(yaml, resp);
   }
 
   @Override
   public void update(String yaml) throws SQLException {
     DynamicKubernetesObject obj = objFromYaml(yaml);
-    KubernetesApiResponse<DynamicKubernetesObject> existing = context.dynamic(obj.getApiVersion(),
-        K8sUtils.guessPlural(obj)).get(obj.getMetadata().getNamespace(),
-        obj.getMetadata().getName());
+    KubernetesApiResponse<DynamicKubernetesObject> existing =
+        context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj))
+            .get(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
     final KubernetesApiResponse<DynamicKubernetesObject> resp;
     if (existing.isSuccess()) {
       obj.setMetadata(existing.getObject().getMetadata());
-      resp = context.dynamic(obj.getApiVersion(),
-          K8sUtils.guessPlural(obj)).update(obj);
+      resp = context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).update(obj);
     } else {
-      resp = context.dynamic(obj.getApiVersion(),
-          K8sUtils.guessPlural(obj)).create(obj);
+      resp = context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj);
     }
     checkResponse(yaml, resp);
   }
- 
+
   private DynamicKubernetesObject objFromYaml(String yaml) {
     DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
     if (obj.getMetadata().getNamespace() == null) {
@@ -65,7 +64,7 @@ public class K8sYamlApi implements Api<String> {
     }
     return obj;
   }
- 
+
   private void checkResponse(String yaml, KubernetesApiResponse<?> resp) throws SQLException {
     try {
       resp.throwsApiException();

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployer.java
@@ -1,8 +1,9 @@
 package com.linkedin.hoptimator.k8s;
 
+import java.sql.SQLException;
+
 import com.linkedin.hoptimator.Deployer;
 
-import java.sql.SQLException;
 
 public abstract class K8sYamlDeployer<T> implements Deployer<T> {
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/NamespaceTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/NamespaceTable.java
@@ -1,9 +1,10 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.RemoteTable;
-
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1NamespaceList;
+
+import com.linkedin.hoptimator.util.RemoteTable;
+
 
 public class NamespaceTable extends RemoteTable<V1Namespace, NamespaceTable.Row> {
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/SecretTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/SecretTable.java
@@ -1,9 +1,10 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.util.RemoteTable;
-
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
+
+import com.linkedin.hoptimator.util.RemoteTable;
+
 
 public class SecretTable extends RemoteTable<V1Secret, SecretTable.Row> {
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Database.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Database.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Database metadata.
  */
 @ApiModel(description = "Database metadata.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1Database implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * DatabaseList is a list of Database
  */
 @ApiModel(description = "DatabaseList is a list of Database")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1DatabaseList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Database spec.
  */
 @ApiModel(description = "Database spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1DatabaseSpec {
   /**
    * SQL dialect the driver expects.

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplate.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplate.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Template to apply to matching jobs.
  */
 @ApiModel(description = "Template to apply to matching jobs.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1JobTemplate implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * JobTemplateList is a list of JobTemplate
  */
 @ApiModel(description = "JobTemplateList is a list of JobTemplate")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1JobTemplateList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * TableTemplate spec.
  */
 @ApiModel(description = "TableTemplate spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1JobTemplateSpec {
   public static final String SERIALIZED_NAME_DATABASES = "databases";
   @SerializedName(SERIALIZED_NAME_DATABASES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Pipeline.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Pipeline.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * A set of objects that work together to deliver data.
  */
 @ApiModel(description = "A set of objects that work together to deliver data.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1Pipeline implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * PipelineList is a list of Pipeline
  */
 @ApiModel(description = "PipelineList is a list of Pipeline")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1PipelineList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Pipeline spec.
  */
 @ApiModel(description = "Pipeline spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1PipelineSpec {
   public static final String SERIALIZED_NAME_SQL = "sql";
   @SerializedName(SERIALIZED_NAME_SQL)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Pipeline status.
  */
 @ApiModel(description = "Pipeline status.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1PipelineStatus {
   public static final String SERIALIZED_NAME_FAILED = "failed";
   @SerializedName(SERIALIZED_NAME_FAILED)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Subscription.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Subscription.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator Subscription
  */
 @ApiModel(description = "Hoptimator Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1Subscription implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SubscriptionList is a list of Subscription
  */
 @ApiModel(description = "SubscriptionList is a list of Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1SubscriptionList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionSpec.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Subscription spec
  */
 @ApiModel(description = "Subscription spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1SubscriptionSpec {
   public static final String SERIALIZED_NAME_DATABASE = "database";
   @SerializedName(SERIALIZED_NAME_DATABASE)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionStatus.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1SubscriptionStatus {
   public static final String SERIALIZED_NAME_ATTRIBUTES = "attributes";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplate.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplate.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Template to apply to matching tables.
  */
 @ApiModel(description = "Template to apply to matching tables.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1TableTemplate implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * TableTemplateList is a list of TableTemplate
  */
 @ApiModel(description = "TableTemplateList is a list of TableTemplate")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1TableTemplateList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * TableTemplate spec.
  */
 @ApiModel(description = "TableTemplate spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1TableTemplateSpec {
   public static final String SERIALIZED_NAME_CONNECTOR = "connector";
   @SerializedName(SERIALIZED_NAME_CONNECTOR)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1View.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1View.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * A SQL view.
  */
 @ApiModel(description = "A SQL view.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1View implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * ViewList is a list of View
  */
 @ApiModel(description = "ViewList is a list of View")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1ViewList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * View spec.
  */
 @ApiModel(description = "View spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-04T03:00:43.571Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:52:51.758Z[Etc/UTC]")
 public class V1alpha1ViewSpec {
   public static final String SERIALIZED_NAME_MATERIALIZED = "materialized";
   @SerializedName(SERIALIZED_NAME_MATERIALIZED)

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/TestSqlScripts.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/TestSqlScripts.java
@@ -1,9 +1,10 @@
 package com.linkedin.hoptimator.k8s;
 
-import com.linkedin.hoptimator.jdbc.QuidemTestBase;
-
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import com.linkedin.hoptimator.jdbc.QuidemTestBase;
+
 
 public class TestSqlScripts extends QuidemTestBase {
 

--- a/hoptimator-kafka-controller/src/main/java/com/linkedin/hoptimator/operator/kafka/KafkaControllerProvider.java
+++ b/hoptimator-kafka-controller/src/main/java/com/linkedin/hoptimator/operator/kafka/KafkaControllerProvider.java
@@ -1,46 +1,47 @@
 package com.linkedin.hoptimator.operator.kafka;
 
-import com.linkedin.hoptimator.operator.ControllerProvider;
-import com.linkedin.hoptimator.operator.Operator;
-import com.linkedin.hoptimator.models.V1alpha1Acl;
-import com.linkedin.hoptimator.models.V1alpha1AclList;
-import com.linkedin.hoptimator.models.V1alpha1KafkaTopic;
-import com.linkedin.hoptimator.models.V1alpha1KafkaTopicList;
+import java.util.Arrays;
+import java.util.Collection;
 
 import io.kubernetes.client.extended.controller.Controller;
 import io.kubernetes.client.extended.controller.builder.ControllerBuilder;
 import io.kubernetes.client.extended.controller.reconciler.Reconciler;
 
-import java.util.Arrays;
-import java.util.Collection;
+import com.linkedin.hoptimator.models.V1alpha1Acl;
+import com.linkedin.hoptimator.models.V1alpha1AclList;
+import com.linkedin.hoptimator.models.V1alpha1KafkaTopic;
+import com.linkedin.hoptimator.models.V1alpha1KafkaTopicList;
+import com.linkedin.hoptimator.operator.ControllerProvider;
+import com.linkedin.hoptimator.operator.Operator;
+
 
 /** Provides a Controller plugin for KafkaTopics. */
 public class KafkaControllerProvider implements ControllerProvider {
 
   @Override
   public Collection<Controller> controllers(Operator operator) {
-    operator.registerApi("KafkaTopic", "kafkatopic", "kafkatopics", "hoptimator.linkedin.com",
-      "v1alpha1", V1alpha1KafkaTopic.class, V1alpha1KafkaTopicList.class);
+    operator.registerApi("KafkaTopic", "kafkatopic", "kafkatopics", "hoptimator.linkedin.com", "v1alpha1",
+        V1alpha1KafkaTopic.class, V1alpha1KafkaTopicList.class);
 
     // N.B. this shared CRD may be re-registered by other ControllerProviders
-    operator.registerApi("Acl", "acl", "acls", "hoptimator.linkedin.com",
-      "v1alpha1", V1alpha1Acl.class, V1alpha1AclList.class);
+    operator.registerApi("Acl", "acl", "acls", "hoptimator.linkedin.com", "v1alpha1", V1alpha1Acl.class,
+        V1alpha1AclList.class);
 
     Reconciler topicReconciler = new KafkaTopicReconciler(operator);
     Controller topicController = ControllerBuilder.defaultBuilder(operator.informerFactory())
-      .withReconciler(topicReconciler)
-      .withName("kafka-topic-controller")
-      .withWorkerCount(1)
-      .watch(x -> ControllerBuilder.controllerWatchBuilder(V1alpha1KafkaTopic.class, x).build())
-      .build();
+        .withReconciler(topicReconciler)
+        .withName("kafka-topic-controller")
+        .withWorkerCount(1)
+        .watch(x -> ControllerBuilder.controllerWatchBuilder(V1alpha1KafkaTopic.class, x).build())
+        .build();
 
     Reconciler topicAclReconciler = new KafkaTopicAclReconciler(operator);
     Controller topicAclController = ControllerBuilder.defaultBuilder(operator.informerFactory())
-      .withReconciler(topicAclReconciler)
-      .withName("kafka-topic-acl-controller")
-      .withWorkerCount(1)
-      .watch(x -> ControllerBuilder.controllerWatchBuilder(V1alpha1Acl.class, x).build())
-      .build();
+        .withReconciler(topicAclReconciler)
+        .withName("kafka-topic-acl-controller")
+        .withWorkerCount(1)
+        .watch(x -> ControllerBuilder.controllerWatchBuilder(V1alpha1Acl.class, x).build())
+        .build();
 
     return Arrays.asList(new Controller[]{topicController, topicAclController});
   }

--- a/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/ClusterSchema.java
+++ b/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/ClusterSchema.java
@@ -1,18 +1,17 @@
 package com.linkedin.hoptimator.kafka;
 
-import org.apache.kafka.clients.admin.AdminClient;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
-
+import org.apache.kafka.clients.admin.AdminClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.Properties;
-import java.util.concurrent.ExecutionException;
 
 public class ClusterSchema extends AbstractSchema {
 
@@ -30,7 +29,7 @@ public class ClusterSchema extends AbstractSchema {
     AdminClient adminClient = AdminClient.create(properties);
     log.info("Loading Kafka topics from {} ...", properties.getProperty("bootstrap.servers"));
     Set<String> topicNames = adminClient.listTopics().names().get();
-    log.info("Loaded {} topics.",  topicNames.size());
+    log.info("Loaded {} topics.", topicNames.size());
     for (String name : topicNames) {
       tableMap.put(name, new KafkaTopic(name, properties));
     }

--- a/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
+++ b/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
@@ -1,6 +1,9 @@
 package com.linkedin.hoptimator.kafka;
 
-import org.apache.kafka.clients.admin.AdminClient;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
 
 import org.apache.calcite.avatica.ConnectStringParser;
 import org.apache.calcite.avatica.DriverVersion;
@@ -8,11 +11,6 @@ import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.SchemaPlus;
 
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Locale;
-import java.util.Properties;
 
 /** JDBC driver for Kafka topics. */
 public class KafkaDriver extends Driver {

--- a/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaTopic.java
+++ b/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaTopic.java
@@ -1,11 +1,12 @@
 package com.linkedin.hoptimator.kafka;
 
+import java.util.Properties;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import java.util.Properties;
 
 /** A batch of records from a Kafka topic. */
 public class KafkaTopic extends AbstractTable {
@@ -21,9 +22,10 @@ public class KafkaTopic extends AbstractTable {
   @Override
   public RelDataType getRowType(RelDataTypeFactory typeFactory) {
     RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(typeFactory);
-    return builder
-        .add("KEY", SqlTypeName.VARCHAR).nullable(true)
-        .add("VALUE", SqlTypeName.BINARY).nullable(true)
+    return builder.add("KEY", SqlTypeName.VARCHAR)
+        .nullable(true)
+        .add("VALUE", SqlTypeName.BINARY)
+        .nullable(true)
         .build();
   }
 }

--- a/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
+++ b/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
@@ -1,9 +1,10 @@
 package com.linkedin.hoptimator.kafka;
 
-import com.linkedin.hoptimator.jdbc.QuidemTestBase;
-
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import com.linkedin.hoptimator.jdbc.QuidemTestBase;
+
 
 public class TestSqlScripts extends QuidemTestBase {
 

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Acl.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Acl.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Access control rule (colloquially, an Acl)
  */
 @ApiModel(description = "Access control rule (colloquially, an Acl)")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1Acl implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclList.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * AclList is a list of Acl
  */
 @ApiModel(description = "AclList is a list of Acl")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1AclList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpec.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpec.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * A set of related ACL rules.
  */
 @ApiModel(description = "A set of related ACL rules.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1AclSpec {
   /**
    * The resource access method.

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpecResource.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclSpecResource.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * The resource being controlled.
  */
 @ApiModel(description = "The resource being controlled.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1AclSpecResource {
   public static final String SERIALIZED_NAME_KIND = "kind";
   @SerializedName(SERIALIZED_NAME_KIND)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclStatus.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1AclStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Status, as set by the operator.
  */
 @ApiModel(description = "Status, as set by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1AclStatus {
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopic.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopic.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Kafka Topic
  */
 @ApiModel(description = "Kafka Topic")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1KafkaTopic implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicList.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * KafkaTopicList is a list of KafkaTopic
  */
 @ApiModel(description = "KafkaTopicList is a list of KafkaTopic")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1KafkaTopicList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpec.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpec.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * Desired Kafka topic configuration.
  */
 @ApiModel(description = "Desired Kafka topic configuration.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpec {
   public static final String SERIALIZED_NAME_CLIENT_CONFIGS = "clientConfigs";
   @SerializedName(SERIALIZED_NAME_CLIENT_CONFIGS)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecClientConfigs.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecClientConfigs.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * V1alpha1KafkaTopicSpecClientConfigs
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpecClientConfigs {
   public static final String SERIALIZED_NAME_CONFIG_MAP_REF = "configMapRef";
   @SerializedName(SERIALIZED_NAME_CONFIG_MAP_REF)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecConfigMapRef.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicSpecConfigMapRef.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Reference to a ConfigMap to use for AdminClient configuration.
  */
 @ApiModel(description = "Reference to a ConfigMap to use for AdminClient configuration.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1KafkaTopicSpecConfigMapRef {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicStatus.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1KafkaTopicStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Current state of the topic.
  */
 @ApiModel(description = "Current state of the topic.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1KafkaTopicStatus {
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJob.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJob.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator generic SQL job
  */
 @ApiModel(description = "Hoptimator generic SQL job")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1SqlJob implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobList.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SqlJobList is a list of SqlJob
  */
 @ApiModel(description = "SqlJobList is a list of SqlJob")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1SqlJobList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobSpec.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * SQL job spec
  */
 @ApiModel(description = "SQL job spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1SqlJobSpec {
   /**
    * Flink, etc.

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobStatus.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SqlJobStatus.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1SqlJobStatus {
   public static final String SERIALIZED_NAME_FAILED = "failed";
   @SerializedName(SERIALIZED_NAME_FAILED)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Subscription.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1Subscription.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator Subscription
  */
 @ApiModel(description = "Hoptimator Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1Subscription implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionList.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SubscriptionList is a list of Subscription
  */
 @ApiModel(description = "SubscriptionList is a list of Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1SubscriptionList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionSpec.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionSpec.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Subscription spec
  */
 @ApiModel(description = "Subscription spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1SubscriptionSpec {
   public static final String SERIALIZED_NAME_DATABASE = "database";
   @SerializedName(SERIALIZED_NAME_DATABASE)

--- a/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionStatus.java
+++ b/hoptimator-models/src/main/java/com/linkedin/hoptimator/models/V1alpha1SubscriptionStatus.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-26T20:21:01.735Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-09T16:55:33.927Z[Etc/UTC]")
 public class V1alpha1SubscriptionStatus {
   public static final String SERIALIZED_NAME_ATTRIBUTES = "attributes";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES)

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/ConfigAssembler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/ConfigAssembler.java
@@ -1,12 +1,13 @@
 package com.linkedin.hoptimator.operator;
 
-import io.kubernetes.client.openapi.models.V1ConfigMap;
-
 import java.util.ArrayList;
-import java.util.Properties;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+
 
 public class ConfigAssembler {
   private final Operator operator;
@@ -14,7 +15,7 @@ public class ConfigAssembler {
   private final Map<String, String> overrides = new HashMap<>();
 
   public ConfigAssembler(Operator operator) {
-    this.operator = operator;    
+    this.operator = operator;
   }
 
   public void addOverride(String key, String value) {
@@ -48,7 +49,7 @@ public class ConfigAssembler {
     }
 
     Map<String, String> fetch(Operator operator) {
-      return operator.<V1ConfigMap>fetch("configmap", namespace, name).getData(); 
+      return operator.<V1ConfigMap>fetch("configmap", namespace, name).getData();
     }
   }
 }

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/ControllerProvider.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/ControllerProvider.java
@@ -1,8 +1,9 @@
 package com.linkedin.hoptimator.operator;
 
+import java.util.Collection;
+
 import io.kubernetes.client.extended.controller.Controller;
 
-import java.util.Collection;
 
 /** Service Provider Interface to enable dynamically loading Controllers. */
 public interface ControllerProvider {

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/ControllerService.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/ControllerService.java
@@ -1,17 +1,19 @@
 package com.linkedin.hoptimator.operator;
 
-import org.apache.calcite.plan.RelOptRule;
-
-import io.kubernetes.client.extended.controller.Controller;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
+import io.kubernetes.client.extended.controller.Controller;
+
+
 /** Loads controller plugins via the ControllerProvider Service Provider Interface. */
 public final class ControllerService {
+
+  private ControllerService() {
+  }
 
   public static Collection<ControllerProvider> providers() {
     ServiceLoader<ControllerProvider> loader = ServiceLoader.load(ControllerProvider.class);
@@ -21,7 +23,6 @@ public final class ControllerService {
   }
 
   public static Collection<Controller> controllers(Operator operator) {
-    return providers().stream().flatMap(x -> x.controllers(operator).stream())
-      .collect(Collectors.toList());
+    return providers().stream().flatMap(x -> x.controllers(operator).stream()).collect(Collectors.toList());
   }
 }

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/Operator.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/Operator.java
@@ -1,25 +1,7 @@
 package com.linkedin.hoptimator.operator;
 
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.V1OwnerReference;
-import io.kubernetes.client.informer.SharedInformerFactory;
-import io.kubernetes.client.informer.SharedIndexInformer;
-import io.kubernetes.client.informer.cache.Indexer;
-import io.kubernetes.client.informer.cache.Lister;
-import io.kubernetes.client.common.KubernetesObject;
-import io.kubernetes.client.common.KubernetesListObject;
-import io.kubernetes.client.openapi.models.V1OwnerReference;
-import io.kubernetes.client.util.generic.GenericKubernetesApi;
-import io.kubernetes.client.util.generic.KubernetesApiResponse;
-import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
-import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
-import io.kubernetes.client.util.generic.dynamic.Dynamics;
-
-import com.linkedin.hoptimator.catalog.Resource;
-
-import java.util.ArrayList;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,18 +10,33 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.informer.cache.Lister;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1OwnerReference;
+import io.kubernetes.client.util.generic.GenericKubernetesApi;
+import io.kubernetes.client.util.generic.KubernetesApiResponse;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import io.kubernetes.client.util.generic.dynamic.Dynamics;
+
+
 /** Single handle to all the clients and configs required by all the controllers. */
 public class Operator {
   private final static Logger log = LoggerFactory.getLogger(Operator.class);
- 
-  private final String namespace; 
+
+  private final String namespace;
   private final ApiClient apiClient;
   private final SharedInformerFactory informerFactory;
   private final Map<String, ApiInfo<?, ?>> apiInfo = new HashMap<>();
   private final Properties properties;
 
-  public Operator(String namespace, ApiClient apiClient, SharedInformerFactory informerFactory,
-      Properties properties) {
+  public Operator(String namespace, ApiClient apiClient, SharedInformerFactory informerFactory, Properties properties) {
     this.namespace = namespace;
     this.apiClient = apiClient;
     this.informerFactory = informerFactory;
@@ -62,20 +59,19 @@ public class Operator {
   public Properties properties() {
     return properties;
   }
-  
-  public <T extends KubernetesObject, L extends KubernetesListObject> void registerApi(String kind,
-      String singular, String plural, String group, String version, Class<T> type, Class<L> list) {
+
+  public <T extends KubernetesObject, L extends KubernetesListObject> void registerApi(String kind, String singular,
+      String plural, String group, String version, Class<T> type, Class<L> list) {
     registerApi(new ApiInfo<T, L>(kind, singular, plural, group, version, type, list), true);
   }
 
-  public void registerApi(String kind, String singular, String plural, String group,
-      String version) {
-    registerApi(new ApiInfo<KubernetesObject, KubernetesListObject>(kind, singular, plural, group,
-      version, KubernetesObject.class, KubernetesListObject.class), false);
+  public void registerApi(String kind, String singular, String plural, String group, String version) {
+    registerApi(new ApiInfo<KubernetesObject, KubernetesListObject>(kind, singular, plural, group, version,
+        KubernetesObject.class, KubernetesListObject.class), false);
   }
 
-  public <T extends KubernetesObject, L extends KubernetesListObject> void registerApi(
-      ApiInfo<T, L> api, boolean watch) {
+  public <T extends KubernetesObject, L extends KubernetesListObject> void registerApi(ApiInfo<T, L> api,
+      boolean watch) {
     this.apiInfo.put(api.groupVersionKind(), api);
     if (watch) {
       // side-effect: register shared informer
@@ -84,8 +80,7 @@ public class Operator {
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends KubernetesObject, L extends KubernetesListObject> ApiInfo<T, L> apiInfo(
-      String groupVersionKind) {
+  public <T extends KubernetesObject, L extends KubernetesListObject> ApiInfo<T, L> apiInfo(String groupVersionKind) {
     if (!this.apiInfo.containsKey(groupVersionKind)) {
       throw new IllegalArgumentException("No API for '" + groupVersionKind + "' registered!");
     }
@@ -102,8 +97,7 @@ public class Operator {
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends KubernetesObject> T fetch(String groupVersionKind, String namespace,
-      String name) { 
+  public <T extends KubernetesObject> T fetch(String groupVersionKind, String namespace, String name) {
     return (T) lister(groupVersionKind).namespace(namespace).get(name);
   }
 
@@ -113,14 +107,14 @@ public class Operator {
   }
 
   public DynamicKubernetesApi apiFor(DynamicKubernetesObject obj) {
-    String groupVersion = obj.getApiVersion(); 
+    String groupVersion = obj.getApiVersion();
     String kind = obj.getKind();
     return apiInfo(groupVersion + "/" + kind).dynamic(apiClient);
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends KubernetesObject, L extends KubernetesListObject> GenericKubernetesApi<T, L>
-      apiFor(String groupVersionKind) {
+  public <T extends KubernetesObject, L extends KubernetesListObject> GenericKubernetesApi<T, L> apiFor(
+      String groupVersionKind) {
     return (GenericKubernetesApi<T, L>) apiInfo(groupVersionKind).generic(apiClient);
   }
 
@@ -131,17 +125,16 @@ public class Operator {
   public Duration pendingRetryDuration() {
     return Duration.ofMinutes(1);
   }
-  
+
   public Duration resyncPeriod() {
     return Duration.ofMinutes(10);
   }
 
   public void apply(String yaml, KubernetesObject owner) throws ApiException {
-    V1OwnerReference ownerReference = new V1OwnerReference()
-      .kind(owner.getKind())
-      .name(owner.getMetadata().getName())
-      .apiVersion(owner.getApiVersion())
-      .uid(owner.getMetadata().getUid());
+    V1OwnerReference ownerReference = new V1OwnerReference().kind(owner.getKind())
+        .name(owner.getMetadata().getName())
+        .apiVersion(owner.getApiVersion())
+        .uid(owner.getMetadata().getUid());
     DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
     if (obj.getMetadata().getNamespace() == null) {
       obj.getMetadata().setNamespace(owner.getMetadata().getNamespace());
@@ -154,30 +147,31 @@ public class Operator {
     KubernetesApiResponse<DynamicKubernetesObject> existing = apiFor(obj).get(namespace, name);
     if (existing.isSuccess()) {
       String resourceVersion = existing.getObject().getMetadata().getResourceVersion();
-      log.info("Updating existing downstream resource {}/{} {} as \n{}",
-        namespace, name, resourceVersion, yaml);
+      log.info("Updating existing downstream resource {}/{} {} as \n{}", namespace, name, resourceVersion, yaml);
       List<V1OwnerReference> owners = existing.getObject().getMetadata().getOwnerReferences();
       if (owners == null) {
         owners = new ArrayList<>();
       }
       if (owners.stream().anyMatch(x -> x.getUid().equals(ownerReference.getUid()))) {
-        log.info("Existing downstream resource {}/{} is already owned by {}/{}.",
-          namespace, name, ownerReference.getKind(), ownerReference.getName());
+        log.info("Existing downstream resource {}/{} is already owned by {}/{}.", namespace, name,
+            ownerReference.getKind(), ownerReference.getName());
       } else {
-        log.info("Existing downstream resource {}/{} will be owned by {}/{} and {} others.",
-          namespace, name, ownerReference.getKind(), ownerReference.getName(), owners.size());
+        log.info("Existing downstream resource {}/{} will be owned by {}/{} and {} others.", namespace, name,
+            ownerReference.getKind(), ownerReference.getName(), owners.size());
         owners.add(ownerReference);
       }
       obj.setMetadata(obj.getMetadata().ownerReferences(owners).resourceVersion(resourceVersion));
       apiFor(obj).update(obj)
-        .onFailure((x, y) -> log.error("Error updating downstream resource {}/{}: {}.", namespace, name, y.getMessage()))
-        .throwsApiException();
+          .onFailure(
+              (x, y) -> log.error("Error updating downstream resource {}/{}: {}.", namespace, name, y.getMessage()))
+          .throwsApiException();
     } else {
       log.info("Creating downstream resource {}/{} as \n{}", namespace, name, yaml);
       obj.setMetadata(obj.getMetadata().addOwnerReferencesItem(ownerReference));
       apiFor(obj).create(obj)
-        .onFailure((x, y) -> log.error("Error creating downstream resource {}/{}: {}.", namespace, name, y.getMessage()))
-        .throwsApiException();
+          .onFailure(
+              (x, y) -> log.error("Error creating downstream resource {}/{}: {}.", namespace, name, y.getMessage()))
+          .throwsApiException();
     }
   }
 
@@ -215,20 +209,30 @@ public class Operator {
       log.debug("Exception looking for .status.ready. Swallowing.", e);
     }
     try {
-      return obj.getRaw().get("status").getAsJsonObject().get("state").getAsString()
-        .matches("(?i)READY|RUNNING|FINISHED");
+      return obj.getRaw()
+          .get("status")
+          .getAsJsonObject()
+          .get("state")
+          .getAsString()
+          .matches("(?i)READY|RUNNING|FINISHED");
     } catch (Exception e) {
       log.debug("Exception looking for .status.state. Swallowing.", e);
     }
     try {
-      return obj.getRaw().get("status").getAsJsonObject().get("jobStatus").getAsJsonObject()
-        .get("state").getAsString().matches("(?i)READY|RUNNING|FINISHED");
+      return obj.getRaw()
+          .get("status")
+          .getAsJsonObject()
+          .get("jobStatus")
+          .getAsJsonObject()
+          .get("state")
+          .getAsString()
+          .matches("(?i)READY|RUNNING|FINISHED");
     } catch (Exception e) {
       log.debug("Exception looking for .status.jobStatus.state. Swallowing.", e);
     }
     // TODO: Look for common Conditions
-    log.warn("Resource {}/{}/{} considered ready by default.", obj.getMetadata().getNamespace(),
-      obj.getKind(), obj.getMetadata().getName());
+    log.warn("Resource {}/{}/{} considered ready by default.", obj.getMetadata().getNamespace(), obj.getKind(),
+        obj.getMetadata().getName());
     return true;
   }
 
@@ -265,21 +269,26 @@ public class Operator {
       log.debug("Exception looking for .status.ready. Swallowing.", e);
     }
     try {
-      return obj.getRaw().get("status").getAsJsonObject().get("state").getAsString()
-        .matches("(?i)FAILED|ERROR");
+      return obj.getRaw().get("status").getAsJsonObject().get("state").getAsString().matches("(?i)FAILED|ERROR");
     } catch (Exception e) {
       log.debug("Exception looking for .status.state. Swallowing.", e);
     }
     try {
-      return obj.getRaw().get("status").getAsJsonObject().get("jobStatus").getAsJsonObject()
-        .get("state").getAsString().matches("(?i)FAILED|ERROR");
+      return obj.getRaw()
+          .get("status")
+          .getAsJsonObject()
+          .get("jobStatus")
+          .getAsJsonObject()
+          .get("state")
+          .getAsString()
+          .matches("(?i)FAILED|ERROR");
     } catch (Exception e) {
       log.debug("Exception looking for .status.jobStatus.state. Swallowing.", e);
     }
     // TODO: Look for common Conditions
     return false;
   }
- 
+
   public static class ApiInfo<T extends KubernetesObject, L extends KubernetesListObject> {
     private final String kind;
     private final String singular;
@@ -289,7 +298,8 @@ public class Operator {
     private final Class<T> type;
     private final Class<L> list;
 
-    public ApiInfo(String kind, String singular, String plural, String group, String version, Class<T> type, Class<L> list) {
+    public ApiInfo(String kind, String singular, String plural, String group, String version, Class<T> type,
+        Class<L> list) {
       this.kind = kind;
       this.singular = singular;
       this.plural = plural;

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/PipelineOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/PipelineOperatorApp.java
@@ -1,19 +1,19 @@
 package com.linkedin.hoptimator.operator;
 
-import io.kubernetes.client.informer.SharedInformerFactory;
-import io.kubernetes.client.extended.controller.Controller;
-import io.kubernetes.client.extended.controller.ControllerManager;
-
-import com.linkedin.hoptimator.k8s.K8sContext;
-import com.linkedin.hoptimator.k8s.K8sApiEndpoints;
-import com.linkedin.hoptimator.operator.pipeline.PipelineReconciler;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.time.Duration;
+import io.kubernetes.client.extended.controller.Controller;
+import io.kubernetes.client.extended.controller.ControllerManager;
+
+import com.linkedin.hoptimator.k8s.K8sApiEndpoints;
+import com.linkedin.hoptimator.k8s.K8sContext;
+import com.linkedin.hoptimator.operator.pipeline.PipelineReconciler;
+
 
 public class PipelineOperatorApp {
   private static final Logger log = LoggerFactory.getLogger(HoptimatorOperatorApp.class);
@@ -32,10 +32,10 @@ public class PipelineOperatorApp {
     // TODO: add additional controllers from ControllerProvider SPI
     controllers.add(PipelineReconciler.controller(context));
 
-    ControllerManager controllerManager = new ControllerManager(context.informerFactory(),
-        controllers.toArray(new Controller[0]));
-  
+    ControllerManager controllerManager =
+        new ControllerManager(context.informerFactory(), controllers.toArray(new Controller[0]));
+
     log.info("Starting operator with {} controllers.", controllers.size());
-    controllerManager.run();  
+    controllerManager.run();
   }
 }

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionEnvironment.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/subscription/SubscriptionEnvironment.java
@@ -1,13 +1,9 @@
 package com.linkedin.hoptimator.operator.subscription;
 
-import io.kubernetes.client.extended.controller.reconciler.Request;
-
 import com.linkedin.hoptimator.catalog.AvroConverter;
 import com.linkedin.hoptimator.catalog.Resource;
 import com.linkedin.hoptimator.planner.Pipeline;
 
-import java.util.Map;
-import java.util.Collections;
 
 /**
  * Exposes Subscription variables to resource templates.
@@ -32,7 +28,7 @@ public class SubscriptionEnvironment extends Resource.SimpleEnvironment {
   public SubscriptionEnvironment(String namespace, String name, Pipeline pipeline) {
     export("pipeline.namespace", namespace);
     export("pipeline.name", name);
-    export("pipeline.avroSchema", AvroConverter.avro("com.linkedin.hoptimator", "OutputRecord",
-      pipeline.outputType()).toString(false));
+    export("pipeline.avroSchema",
+        AvroConverter.avro("com.linkedin.hoptimator", "OutputRecord", pipeline.outputType()).toString(false));
   }
 }

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/Pipeline.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/Pipeline.java
@@ -1,16 +1,17 @@
 package com.linkedin.hoptimator.planner;
 
-import org.apache.calcite.rel.type.RelDataType;
-
-import com.linkedin.hoptimator.catalog.Resource;
-import com.linkedin.hoptimator.catalog.ResourceProvider;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.apache.calcite.rel.type.RelDataType;
+
+import com.linkedin.hoptimator.catalog.Resource;
+import com.linkedin.hoptimator.catalog.ResourceProvider;
+
 
 /** A set of Resources that deliver data.
  *
@@ -21,8 +22,8 @@ public class Pipeline {
   private final SqlJob sqlJob;
   private final RelDataType outputType;
 
-  public Pipeline(Collection<Resource> upstreamResources, SqlJob sqlJob,
-      Collection<Resource> downstreamResources, RelDataType outputType) {
+  public Pipeline(Collection<Resource> upstreamResources, SqlJob sqlJob, Collection<Resource> downstreamResources,
+      RelDataType outputType) {
     this.upstreamResources = upstreamResources;
     this.sqlJob = sqlJob;
     this.downstreamResources = downstreamResources;
@@ -51,10 +52,8 @@ public class Pipeline {
   /** All Resources in the pipeline, including the SQL job and sink. */
   public Collection<Resource> resources() {
     // We re-use ResourceProvider here for its source->sink relationships
-    ResourceProvider resourceProvider = ResourceProvider
-      .from(upstreamResources)
-      .to(sqlJob)
-      .toAll(x -> downstreamResources);
+    ResourceProvider resourceProvider =
+        ResourceProvider.from(upstreamResources).to(sqlJob).toAll(x -> downstreamResources);
 
     // All resources are now "provided", so we can pass null here:
     return resourceProvider.resources(null);
@@ -73,17 +72,17 @@ public class Pipeline {
   public String mermaid() {
     StringBuilder sb = new StringBuilder();
     sb.append("flowchart\n");
-    Map<String, List<Resource>> grouped = resources().stream()
-      .collect(Collectors.groupingBy(x -> x.template()));
+    Map<String, List<Resource>> grouped = resources().stream().collect(Collectors.groupingBy(x -> x.template()));
     grouped.forEach((k, v) -> {
       sb.append("  subgraph " + k + "\n");
       v.forEach(x -> {
-        String description = x.keys().stream()
-          .filter(k2 -> x.property(k2) != null)
-          .filter(k2 -> !x.property(k2).isEmpty())
-          .filter(k2 -> !"id".equals(k2))
-          .map(k2 -> k2 + ": " + sanitize(x.property(k2)))
-          .collect(Collectors.joining("\n"));
+        String description = x.keys()
+            .stream()
+            .filter(k2 -> x.property(k2) != null)
+            .filter(k2 -> !x.property(k2).isEmpty())
+            .filter(k2 -> !"id".equals(k2))
+            .map(k2 -> k2 + ": " + sanitize(x.property(k2)))
+            .collect(Collectors.joining("\n"));
         sb.append("  " + id(x) + "[\"" + description + "\"]\n");
       });
       sb.append("  end\n");
@@ -107,7 +106,7 @@ public class Pipeline {
   private static String sanitize(String s) {
     String safe = s.replaceAll("\"", "&quot;").replaceAll("\n", " ").trim();
     if (safe.length() > 20) {
-      return safe.substring(0, 17) + "..."; 
+      return safe.substring(0, 17) + "...";
     }
     return safe;
   }

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRel.java
@@ -1,23 +1,22 @@
 package com.linkedin.hoptimator.planner;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.rel.type.RelDataTypeImpl;
+import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.util.Litmus;
 
-import com.linkedin.hoptimator.catalog.Resource;
-import com.linkedin.hoptimator.catalog.ResourceProvider;
 import com.linkedin.hoptimator.catalog.HopTable;
+import com.linkedin.hoptimator.catalog.Resource;
 import com.linkedin.hoptimator.catalog.ScriptImplementor;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 /**
  * Calling convention which implements an SQL-based streaming data pipeline.
@@ -81,8 +80,7 @@ public interface PipelineRel extends RelNode {
     public ScriptImplementor insertInto(HopTable sink) {
       RelOptUtil.eq(sink.name(), sink.rowType(), "subscription", rowType(), Litmus.THROW);
       RelNode castRel = RelOptUtil.createCastRel(relNode, sink.rowType(), true);
-      return script.database(sink.database()).with(sink)
-        .insert(sink.database(), sink.name(), castRel);
+      return script.database(sink.database()).with(sink).insert(sink.database(), sink.name(), castRel);
     }
 
     /** Add any resources, SQL, DDL etc required to access the table. */

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRules.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/PipelineRules.java
@@ -1,63 +1,58 @@
 package com.linkedin.hoptimator.planner;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.Convention;
-import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRule;
-import org.apache.calcite.plan.RelOptPlanner;
-import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalCalc;
 import org.apache.calcite.rel.logical.LogicalFilter;
-import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalJoin;
-import org.apache.calcite.rel.core.Calc;
-import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.rel.core.Filter;
-import org.apache.calcite.rel.core.Project;
-import org.apache.calcite.rel.core.Join;
-import org.apache.calcite.rel.core.CorrelationId;
-import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.schema.Table;
 
+import com.linkedin.hoptimator.catalog.HopRel;
 import com.linkedin.hoptimator.catalog.HopTable;
 import com.linkedin.hoptimator.catalog.HopTableScan;
-import com.linkedin.hoptimator.catalog.HopRel;
 import com.linkedin.hoptimator.catalog.ProtoTable;
 import com.linkedin.hoptimator.catalog.RuleProvider;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.Objects;
 
 public class PipelineRules implements RuleProvider {
 
   @Override
   public Collection<RelOptRule> rules() {
-    return Arrays.asList(
-      PipelineTableScanRule.INSTANCE,
-      PipelineFilterRule.INSTANCE,
-      PipelineProjectRule.INSTANCE,
-      PipelineJoinRule.INSTANCE,
-      PipelineCalcRule.INSTANCE);
+    return Arrays.asList(PipelineTableScanRule.INSTANCE, PipelineFilterRule.INSTANCE, PipelineProjectRule.INSTANCE,
+        PipelineJoinRule.INSTANCE, PipelineCalcRule.INSTANCE);
   }
- 
+
   static class PipelineTableScanRule extends ConverterRule {
-    static final PipelineTableScanRule INSTANCE = Config.INSTANCE
-      .withConversion(HopTableScan.class, HopRel.CONVENTION,
-          PipelineRel.CONVENTION, "PipelineTableScanRule")
-      .withRuleFactory(PipelineTableScanRule::new)
-      .as(Config.class)
-      .toRule(PipelineTableScanRule.class);
+    static final PipelineTableScanRule INSTANCE =
+        Config.INSTANCE.withConversion(HopTableScan.class, HopRel.CONVENTION, PipelineRel.CONVENTION,
+                "PipelineTableScanRule")
+            .withRuleFactory(PipelineTableScanRule::new)
+            .as(Config.class)
+            .toRule(PipelineTableScanRule.class);
 
     protected PipelineTableScanRule(Config config) {
       super(config);
@@ -95,12 +90,12 @@ public class PipelineRules implements RuleProvider {
   }
 
   static class PipelineFilterRule extends ConverterRule {
-    static final PipelineFilterRule INSTANCE = Config.INSTANCE
-      .withConversion(LogicalFilter.class, Convention.NONE,
-          PipelineRel.CONVENTION, "PipelineFilterRule")
-      .withRuleFactory(PipelineFilterRule::new)
-      .as(Config.class)
-      .toRule(PipelineFilterRule.class);
+    static final PipelineFilterRule INSTANCE =
+        Config.INSTANCE.withConversion(LogicalFilter.class, Convention.NONE, PipelineRel.CONVENTION,
+                "PipelineFilterRule")
+            .withRuleFactory(PipelineFilterRule::new)
+            .as(Config.class)
+            .toRule(PipelineFilterRule.class);
 
     protected PipelineFilterRule(Config config) {
       super(config);
@@ -133,12 +128,12 @@ public class PipelineRules implements RuleProvider {
   }
 
   static class PipelineProjectRule extends ConverterRule {
-    static final PipelineProjectRule INSTANCE = Config.INSTANCE
-      .withConversion(LogicalProject.class, Convention.NONE,
-          PipelineRel.CONVENTION, "PipelineProjectRule")
-      .withRuleFactory(PipelineProjectRule::new)
-      .as(Config.class)
-      .toRule(PipelineProjectRule.class);
+    static final PipelineProjectRule INSTANCE =
+        Config.INSTANCE.withConversion(LogicalProject.class, Convention.NONE, PipelineRel.CONVENTION,
+                "PipelineProjectRule")
+            .withRuleFactory(PipelineProjectRule::new)
+            .as(Config.class)
+            .toRule(PipelineProjectRule.class);
 
     protected PipelineProjectRule(Config config) {
       super(config);
@@ -149,14 +144,14 @@ public class PipelineRules implements RuleProvider {
       Project project = (Project) rel;
       RelTraitSet traitSet = project.getTraitSet().replace(PipelineRel.CONVENTION);
       return new PipelineProject(rel.getCluster(), traitSet, convert(project.getInput(), PipelineRel.CONVENTION),
-        project.getProjects(), project.getRowType());
+          project.getProjects(), project.getRowType());
     }
   }
 
   static class PipelineProject extends Project implements PipelineRel {
 
-    PipelineProject(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
-        List<? extends RexNode> projects, RelDataType rowType) {
+    PipelineProject(RelOptCluster cluster, RelTraitSet traitSet, RelNode input, List<? extends RexNode> projects,
+        RelDataType rowType) {
       super(cluster, traitSet, Collections.emptyList(), input, projects, rowType);
       assert getConvention() == PipelineRel.CONVENTION;
       assert input.getConvention() == PipelineRel.CONVENTION;
@@ -173,12 +168,11 @@ public class PipelineRules implements RuleProvider {
   }
 
   static class PipelineJoinRule extends ConverterRule {
-    static final PipelineJoinRule INSTANCE = Config.INSTANCE
-      .withConversion(LogicalJoin.class, Convention.NONE,
-          PipelineRel.CONVENTION, "PipelineJoinRule")
-      .withRuleFactory(PipelineJoinRule::new)
-      .as(Config.class)
-      .toRule(PipelineJoinRule.class);
+    static final PipelineJoinRule INSTANCE =
+        Config.INSTANCE.withConversion(LogicalJoin.class, Convention.NONE, PipelineRel.CONVENTION, "PipelineJoinRule")
+            .withRuleFactory(PipelineJoinRule::new)
+            .as(Config.class)
+            .toRule(PipelineJoinRule.class);
 
     protected PipelineJoinRule(Config config) {
       super(config);
@@ -189,15 +183,15 @@ public class PipelineRules implements RuleProvider {
       Join join = (Join) rel;
       RelTraitSet traitSet = join.getTraitSet().replace(PipelineRel.CONVENTION);
       return new PipelineJoin(rel.getCluster(), traitSet, convert(join.getLeft(), PipelineRel.CONVENTION),
-          convert(join.getRight(), PipelineRel.CONVENTION), join.getCondition(),
-          join.getVariablesSet(), join.getJoinType());
+          convert(join.getRight(), PipelineRel.CONVENTION), join.getCondition(), join.getVariablesSet(),
+          join.getJoinType());
     }
   }
 
   static class PipelineJoin extends Join implements PipelineRel {
 
     PipelineJoin(RelOptCluster cluster, RelTraitSet traitSet, RelNode left, RelNode right, RexNode condition,
-         Set<CorrelationId> variablesSet, JoinRelType joinType) {
+        Set<CorrelationId> variablesSet, JoinRelType joinType) {
       super(cluster, traitSet, Collections.emptyList(), left, right, condition, variablesSet, joinType);
     }
 
@@ -213,12 +207,11 @@ public class PipelineRules implements RuleProvider {
   }
 
   static class PipelineCalcRule extends ConverterRule {
-    static final PipelineCalcRule INSTANCE = Config.INSTANCE
-      .withConversion(LogicalCalc.class, Convention.NONE,
-          PipelineRel.CONVENTION, "PipelineCalcRule")
-      .withRuleFactory(PipelineCalcRule::new)
-      .as(Config.class)
-      .toRule(PipelineCalcRule.class);
+    static final PipelineCalcRule INSTANCE =
+        Config.INSTANCE.withConversion(LogicalCalc.class, Convention.NONE, PipelineRel.CONVENTION, "PipelineCalcRule")
+            .withRuleFactory(PipelineCalcRule::new)
+            .as(Config.class)
+            .toRule(PipelineCalcRule.class);
 
     protected PipelineCalcRule(Config config) {
       super(config);
@@ -263,10 +256,11 @@ public class PipelineRules implements RuleProvider {
       List<String> tail = qualifiedName.subList(1, qualifiedName.size());
       CalciteSchema subSchema = schema.getSubSchema(head, false);
       if (subSchema == null) {
-        throw new IllegalArgumentException("No schema '" + schema.getName() + "' found when looking for table '"
-            + qualifiedName.get(qualifiedName.size() - 1) + "'");
+        throw new IllegalArgumentException(
+            "No schema '" + schema.getName() + "' found when looking for table '" + qualifiedName.get(
+                qualifiedName.size() - 1) + "'");
       }
-      return findTable(subSchema, tail); 
+      return findTable(subSchema, tail);
     }
   }
 

--- a/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/SqlJob.java
+++ b/hoptimator-planner/src/main/java/com/linkedin/hoptimator/planner/SqlJob.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.planner;
 
 import com.linkedin.hoptimator.catalog.Resource;
 
+
 /**
  * Anything that can run SQL, e.g. a Flink job.
  *

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Api.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Api.java
@@ -1,11 +1,12 @@
 package com.linkedin.hoptimator.util;
 
-import java.util.Collection;
 import java.sql.SQLException;
+import java.util.Collection;
+
 
 /** A set of CRUD'able objects. */
 public interface Api<T> {
-  
+
   Collection<T> list() throws SQLException;
 
   default void create(T t) throws SQLException {

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ArrayTable.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ArrayTable.java
@@ -1,39 +1,40 @@
 package com.linkedin.hoptimator.util;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Linq4j;
-import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.logical.LogicalTableModify;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.schema.ModifiableTable;
 import org.apache.calcite.schema.ScannableTable;
-import org.apache.calcite.schema.TranslatableTable;
-import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.plan.Convention;
-import org.apache.calcite.plan.RelOptTable;
-import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 /** An in-memory table. */
-public abstract class ArrayTable<T> extends AbstractTable implements TranslatableTable, ModifiableTable,
-    ScannableTable {
+public abstract class ArrayTable<T> extends AbstractTable
+    implements TranslatableTable, ModifiableTable, ScannableTable {
 
   private final Class<T> elementType;
   private final RelDataType javaType;
@@ -88,11 +89,12 @@ public abstract class ArrayTable<T> extends AbstractTable implements Translatabl
   }
 
   @Override
-  public TableModify toModificationRel(RelOptCluster cluster, RelOptTable table, Prepare.CatalogReader schema, RelNode input,
-      TableModify.Operation operation, List<String> updateColumnList, List<RexNode> sourceExpressionList, boolean flattened) {
+  public TableModify toModificationRel(RelOptCluster cluster, RelOptTable table, Prepare.CatalogReader schema,
+      RelNode input, TableModify.Operation operation, List<String> updateColumnList, List<RexNode> sourceExpressionList,
+      boolean flattened) {
     RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
-    return new LogicalTableModify(cluster, traitSet, table, schema, input,
-        operation, updateColumnList, sourceExpressionList, flattened);
+    return new LogicalTableModify(cluster, traitSet, table, schema, input, operation, updateColumnList,
+        sourceExpressionList, flattened);
   }
 
   @SuppressWarnings("unchecked")

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConnectionService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConnectionService.java
@@ -1,16 +1,17 @@
 package com.linkedin.hoptimator.util;
 
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
 import com.linkedin.hoptimator.Connector;
 import com.linkedin.hoptimator.ConnectorProvider;
 
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Collection;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-import java.sql.SQLException;
 
 public final class ConnectionService {
 
@@ -33,7 +34,6 @@ public final class ConnectionService {
   }
 
   public static <T> Collection<Connector<T>> connectors(Class<T> clazz) {
-    return providers().stream().flatMap(x -> x.connectors(clazz).stream())
-        .collect(Collectors.toList());
+    return providers().stream().flatMap(x -> x.connectors(clazz).stream()).collect(Collectors.toList());
   }
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
@@ -1,24 +1,25 @@
 package com.linkedin.hoptimator.util;
 
-import com.linkedin.hoptimator.Deployable;
-import com.linkedin.hoptimator.Deployer;
-import com.linkedin.hoptimator.DeployerProvider;
-import com.linkedin.hoptimator.util.planner.PipelineRel;
-import com.linkedin.hoptimator.util.planner.PipelineRules;
-
-import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.plan.RelOptPlanner;
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.tools.Program;
-import org.apache.calcite.tools.Programs;
-
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
-import java.sql.SQLException;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+
+import com.linkedin.hoptimator.Deployable;
+import com.linkedin.hoptimator.Deployer;
+import com.linkedin.hoptimator.DeployerProvider;
+import com.linkedin.hoptimator.util.planner.PipelineRel;
+import com.linkedin.hoptimator.util.planner.PipelineRules;
+
 
 public final class DeploymentService {
 
@@ -59,8 +60,7 @@ public final class DeploymentService {
   }
 
   public static <T> Collection<Deployer<T>> deployers(Class<T> clazz) {
-    return providers().stream().flatMap(x -> x.deployers(clazz).stream())
-        .collect(Collectors.toList());
+    return providers().stream().flatMap(x -> x.deployers(clazz).stream()).collect(Collectors.toList());
   }
 
   public static <T> List<Deployable> deployables(T object, Class<T> clazz) {
@@ -95,8 +95,8 @@ public final class DeploymentService {
     RelOptPlanner planner = rel.getCluster().getPlanner();
     PipelineRules.rules().forEach(x -> planner.addRule(x));
     // TODO add materializations here (currently empty list)
-    PipelineRel plan = (PipelineRel) program.run(rel.getCluster().getPlanner(), rel,
-        traitSet, Collections.emptyList(), Collections.emptyList());
+    PipelineRel plan = (PipelineRel) program.run(rel.getCluster().getPlanner(), rel, traitSet, Collections.emptyList(),
+        Collections.emptyList());
     PipelineRel.Implementor implementor = new PipelineRel.Implementor();
     implementor.visit(plan);
     return implementor;

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/HoptimatorJdbcCatalogSchema.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/HoptimatorJdbcCatalogSchema.java
@@ -1,17 +1,18 @@
 package com.linkedin.hoptimator.util;
 
-import com.linkedin.hoptimator.util.planner.HoptimatorJdbcConvention;
+import javax.sql.DataSource;
 
-import org.apache.calcite.adapter.jdbc.JdbcSchema;
 import org.apache.calcite.adapter.jdbc.JdbcCatalogSchema;
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
 import org.apache.calcite.linq4j.tree.Expression;
-import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlDialectFactory;
 import org.apache.calcite.sql.SqlDialectFactoryImpl;
 
-import javax.sql.DataSource;
+import com.linkedin.hoptimator.util.planner.HoptimatorJdbcConvention;
+
 
 public class HoptimatorJdbcCatalogSchema extends JdbcCatalogSchema {
 
@@ -20,19 +21,18 @@ public class HoptimatorJdbcCatalogSchema extends JdbcCatalogSchema {
     super(dataSource, dialect, new HoptimatorJdbcConvention(dialect, expression, name), name);
   }
 
-  public HoptimatorJdbcCatalogSchema(String name, String database, DataSource dataSource,
-      SchemaPlus parentSchema, SqlDialect dialect) {
-    this(name, database, dataSource, dialect, Schemas.subSchemaExpression(parentSchema, name,
-        HoptimatorJdbcCatalogSchema.class));
+  public HoptimatorJdbcCatalogSchema(String name, String database, DataSource dataSource, SchemaPlus parentSchema,
+      SqlDialect dialect) {
+    this(name, database, dataSource, dialect,
+        Schemas.subSchemaExpression(parentSchema, name, HoptimatorJdbcCatalogSchema.class));
   }
 
-  public HoptimatorJdbcCatalogSchema(String name, String database, DataSource dataSource,
-      SchemaPlus parentSchema, SqlDialectFactory dialectFactory) {
+  public HoptimatorJdbcCatalogSchema(String name, String database, DataSource dataSource, SchemaPlus parentSchema,
+      SqlDialectFactory dialectFactory) {
     this(name, database, dataSource, parentSchema, JdbcSchema.createDialect(dialectFactory, dataSource));
   }
 
-  public HoptimatorJdbcCatalogSchema(String name, String database, DataSource dataSource,
-      SchemaPlus parentSchema) {
+  public HoptimatorJdbcCatalogSchema(String name, String database, DataSource dataSource, SchemaPlus parentSchema) {
     this(name, database, dataSource, parentSchema, SqlDialectFactoryImpl.INSTANCE);
   }
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/HoptimatorJdbcSchema.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/HoptimatorJdbcSchema.java
@@ -1,55 +1,52 @@
 package com.linkedin.hoptimator.util;
 
-import com.linkedin.hoptimator.Database;
-import com.linkedin.hoptimator.util.planner.HoptimatorJdbcConvention;
+import javax.sql.DataSource;
 
 import org.apache.calcite.adapter.jdbc.JdbcSchema;
 import org.apache.calcite.linq4j.tree.Expression;
-import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlDialectFactory;
 import org.apache.calcite.sql.SqlDialectFactoryImpl;
 
-import javax.sql.DataSource;
+import com.linkedin.hoptimator.Database;
+import com.linkedin.hoptimator.util.planner.HoptimatorJdbcConvention;
+
 
 public class HoptimatorJdbcSchema extends JdbcSchema implements Database {
 
   private final String database;
 
-  public static HoptimatorJdbcSchema create(String database, String catalog, String schema,
-      DataSource dataSource, SchemaPlus parentSchema, SqlDialect dialect) {
+  public static HoptimatorJdbcSchema create(String database, String catalog, String schema, DataSource dataSource,
+      SchemaPlus parentSchema, SqlDialect dialect) {
     if (dialect == null) {
       return new HoptimatorJdbcSchema(database, catalog, schema, dataSource, parentSchema);
     } else {
-      return new HoptimatorJdbcSchema(database, catalog, schema, dataSource, parentSchema,
-          dialect);
+      return new HoptimatorJdbcSchema(database, catalog, schema, dataSource, parentSchema, dialect);
     }
   }
 
-  public HoptimatorJdbcSchema(String database, String catalog, String schema,
-      DataSource dataSource, SqlDialect dialect, Expression expression) {
+  public HoptimatorJdbcSchema(String database, String catalog, String schema, DataSource dataSource, SqlDialect dialect,
+      Expression expression) {
     super(dataSource, dialect, new HoptimatorJdbcConvention(dialect, expression, database), catalog, schema);
     this.database = database;
   }
 
-  public HoptimatorJdbcSchema(String database, String catalog, String schema,
-      DataSource dataSource, SchemaPlus parentSchema, SqlDialect dialect) {
-    this(database, catalog, schema, dataSource, dialect, Schemas.subSchemaExpression(
-        parentSchema, schema, HoptimatorJdbcSchema.class));
+  public HoptimatorJdbcSchema(String database, String catalog, String schema, DataSource dataSource,
+      SchemaPlus parentSchema, SqlDialect dialect) {
+    this(database, catalog, schema, dataSource, dialect,
+        Schemas.subSchemaExpression(parentSchema, schema, HoptimatorJdbcSchema.class));
   }
 
-  public HoptimatorJdbcSchema(String database, String catalog, String schema,
-      DataSource dataSource, SchemaPlus parentSchema, SqlDialectFactory dialectFactory) {
-    this(database, catalog, schema, dataSource, parentSchema, createDialect(dialectFactory,
-        dataSource));
+  public HoptimatorJdbcSchema(String database, String catalog, String schema, DataSource dataSource,
+      SchemaPlus parentSchema, SqlDialectFactory dialectFactory) {
+    this(database, catalog, schema, dataSource, parentSchema, createDialect(dialectFactory, dataSource));
   }
 
-  public HoptimatorJdbcSchema(String database, String catalog, String schema,
-      DataSource dataSource, SchemaPlus parentSchema) {
-    this(database, catalog, schema, dataSource, parentSchema,
-        SqlDialectFactoryImpl.INSTANCE);
+  public HoptimatorJdbcSchema(String database, String catalog, String schema, DataSource dataSource,
+      SchemaPlus parentSchema) {
+    this(database, catalog, schema, dataSource, parentSchema, SqlDialectFactoryImpl.INSTANCE);
   }
 
   @Override

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Job.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Job.java
@@ -1,10 +1,9 @@
 package com.linkedin.hoptimator.util;
 
+import java.util.function.Function;
+
 import org.apache.calcite.sql.SqlDialect;
 
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 
 public class Job {
 

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/MaterializedView.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/MaterializedView.java
@@ -1,15 +1,13 @@
 package com.linkedin.hoptimator.util;
 
-import com.linkedin.hoptimator.util.planner.Pipeline;
-import com.linkedin.hoptimator.util.planner.ScriptImplementor;
-
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.sql.SqlDialect;
-
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.apache.calcite.sql.SqlDialect;
+
+import com.linkedin.hoptimator.util.planner.Pipeline;
+
 
 public class MaterializedView {
 
@@ -19,8 +17,8 @@ public class MaterializedView {
   private final Function<SqlDialect, String> pipelineSql;
   private final Pipeline pipeline;
 
-  public MaterializedView(String database, List<String> path, String viewSql,
-      Function<SqlDialect, String> pipelineSql, Pipeline pipeline) {
+  public MaterializedView(String database, List<String> path, String viewSql, Function<SqlDialect, String> pipelineSql,
+      Pipeline pipeline) {
     this.database = database;
     this.path = path;
     this.viewSql = viewSql;
@@ -61,7 +59,7 @@ public class MaterializedView {
   protected String pathString() {
     return path.stream().collect(Collectors.joining("."));
   }
- 
+
   @Override
   public String toString() {
     return "MaterializedView[" + pathString() + "]";

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/RemoteRowList.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/RemoteRowList.java
@@ -1,8 +1,9 @@
 package com.linkedin.hoptimator.util;
 
+import java.sql.SQLException;
 import java.util.AbstractCollection;
 import java.util.Iterator;
-import java.sql.SQLException;
+
 
 /** A list of rows corresponding to remote objects behind some API. */
 public class RemoteRowList<T, U> extends AbstractCollection<U> {

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/RemoteTable.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/RemoteTable.java
@@ -1,35 +1,36 @@
 package com.linkedin.hoptimator.util;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.linq4j.Linq4j;
-import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.logical.LogicalTableModify;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.schema.ModifiableTable;
-import org.apache.calcite.schema.TranslatableTable;
-import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.plan.Convention;
-import org.apache.calcite.plan.RelOptTable;
-import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
 
-import java.util.Collection;
-import java.util.List;
 
 /** A table behind some CRUD API */
-public abstract class RemoteTable<T, U> extends AbstractTable implements TranslatableTable, ModifiableTable,
-    RowMapper<T, U> {
+public abstract class RemoteTable<T, U> extends AbstractTable
+    implements TranslatableTable, ModifiableTable, RowMapper<T, U> {
 
   private final Api<T> api;
   private final Class<U> elementType;
@@ -96,10 +97,11 @@ public abstract class RemoteTable<T, U> extends AbstractTable implements Transla
   }
 
   @Override
-  public TableModify toModificationRel(RelOptCluster cluster, RelOptTable table, Prepare.CatalogReader schema, RelNode input,
-      TableModify.Operation operation, List<String> updateColumnList, List<RexNode> sourceExpressionList, boolean flattened) {
+  public TableModify toModificationRel(RelOptCluster cluster, RelOptTable table, Prepare.CatalogReader schema,
+      RelNode input, TableModify.Operation operation, List<String> updateColumnList, List<RexNode> sourceExpressionList,
+      boolean flattened) {
     RelTraitSet traitSet = cluster.traitSetOf(Convention.NONE);
-    return new LogicalTableModify(cluster, traitSet, table, schema, input,
-        operation, updateColumnList, sourceExpressionList, flattened);
+    return new LogicalTableModify(cluster, traitSet, table, schema, input, operation, updateColumnList,
+        sourceExpressionList, flattened);
   }
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/RowMapper.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/RowMapper.java
@@ -3,5 +3,6 @@ package com.linkedin.hoptimator.util;
 public interface RowMapper<T, U> {
 
   U toRow(T t);
+
   T fromRow(U u);
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Sink.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Sink.java
@@ -1,14 +1,14 @@
 package com.linkedin.hoptimator.util;
 
-import org.apache.calcite.rel.type.RelDataType;
-
 import java.util.List;
 import java.util.Map;
 
+import org.apache.calcite.rel.type.RelDataType;
+
+
 public class Sink extends Source {
 
-  public Sink(String database, List<String> path, RelDataType rowType,
-      Map<String, String> options) {
+  public Sink(String database, List<String> path, RelDataType rowType, Map<String, String> options) {
     super(database, path, rowType, options);
   }
 

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Source.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Source.java
@@ -1,17 +1,18 @@
 package com.linkedin.hoptimator.util;
 
-import org.apache.calcite.rel.type.RelDataType;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.apache.calcite.rel.type.RelDataType;
+
 
 public class Source {
 
   private final String database;
   private final List<String> path;
   private final RelDataType rowType;
-  private final Map<String, String> options; 
+  private final Map<String, String> options;
 
   public Source(String database, List<String> path, RelDataType rowType, Map<String, String> options) {
     this.database = database;

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
@@ -1,12 +1,12 @@
 package com.linkedin.hoptimator.util;
 
-import java.util.Locale;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 
 /** A convenient way to generate K8s YAML. */
 public interface Template {
@@ -54,7 +54,7 @@ public interface Template {
     }
 
     public SimpleEnvironment with(String key, String value) {
-      return new SimpleEnvironment(vars){{
+      return new SimpleEnvironment(vars) {{
         export(key, value);
       }};
     }
@@ -66,7 +66,7 @@ public interface Template {
     }
 
     public SimpleEnvironment with(String key, Supplier<String> supplier) {
-      return new SimpleEnvironment(vars){{
+      return new SimpleEnvironment(vars) {{
         export(key, supplier);
       }};
     }
@@ -157,12 +157,12 @@ public interface Template {
     public SimpleTemplate(String template) {
       this.template = template;
     }
-        
+
     @Override
     public String render(Environment env) {
       StringBuffer sb = new StringBuffer();
-      Pattern p = Pattern.compile(
-        "([\\s\\-\\#]*)\\{\\{\\s*([\\w_\\-\\.]+)\\s*(:([\\w_\\-\\.]+))?\\s*((\\w+\\s*)*)\\s*\\}\\}");
+      Pattern p =
+          Pattern.compile("([\\s\\-\\#]*)\\{\\{\\s*([\\w_\\-\\.]+)\\s*(:([\\w_\\-\\.]+))?\\s*((\\w+\\s*)*)\\s*\\}\\}");
       Matcher m = p.matcher(template);
       while (m.find()) {
         String prefix = m.group(1);
@@ -182,7 +182,7 @@ public interface Template {
         String replacement = quotedPrefix + quotedValue.replaceAll("\\n", quotedPrefix);
         m.appendReplacement(sb, replacement);
       }
-      m.appendTail(sb); 
+      m.appendTail(sb);
       return sb.toString();
     }
 
@@ -191,16 +191,16 @@ public interface Template {
       String[] funcs = transform.split("\\W+");
       for (String f : funcs) {
         switch (f) {
-        case "toLowerCase":
-          res = res.toLowerCase(Locale.ROOT);
-          break;
-        case "toUpperCase":
-          res = res.toUpperCase(Locale.ROOT);
-          break;
-        case "concat":
-          res = res.replace("\n", "");
-          break;
-        default:
+          case "toLowerCase":
+            res = res.toLowerCase(Locale.ROOT);
+            break;
+          case "toUpperCase":
+            res = res.toUpperCase(Locale.ROOT);
+            break;
+          case "concat":
+            res = res.replace("\n", "");
+            break;
+          default:
         }
       }
       return res;

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/WrappedSchemaPlus.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/WrappedSchemaPlus.java
@@ -1,8 +1,9 @@
 package com.linkedin.hoptimator.util;
 
+import java.sql.Wrapper;
+
 import org.apache.calcite.schema.SchemaPlus;
 
-import java.sql.Wrapper;
 
 public class WrappedSchemaPlus implements Wrapper {
 

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/HoptimatorJdbcConvention.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/HoptimatorJdbcConvention.java
@@ -5,6 +5,7 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.sql.SqlDialect;
 
+
 public class HoptimatorJdbcConvention extends JdbcConvention {
 
   private final String database;

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/Pipeline.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/Pipeline.java
@@ -1,14 +1,11 @@
 package com.linkedin.hoptimator.util.planner;
 
-import com.linkedin.hoptimator.Deployable;
-
-import org.apache.calcite.sql.SqlDialect;
-import org.apache.calcite.sql.dialect.AnsiSqlDialect;
-
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
-import java.sql.SQLException;
+
+import com.linkedin.hoptimator.Deployable;
+
 
 /**
  * A set of Deployable objects that work together to deliver data.
@@ -40,7 +37,7 @@ public class Pipeline implements Deployable {
     for (Deployable deployable : deployables) {
       deployable.update();
     }
-  } 
+  }
 
   @Override
   public List<String> specify() throws SQLException {

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
@@ -1,11 +1,12 @@
 package com.linkedin.hoptimator.util.planner;
 
-import com.linkedin.hoptimator.Deployable;
-import com.linkedin.hoptimator.util.ConnectionService;
-import com.linkedin.hoptimator.util.DeploymentService;
-import com.linkedin.hoptimator.util.Source;
-import com.linkedin.hoptimator.util.Sink;
-import com.linkedin.hoptimator.util.Job;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptUtil;
@@ -14,13 +15,13 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.util.Litmus;
 
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.sql.SQLException;
+import com.linkedin.hoptimator.Deployable;
+import com.linkedin.hoptimator.util.ConnectionService;
+import com.linkedin.hoptimator.util.DeploymentService;
+import com.linkedin.hoptimator.util.Job;
+import com.linkedin.hoptimator.util.Sink;
+import com.linkedin.hoptimator.util.Source;
+
 
 /**
  * Calling convention which implements a data pipeline.
@@ -57,12 +58,11 @@ public interface PipelineRel extends RelNode {
 
     /**
      * Adds a source to the pipeline.
-     * 
+     *
      * This involves deploying any relevant objects, and configuring a
      * a connector. The connector is configured via `CREATE TABLE...WITH(...)`.
      */
-    public void addSource(String database, List<String> path, RelDataType rowType,
-        Map<String, String> options) {
+    public void addSource(String database, List<String> path, RelDataType rowType, Map<String, String> options) {
       sources.add(new Source(database, path, rowType, options));
     }
 
@@ -72,8 +72,7 @@ public interface PipelineRel extends RelNode {
      * By default, the sink is `PIPELINE.SINK`. An expected row type is required
      * for validation purposes.
      */
-    public void setSink(String database, List<String> path, RelDataType rowType,
-        Map<String, String> options) {
+    public void setSink(String database, List<String> path, RelDataType rowType, Map<String, String> options) {
       this.sinkDatabase = database;
       this.sinkPath = path;
       this.sinkRowType = rowType;

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/ScriptImplementor.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/ScriptImplementor.java
@@ -1,17 +1,23 @@
 package com.linkedin.hoptimator.util.planner;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.rel.rel2sql.SqlImplementor;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
-import org.apache.calcite.sql.SqlWriter;
-import org.apache.calcite.sql.SqlWriterConfig;
-import org.apache.calcite.sql.SqlDataTypeSpec;
-import org.apache.calcite.sql.SqlCollectionTypeNameSpec;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCollectionTypeNameSpec;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -19,6 +25,8 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlRowTypeNameSpec;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.sql.fun.SqlRowOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -26,13 +34,6 @@ import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
 
-import java.util.Map;
-import java.util.List;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.Optional;
 
 /**
  * An abstract way to write SQL scripts.
@@ -61,7 +62,8 @@ public interface ScriptImplementor {
 
   /** Construct an empty ScriptImplementor */
   static ScriptImplementor empty() {
-    return w -> { };
+    return w -> {
+    };
   }
 
   /** Append a subsequent ScriptImplementor */
@@ -78,8 +80,7 @@ public interface ScriptImplementor {
   }
 
   /** Append a connector definition, e.g. `CREATE TABLE ... WITH (...)` */
-  default ScriptImplementor connector(String name, RelDataType rowType,
-      Map<String, String> connectorConfig) {
+  default ScriptImplementor connector(String name, RelDataType rowType, Map<String, String> connectorConfig) {
     return with(new ConnectorImplementor(name, rowType, connectorConfig));
   }
 
@@ -93,7 +94,7 @@ public interface ScriptImplementor {
     return with(new InsertImplementor(name, relNode));
   }
 
-  /** Render the script as DDL/SQL in the default dialect */ 
+  /** Render the script as DDL/SQL in the default dialect */
   default String sql() {
     return sql(AnsiSqlDialect.DEFAULT);
   }
@@ -102,8 +103,7 @@ public interface ScriptImplementor {
   default String sql(SqlDialect dialect) {
     SqlWriter w = new SqlPrettyWriter(SqlWriterConfig.of().withDialect(dialect));
     implement(w);
-    return w.toSqlString().getSql()
-      .replaceAll("\\n", " ").replaceAll("\\s*;\\s*", ";\n").trim();
+    return w.toSqlString().getSql().replaceAll("\\n", " ").replaceAll("\\s*;\\s*", ";\n").trim();
   }
 
   /** Generate SQL for a given dialect */
@@ -124,8 +124,8 @@ public interface ScriptImplementor {
       RelToSqlConverter converter = new RelToSqlConverter(w.getDialect());
       w.literal(converter.visitRoot(relNode).asStatement().toSqlString(w.getDialect()).getSql());
       w.literal(";");
-    }  
-  } 
+    }
+  }
 
   /** Implements an arbitrary RelNode as a query */
   class QueryImplementor implements ScriptImplementor {
@@ -155,8 +155,7 @@ public interface ScriptImplementor {
       public SqlNode visit(SqlCall call) {
         List<SqlNode> operands = call.getOperandList().stream().map(x -> x.accept(this)).collect(Collectors.toList());
         if ((call.getKind() == SqlKind.ROW || call.getKind() == SqlKind.COLUMN_LIST
-              || call.getOperator() instanceof SqlRowOperator)
-              && operands.size() > 1) {
+            || call.getOperator() instanceof SqlRowOperator) && operands.size() > 1) {
           return IMPLIED_ROW_OPERATOR.createCall(call.getParserPosition(), operands);
         } else {
           return call.getOperator().createCall(call.getParserPosition(), operands);
@@ -177,8 +176,7 @@ public interface ScriptImplementor {
     private final RelDataType rowType;
     private final Map<String, String> connectorConfig;
 
-    public ConnectorImplementor(String name, RelDataType rowType,
-        Map<String, String> connectorConfig) {
+    public ConnectorImplementor(String name, RelDataType rowType, Map<String, String> connectorConfig) {
       this.name = name;
       this.rowType = rowType;
       this.connectorConfig = connectorConfig;
@@ -315,7 +313,6 @@ public interface ScriptImplementor {
     }
   }
 
-
   /** Implements row type specs, e.g. `NAME VARCHAR(20), AGE INTEGER`.
    *
    * N.B. the following magic:
@@ -330,14 +327,13 @@ public interface ScriptImplementor {
 
     @Override
     public void implement(SqlWriter w) {
-      List<SqlIdentifier> fieldNames = dataType.getFieldList().stream()
+      List<SqlIdentifier> fieldNames = dataType.getFieldList()
+          .stream()
           .map(x -> x.getName())
           .map(x -> new SqlIdentifier(x, SqlParserPos.ZERO))
           .collect(Collectors.toList());
-      List<SqlDataTypeSpec> fieldTypes = dataType.getFieldList().stream()
-          .map(x -> x.getType())
-          .map(x -> toSpec(x))
-          .collect(Collectors.toList());
+      List<SqlDataTypeSpec> fieldTypes =
+          dataType.getFieldList().stream().map(x -> x.getType()).map(x -> toSpec(x)).collect(Collectors.toList());
       for (int i = 0; i < fieldNames.size(); i++) {
         w.sep(",");
         fieldNames.get(i).unparse(w, 0, 0);
@@ -346,29 +342,30 @@ public interface ScriptImplementor {
         } else {
           fieldTypes.get(i).unparse(w, 0, 0);
         }
-      } 
+      }
     }
 
     private static SqlDataTypeSpec toSpec(RelDataType dataType) {
       if (dataType.isStruct()) {
-        List<SqlIdentifier> fieldNames = dataType.getFieldList().stream()
+        List<SqlIdentifier> fieldNames = dataType.getFieldList()
+            .stream()
             .map(x -> x.getName())
             .map(x -> new SqlIdentifier(x, SqlParserPos.ZERO))
             .collect(Collectors.toList());
-        List<SqlDataTypeSpec> fieldTypes = dataType.getFieldList().stream()
-            .map(x -> x.getType())
-            .map(x -> toSpec(x))
-            .collect(Collectors.toList());
-        return maybeNullable(dataType, new SqlDataTypeSpec(new SqlRowTypeNameSpec(SqlParserPos.ZERO, fieldNames, fieldTypes), SqlParserPos.ZERO));
+        List<SqlDataTypeSpec> fieldTypes =
+            dataType.getFieldList().stream().map(x -> x.getType()).map(x -> toSpec(x)).collect(Collectors.toList());
+        return maybeNullable(dataType,
+            new SqlDataTypeSpec(new SqlRowTypeNameSpec(SqlParserPos.ZERO, fieldNames, fieldTypes), SqlParserPos.ZERO));
       } else if (dataType.getComponentType() != null) {
-        return maybeNullable(dataType, new SqlDataTypeSpec(new SqlCollectionTypeNameSpec(
-            new SqlBasicTypeNameSpec(Optional.ofNullable(dataType.getComponentType())
-            .map(x -> x.getSqlTypeName()).orElseThrow(
-            () -> new IllegalArgumentException("not a collection?")), SqlParserPos.ZERO),
-            dataType.getSqlTypeName(), SqlParserPos.ZERO),
-            SqlParserPos.ZERO));
+        return maybeNullable(dataType, new SqlDataTypeSpec(new SqlCollectionTypeNameSpec(new SqlBasicTypeNameSpec(
+            Optional.ofNullable(dataType.getComponentType())
+                .map(x -> x.getSqlTypeName())
+                .orElseThrow(() -> new IllegalArgumentException("not a collection?")), SqlParserPos.ZERO),
+            dataType.getSqlTypeName(), SqlParserPos.ZERO), SqlParserPos.ZERO));
       } else {
-        return maybeNullable(dataType, new SqlDataTypeSpec(new SqlBasicTypeNameSpec(dataType.getSqlTypeName(), SqlParserPos.ZERO), SqlParserPos.ZERO));
+        return maybeNullable(dataType,
+            new SqlDataTypeSpec(new SqlBasicTypeNameSpec(dataType.getSqlTypeName(), SqlParserPos.ZERO),
+                SqlParserPos.ZERO));
       }
     }
 
@@ -400,10 +397,10 @@ public interface ScriptImplementor {
           .map(x -> x.getName())
           .map(x -> new SqlIdentifier(x, SqlParserPos.ZERO))
           .collect(Collectors.toList());
-     for (int i = 0; i < fieldNames.size(); i++) {
+      for (int i = 0; i < fieldNames.size(); i++) {
         w.sep(",");
         fieldNames.get(i).unparse(w, 0, 0);
-      } 
+      }
     }
   }
 
@@ -422,5 +419,5 @@ public interface ScriptImplementor {
         w.literal("'" + k + "'='" + v + "'");
       });
     }
-  } 
+  }
 }


### PR DESCRIPTION
Reformatted Makefile to group deploy/undeploy commands.
Added `undeploy-dev-environment` target to Makefile to remove all of the Kafka/Flink resources in the correct order.

Exposed a new internal port via Kafka to allow use of the Kafka CLI to produce/consume messages:
```
  $ kubectl -n kafka run kafka-producer -ti --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server one-kafka-bootstrap:9094 --topic my-topic
  $ kubectl -n kafka run kafka-consumer -ti --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server one-kafka-bootstrap:9094 --topic my-topic --from-beginning
```