### PR TITLE
Publish hoptimator-jdbc

### DIFF
--- a/hoptimator-jdbc/build.gradle
+++ b/hoptimator-jdbc/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'java'
   id 'java-test-fixtures'
+  id 'maven-publish'
 }
 
 dependencies {
@@ -51,4 +52,49 @@ tasks.register('intTest', Test) {
 java {
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
+}
+
+publishing {
+  repositories {
+    maven {
+      name 'GitHubPackages'
+      url = 'https://maven.pkg.github.com/linkedin/Hoptimator'
+      credentials {
+        username = System.getenv('GITHUB_ACTOR')
+        password = System.getenv('GITHUB_TOKEN')
+      }
+    }
+    maven {
+      name 'LinkedInJFrog'
+      url 'https://linkedin.jfrog.io/artifactory/hoptimator'
+      credentials {
+        username = System.getenv('JFROG_USERNAME')
+        password = System.getenv('JFROG_API_KEY')
+      }
+    }
+  }
+  publications {
+    maven(MavenPublication) {
+      groupId = 'com.linkedin.hoptimator'
+      artifactId = 'hoptimator-jdbc'
+      version = System.getenv('VERSION')
+      from components.java
+      pom {
+        name = 'LinkedIn Hoptimator'
+        description = 'Multi-hop declarative data pipelines'
+        url = 'https://github.com/linkedin/Hoptimator'
+        licenses {
+          license {
+            name = 'BSD 2-Clause'
+            url = 'https://raw.githubusercontent.com/linkedin/Hoptimator/main/LICENSE'
+          }
+        }
+        scm {
+          connection = 'scm:git:git://github.com:linkedin/Hoptimator.git'
+          developerConnection = 'scm:git:ssh://github.com:linkedin/Hoptimator.git'
+          url = 'https://github.com/linkedin/Hoptimator'
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Right now we are only publishing hoptimator-jdbc-driver as a fat jar bundling dependencies needed for the CLI. We are getting failures promoting several packages because hoptimator-jdbc by itself is missing, which is depended upon by hoptimator-k8s