### PR TITLE
Fix various issues with SQL generation, flink job routing, integration-tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,15 +34,27 @@ jobs:
         kind load docker-image hoptimator-flink-runner
         kind load docker-image hoptimator-flink-operator
     - name: Run Integration Tests
-      run: make integration-tests
+      run: make integration-tests-kind
+    - name: Capture Integration Reports
+      if: failure()
+      uses: actions/upload-artifact@v4.6.0
+      with:
+        name: reports
+        path: |
+          **/build/reports/tests/intTest/
     - name: Capture Cluster State
       if: always()
       run: |
-        kubectl describe pods
-        kubectl describe deployments
-        kubectl describe kafkas -n kafka
-        kubectl describe flinkdeployments
-        kubectl describe subscriptions
+        kubectl get pods
+        kubectl get svc
+        kubectl get deployments
+        kubectl get pods -n kafka
+        kubectl get svc -n kafka
+        kubectl get deployments -n kafka
+        kubectl get kafkas -n kafka
+        kubectl get flinkdeployments
+        kubectl get subscriptions
+        kubectl get pipelines
     - name: Capture Flink Job Logs
       if: always()
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,14 +33,6 @@ jobs:
         kind load docker-image hoptimator
         kind load docker-image hoptimator-flink-runner
         kind load docker-image hoptimator-flink-operator
