### PR TITLE
Support Venice Primitive keys

### DIFF
--- a/deploy/samples/venicedb.yaml
+++ b/deploy/samples/venicedb.yaml
@@ -20,6 +20,7 @@ spec:
     connector = venice
     storeName = {{table}}
     partial-update-mode = true
-    key.fields-prefix = KEY_
-    key.fields = {{keys}}
+    key.fields-prefix = {{keyPrefix:}}
+    key.fields = {{keys:KEY}}
+    key.type = {{keyType:PRIMITIVE}}
     value.fields-include: EXCEPT_KEY

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
@@ -28,7 +28,7 @@ class K8sConnector implements Connector<Source> {
   @Override
   public Map<String, String> configure(Source source) throws SQLException {
     Template.Environment env =
-        Template.Environment.EMPTY.with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
+        new Template.SimpleEnvironment().with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
             .with("database", source.database())
             .with("table", source.table())
             .with(source.options());

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -26,7 +26,7 @@ class K8sJobDeployer extends K8sYamlDeployer<Job> {
   @Override
   public List<String> specify(Job job) throws SQLException {
     Function<SqlDialect, String> sql = job.sql();
-    Template.Environment env = Template.Environment.EMPTY.with("name",
+    Template.Environment env = new Template.SimpleEnvironment().with("name",
             job.sink().database() + "-" + job.sink().table().toLowerCase(Locale.ROOT))
         .with("database", job.sink().database())
         .with("schema", job.sink().schema())

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSourceDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSourceDeployer.java
@@ -24,7 +24,7 @@ class K8sSourceDeployer extends K8sYamlDeployer<Source> {
   @Override
   public List<String> specify(Source source) throws SQLException {
     Template.Environment env =
-        Template.Environment.EMPTY.with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
+        new Template.SimpleEnvironment().with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
             .with("database", source.database())
             .with("schema", source.schema())
             .with("table", source.table())

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
@@ -162,7 +162,7 @@ public interface Template {
     public String render(Environment env) {
       StringBuffer sb = new StringBuffer();
       Pattern p =
-          Pattern.compile("([\\s\\-\\#]*)\\{\\{\\s*([\\w_\\-\\.]+)\\s*(:([\\w_\\-\\.]+))?\\s*((\\w+\\s*)*)\\s*\\}\\}");
+          Pattern.compile("([\\s\\-\\#]*)\\{\\{\\s*([\\w_\\-\\.]+)\\s*(:([\\w_\\-\\.]*))?\\s*((\\w+\\s*)*)\\s*\\}\\}");
       Matcher m = p.matcher(template);
       while (m.find()) {
         String prefix = m.group(1);

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
@@ -1,0 +1,44 @@
+package com.linkedin.hoptimator.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestTemplate {
+
+  @Test
+  public void testRender() {
+    Template.Environment env =
+        Template.Environment.EMPTY
+            .with("name", "name")
+            .with("nameUpper", "name")
+            .with("nameLower", "NAME")
+            .with("multiline", "1\n2\n3\n")
+            .with("multilineUpper", "a\nb\nc\n")
+            .with("other", "test");
+
+    String template = "{{keys:KEY}}\n"
+        + "{{keyPrefix:}}\n"
+        + "{{name:default}}\n"
+        + "{{nameUpper toUpperCase}}\n"
+        + "{{nameLower toLowerCase}}\n"
+        + "{{multiline concat}}\n"
+        + "{{multilineUpper concat toUpperCase}}\n"
+        + "{{other unknown}}\n";
+
+    String renderedTemplate = new Template.SimpleTemplate(template).render(env);
+    List<String> renderedTemplates = Arrays.asList(renderedTemplate.split("\n"));
+    assertEquals(8, renderedTemplates.size());
+    assertEquals("KEY", renderedTemplates.get(0));
+    assertEquals("", renderedTemplates.get(1));
+    assertEquals("name", renderedTemplates.get(2));
+    assertEquals("NAME", renderedTemplates.get(3));
+    assertEquals("name", renderedTemplates.get(4));
+    assertEquals("123", renderedTemplates.get(5));
+    assertEquals("ABC", renderedTemplates.get(6));
+    assertEquals("test", renderedTemplates.get(7));
+  }
+}

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
@@ -11,8 +11,7 @@ public class TestTemplate {
 
   @Test
   public void testRender() {
-    Template.Environment env =
-        Template.Environment.EMPTY
+    Template.Environment env = new Template.SimpleEnvironment()
             .with("name", "name")
             .with("nameUpper", "name")
             .with("nameLower", "NAME")

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/TestPipelineRel.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/TestPipelineRel.java
@@ -1,0 +1,39 @@
+package com.linkedin.hoptimator.util.planner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+
+import static com.linkedin.hoptimator.util.planner.PipelineRel.Implementor.addKeysAsOption;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestPipelineRel {
+
+  @Test
+  public void testKeyOptions() {
+    RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataTypeFactory.Builder primitiveKeyBuilder = new RelDataTypeFactory.Builder(typeFactory);
+    primitiveKeyBuilder.add("KEY", SqlTypeName.VARCHAR);
+    primitiveKeyBuilder.add("intField", SqlTypeName.INTEGER);
+    Map<String, String> keyOptions = addKeysAsOption(new HashMap<>(), primitiveKeyBuilder.build());
+    assertTrue(keyOptions.isEmpty());
+
+    RelDataTypeFactory.Builder keyBuilder = new RelDataTypeFactory.Builder(typeFactory);
+    keyBuilder.add("keyInt", SqlTypeName.INTEGER);
+    keyBuilder.add("keyString", SqlTypeName.VARCHAR);
+    RelDataTypeFactory.Builder recordBuilder = new RelDataTypeFactory.Builder(typeFactory);
+    recordBuilder.add("intField", SqlTypeName.INTEGER);
+    recordBuilder.add("KEY", keyBuilder.build());
+    keyOptions = addKeysAsOption(new HashMap<>(), recordBuilder.build());
+    assertEquals(3, keyOptions.size());
+    assertEquals("KEY_keyInt;KEY_keyString", keyOptions.get("keys"));
+    assertEquals("KEY_", keyOptions.get("keyPrefix"));
+    assertEquals("RECORD", keyOptions.get("keyType"));
+  }
+}


### PR DESCRIPTION
- Support Primitive Venice Keys
- Add Template option for empty string defaults
- Add template & key option testing


Global templates were causing problems with keys getting overwritten, see example below:

Without change:
```
0: Hoptimator> !pipeline insert into "VENICE-CLUSTER0"."test-store" ("KEY$id", "intField") select "KEY", "intField" from "VENICE-CLUSTER0"."test-store-primitive"
CREATE TABLE IF NOT EXISTS `test-store-primitive` (`intField` INTEGER, `stringField` VARCHAR, `KEY` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-primitive', 'value.fields-include'='EXCEPT_KEY');
CREATE TABLE IF NOT EXISTS `test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY');
INSERT INTO `test-store` (`intField`, `KEY_id`) SELECT `intField`, `KEY` AS `KEY_id` FROM `VENICE-CLUSTER0`.`test-store-primitive`;
```

With change:
```
0: Hoptimator> !pipeline insert into "VENICE-CLUSTER0"."test-store" ("KEY$id", "intField") select "KEY", "intField" from "VENICE-CLUSTER0"."test-store-primitive"
CREATE TABLE IF NOT EXISTS `test-store-primitive` (`intField` INTEGER, `stringField` VARCHAR, `KEY` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY', 'key.fields-prefix'='', 'key.type'='PRIMITIVE', 'partial-update-mode'='true', 'storeName'='test-store-primitive', 'value.fields-include'='EXCEPT_KEY');
CREATE TABLE IF NOT EXISTS `test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY');
INSERT INTO `test-store` (`intField`, `KEY_id`) SELECT `intField`, `KEY` AS `KEY_id` FROM `VENICE-CLUSTER0`.`test-store-primitive`;
```