-    - name: Deploy Dev Environment
-      run: make deploy-dev-environment
-    - name: Deploy Hoptimator
-      run: make deploy
-    - name: Deploy Samples
-      run: make deploy-samples
-    - name: Wait for Readiness
-      run: kubectl wait kafka/one --for=condition=Ready --timeout=10m -n kafka
     - name: Run Integration Tests
       run: make integration-tests
     - name: Capture Cluster State

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM eclipse-temurin:18
 WORKDIR /home/
 ADD ./hoptimator-operator-integration/build/distributions/hoptimator-operator-integration.tar ./
 ADD ./etc/* ./
+ENV POD_NAMESPACE_FILEPATH=/var/run/secrets/kubernetes.io/serviceaccount/namespace
 ENTRYPOINT ["/bin/sh", "-c"]
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The below setup will create a dev environment with various resources within Kube
 ```
   $ make install                                                    # build and install SQL CLI
   $ make deploy-dev-environment                                     # start all local dev setups
-  $ kubectl port-forward -n kafka svc/one-kafka-external-0 9092 &   # forward external Kafka port for use by SQL CLI
+  $ kubectl port-forward -n kafka svc/one-kafka-external-bootstrap 9092 &   # forward external Kafka port for use by SQL CLI
   $ ./hoptimator                                                    # start the SQL CLI
   > !intro
 ```

--- a/deploy/dev/kafka.yaml
+++ b/deploy/dev/kafka.yaml
@@ -41,9 +41,12 @@ spec:
         type: nodeport
         tls: false
         configuration:
+          bootstrap:
+            nodePort: 31092
           brokers:
           - broker: 0
-            advertisedHost: localhost
+            advertisedHost: 127.0.0.1
+            nodePort: 31234
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1

--- a/deploy/dev/kafka.yaml
+++ b/deploy/dev/kafka.yaml
@@ -30,6 +30,8 @@ spec:
         port: 9094
         type: internal
         tls: false
+        configuration:
+          useServiceDnsDomain: true
       - name: tls
         port: 9093
         type: internal

--- a/deploy/dev/rbac.yaml
+++ b/deploy/dev/rbac.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: hoptimator-operator
   namespace: default
@@ -8,6 +8,6 @@ subjects:
   name: hoptimator-operator
   namespace: default
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: hoptimator-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/docker/venice/docker-compose-single-dc-setup.yaml
+++ b/deploy/docker/venice/docker-compose-single-dc-setup.yaml
@@ -16,6 +16,8 @@ services:
     hostname: kafka
     environment:
       - ZOOKEEPER_ADDRESS=zookeeper:2181
+    ports:
+      - 9095:9092
     depends_on:
       zookeeper:
         condition: service_healthy

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,16 +1,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   namespace: default
   name: hoptimator-operator
 rules:
 - apiGroups: ["hoptimator.linkedin.com"]
-  resources: ["acls", "kafkatopics", "subscriptions", "sqljobs"]
+  resources: ["acls", "kafkatopics", "subscriptions", "sqljobs", "pipelines"]
   verbs: ["get", "watch", "list", "update", "create"]
 - apiGroups: ["hoptimator.linkedin.com"]
-  resources: ["kafkatopics/status", "subscriptions/status", "acls/status", "sqljobs/status"]
+  resources: ["kafkatopics/status", "subscriptions/status", "acls/status", "sqljobs/status", "pipelines/status"]
   verbs: ["get", "patch"]
 - apiGroups: ["flink.apache.org"]
-  resources: ["flinkdeployments"]
+  resources: ["flinkdeployments", "flinksessionjobs"]
   verbs: ["get", "update", "create"]
 

--- a/deploy/samples/flinkDeployment.yaml
+++ b/deploy/samples/flinkDeployment.yaml
@@ -3,10 +3,11 @@ kind: FlinkDeployment
 metadata:
   name: basic-session-deployment
 spec:
-  image: flink:1.18
+  image: docker.io/library/hoptimator-flink-runner
+  imagePullPolicy: Never
   flinkVersion: v1_18
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "1"
+    taskmanager.numberOfTaskSlots: "3"
   serviceAccount: flink
   jobManager:
     resource:

--- a/deploy/samples/kafkadb.yaml
+++ b/deploy/samples/kafkadb.yaml
@@ -34,7 +34,9 @@ spec:
   connector: |
     connector = kafka
     topic = {{table}}
-    properties.bootstrap.servers = localhost:9092
+    properties.bootstrap.servers = one-kafka-bootstrap.kafka.svc.cluster.local:9094
+    value.format = json
+    scan.startup.mode = earliest-offset
 
 ---
 

--- a/etc/cluster.yaml
+++ b/etc/cluster.yaml
@@ -2,5 +2,17 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 # Additional worker nodes will not add any real resource capacity. However,
 # it should mean that there are more CPU reservations to hand out.
+networking:
+  ipFamily: ipv4
+  apiServerAddress: 127.0.0.1
 nodes:
 - role: control-plane
+  extraPortMappings:
+    - containerPort: 31092
+      hostPort: 9092
+      listenAddress: "127.0.0.1"
+      protocol: TCP
+    - containerPort: 31234
+      hostPort: 31234
+      listenAddress: "127.0.0.1"
+      protocol: TCP

--- a/hoptimator-kafka/src/test/resources/kafka-ddl.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl.id
@@ -7,14 +7,14 @@ kind: FlinkSessionJob
 metadata:
   name: kafka-database-existing-topic-1
 spec:
-  deploymentName: basic-session-deployment-example
+  deploymentName: basic-session-deployment
   job:
     entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
     args:
-    - CREATE TABLE IF NOT EXISTS `existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='localhost:9092', 'topic'='existing-topic-2')
-    - CREATE TABLE IF NOT EXISTS `existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='localhost:9092', 'topic'='existing-topic-1')
-    - INSERT INTO `existing-topic-1` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`
-    jarURI: local:///opt/hoptimator-flink-runner.jar
+    - CREATE TABLE IF NOT EXISTS `existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.format'='json')
+    - CREATE TABLE IF NOT EXISTS `existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.format'='json')
+    - INSERT INTO `existing-topic-1` (`KEY`, `VALUE`) SELECT * FROM `existing-topic-2`
+    jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless
     state: running

--- a/hoptimator-operator-integration/build.gradle
+++ b/hoptimator-operator-integration/build.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   implementation project(':hoptimator-operator')
   implementation libs.slf4j.simple
-  
+
   testImplementation libs.junit
   testImplementation libs.assertj
 }

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/PipelineOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/PipelineOperatorApp.java
@@ -16,7 +16,7 @@ import com.linkedin.hoptimator.operator.pipeline.PipelineReconciler;
 
 
 public class PipelineOperatorApp {
-  private static final Logger log = LoggerFactory.getLogger(HoptimatorOperatorApp.class);
+  private static final Logger log = LoggerFactory.getLogger(PipelineOperatorApp.class);
 
   public static void main(String[] args) throws Exception {
     new PipelineOperatorApp().run();

--- a/hoptimator-venice/src/test/resources/venice-ddl-insert-all.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-insert-all.id
@@ -13,8 +13,8 @@ spec:
     args:
     - CREATE TABLE IF NOT EXISTS `test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY')
     - CREATE TABLE IF NOT EXISTS `test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
-    - INSERT INTO `test-store-1` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `VENICE-CLUSTER0`.`test-store`
-    jarURI: local:///opt/hoptimator-flink-runner.jar
+    - INSERT INTO `test-store-1` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `test-store`
+    jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless
     state: running

--- a/hoptimator-venice/src/test/resources/venice-ddl-insert-partial.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-insert-partial.id
@@ -13,8 +13,8 @@ spec:
     args:
     - CREATE TABLE IF NOT EXISTS `test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY')
     - CREATE TABLE IF NOT EXISTS `test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
-    - INSERT INTO `test-store-1` (`intField`, `KEY_id`) SELECT CAST(`stringField` AS SIGNED) AS `intField`, `KEY_id` FROM `VENICE-CLUSTER0`.`test-store`
-    jarURI: local:///opt/hoptimator-flink-runner.jar
+    - INSERT INTO `test-store-1` (`intField`, `KEY_id`) SELECT CAST(`stringField` AS SIGNED) AS `intField`, `KEY_id` FROM `test-store`
+    jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless
     state: running

--- a/hoptimator-venice/src/test/resources/venice-ddl-select.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-select.id
@@ -13,8 +13,8 @@ spec:
     args:
     - CREATE TABLE IF NOT EXISTS `test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
     - CREATE TABLE IF NOT EXISTS `SINK` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ()
-    - INSERT INTO `SINK` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `VENICE-CLUSTER0`.`test-store-1`
-    jarURI: local:///opt/hoptimator-flink-runner.jar
+    - INSERT INTO `SINK` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `test-store-1`
+    jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless
     state: running


### PR DESCRIPTION
- Fixed issue with FLINK SQL syntax where query table: `KAFKA`.`existing-topic-2` should have just been `existing-topic-2`.
- Got deployment of Flink jobs working through Flink deployment cluster
  - Updated Flink connector options in `kafkadb.yaml` to the minimum required set needed to pass through to Flink
  - Needed to change Kafka connection mechanism. Connection on the command line using the forwarded port 9092 works via localhost to the 'external' strimzi cluster. However, this doesn't work for k8s pod to pod communication (Flink deployment pod -> Kafka cluster), pod connections need to use the 'internal' strimzi connection mechanisms `one-kafka-bootstrap.kafka.svc.cluster.local:9094`.
- Integration tests has apparently always been failing but were incorrectly showing as passing due to the `... || kill cat port-forward.pid` bit.
  - Fixed kind cluster routing that was causing these failures, also removes the ability to false report passing.
  - Added artifacts to the integration test workflow so on failure you can download the failure report since errors aren't printed to the terminal.
- hoptimator-operator was failing on startup because of two separate issues:
  - rbac was missing the "pipelines" resources
  - The hoptimator-operator K8s pod doesn't have access to .kube/config, needed its own mechanism to determine namespace information.

Testing:

Set up flink datagen connector to generate data and insert it into existing-topic-1.
Ran:
```
0: Hoptimator> create or replace materialized view kafka."existing-topic-2" as select * from kafka."existing-topic-1";
```
which setup a new Flink job to insert the data from existing-topic-1 into existing-topic-2. Was able to verify the data was inserted via CLI Kafka consumer.

Put many helpful commands in the README

Also `make integration-tests-kind` works locally as well if you setup a kind cluster locally.