### PR TITLE
Fix compound identifier bug

### DIFF
--- a/hoptimator-kafka/src/test/resources/kafka-ddl.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl.id
@@ -12,9 +12,11 @@ spec:
   job:
     entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
     args:
-    - CREATE TABLE IF NOT EXISTS `existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.format'='json')
-    - CREATE TABLE IF NOT EXISTS `existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.format'='json')
-    - INSERT INTO `existing-topic-1` (`KEY`, `VALUE`) SELECT * FROM `existing-topic-2`
+    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ()
+    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.format'='json')
+    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ()
+    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.format'='json')
+    - INSERT INTO `KAFKA`.`existing-topic-1` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`
     jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
@@ -148,8 +148,9 @@ public interface PipelineRel extends RelNode {
     private ScriptImplementor script() throws SQLException {
       ScriptImplementor script = ScriptImplementor.empty();
       for (Map.Entry<Source, RelDataType> source : sources.entrySet()) {
+        script = script.database(source.getKey().schema());
         Map<String, String> configs = ConnectionService.configure(source.getKey(), Source.class);
-        script = script.connector(source.getKey().table(), source.getValue(), configs);
+        script = script.connector(source.getKey().schema(), source.getKey().table(), source.getValue(), configs);
       }
       return script;
     }
@@ -163,8 +164,9 @@ public interface PipelineRel extends RelNode {
       }
       Sink sink = new Sink(sinkDatabase, sinkPath, sinkOptions);
       Map<String, String> sinkConfigs = ConnectionService.configure(sink, Sink.class);
-      script = script.connector(sink.table(), targetRowType, sinkConfigs);
-      script = script.insert(sink.table(), query, targetFields);
+      script = script.database(sink.schema());
+      script = script.connector(sink.schema(), sink.table(), targetRowType, sinkConfigs);
+      script = script.insert(sink.schema(), sink.table(), query, targetFields);
       RelOptUtil.equal(sink.table(), targetRowType, "pipeline", query.getRowType(), Litmus.THROW);
       return script.seal();
     }

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestDataTypeUtils.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestDataTypeUtils.java
@@ -41,13 +41,13 @@ public class TestDataTypeUtils {
         flattenedNames);
     RelDataType unflattenedType = DataTypeUtils.unflatten(flattenedType, typeFactory);
     RelOptUtil.eq("original", rowType, "flattened-unflattened", unflattenedType, Litmus.THROW);
-    String originalConnector = new ScriptImplementor.ConnectorImplementor("T1",
+    String originalConnector = new ScriptImplementor.ConnectorImplementor("S", "T1",
         rowType, Collections.emptyMap()).sql();
-    String unflattenedConnector = new ScriptImplementor.ConnectorImplementor("T1",
+    String unflattenedConnector = new ScriptImplementor.ConnectorImplementor("S", "T1",
         unflattenedType, Collections.emptyMap()).sql();
     Assertions.assertEquals(originalConnector, unflattenedConnector,
         "Flattening and unflattening data types should have no impact on connector");
-    Assertions.assertEquals("CREATE TABLE IF NOT EXISTS `T1` (`FOO` ROW(`QUX` VARCHAR, "
+    Assertions.assertEquals("CREATE TABLE IF NOT EXISTS `S`.`T1` (`FOO` ROW(`QUX` VARCHAR, "
         + "`QIZ` VARCHAR), `BAR` ROW(`BAZ` VARCHAR)) WITH ();", unflattenedConnector,
         "Flattened-unflattened connector should be correct");
   }
@@ -71,9 +71,9 @@ public class TestDataTypeUtils {
         .collect(Collectors.toList());
     Assertions.assertIterableEquals(Arrays.asList(new String[]{"FOO", "BAR"}),
         flattenedNames);
-    String flattenedConnector = new ScriptImplementor.ConnectorImplementor("T1",
+    String flattenedConnector = new ScriptImplementor.ConnectorImplementor("S", "T1",
         flattenedType, Collections.emptyMap()).sql();
-    Assertions.assertEquals("CREATE TABLE IF NOT EXISTS `T1` (`FOO` ANY ARRAY, "
+    Assertions.assertEquals("CREATE TABLE IF NOT EXISTS `S`.`T1` (`FOO` ANY ARRAY, "
         + "`BAR` ANY ARRAY) WITH ();", flattenedConnector,
         "Flattened connector should have simplified arrays");
   }

--- a/hoptimator-venice/src/test/resources/venice-ddl-insert-all.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-insert-all.id
@@ -12,9 +12,11 @@ spec:
   job:
     entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
     args:
-    - CREATE TABLE IF NOT EXISTS `test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY')
-    - CREATE TABLE IF NOT EXISTS `test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
-    - INSERT INTO `test-store-1` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `test-store`
+    - CREATE DATABASE IF NOT EXISTS `VENICE-CLUSTER0` WITH ()
+    - CREATE TABLE IF NOT EXISTS `VENICE-CLUSTER0`.`test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY')
+    - CREATE DATABASE IF NOT EXISTS `VENICE-CLUSTER0` WITH ()
+    - CREATE TABLE IF NOT EXISTS `VENICE-CLUSTER0`.`test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
+    - INSERT INTO `VENICE-CLUSTER0`.`test-store-1` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `VENICE-CLUSTER0`.`test-store`
     jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless

--- a/hoptimator-venice/src/test/resources/venice-ddl-insert-partial.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-insert-partial.id
@@ -12,9 +12,11 @@ spec:
   job:
     entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
     args:
-    - CREATE TABLE IF NOT EXISTS `test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY')
-    - CREATE TABLE IF NOT EXISTS `test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
-    - INSERT INTO `test-store-1` (`intField`, `KEY_id`) SELECT CAST(`stringField` AS SIGNED) AS `intField`, `KEY_id` FROM `test-store`
+    - CREATE DATABASE IF NOT EXISTS `VENICE-CLUSTER0` WITH ()
+    - CREATE TABLE IF NOT EXISTS `VENICE-CLUSTER0`.`test-store` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store', 'value.fields-include'='EXCEPT_KEY')
+    - CREATE DATABASE IF NOT EXISTS `VENICE-CLUSTER0` WITH ()
+    - CREATE TABLE IF NOT EXISTS `VENICE-CLUSTER0`.`test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
+    - INSERT INTO `VENICE-CLUSTER0`.`test-store-1` (`intField`, `KEY_id`) SELECT CAST(`stringField` AS SIGNED) AS `intField`, `KEY_id` FROM `VENICE-CLUSTER0`.`test-store`
     jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless

--- a/hoptimator-venice/src/test/resources/venice-ddl-select.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-select.id
@@ -12,9 +12,11 @@ spec:
   job:
     entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
     args:
-    - CREATE TABLE IF NOT EXISTS `test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
-    - CREATE TABLE IF NOT EXISTS `SINK` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ()
-    - INSERT INTO `SINK` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `test-store-1`
+    - CREATE DATABASE IF NOT EXISTS `VENICE-CLUSTER0` WITH ()
+    - CREATE TABLE IF NOT EXISTS `VENICE-CLUSTER0`.`test-store-1` (`intField` INTEGER, `stringField` VARCHAR, `KEY` ROW(`id` INTEGER)) WITH ('connector'='venice', 'key.fields'='KEY_id', 'key.fields-prefix'='KEY_', 'key.type'='RECORD', 'partial-update-mode'='true', 'storeName'='test-store-1', 'value.fields-include'='EXCEPT_KEY')
+    - CREATE DATABASE IF NOT EXISTS `PIPELINE` WITH ()
+    - CREATE TABLE IF NOT EXISTS `PIPELINE`.`SINK` (`intField` INTEGER, `stringField` VARCHAR, `KEY_id` INTEGER) WITH ()
+    - INSERT INTO `PIPELINE`.`SINK` (`intField`, `stringField`, `KEY_id`) SELECT * FROM `VENICE-CLUSTER0`.`test-store-1`
     jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 1
     upgradeMode: stateless


### PR DESCRIPTION
## Summary

- Added `CREATE DATABASE` statements to generated SQL
- Added schema name to `CREATE TABLE` and `INSERT INTO` SQL
- Dropped extraneous logic unflattening logic

## Details

The old planner generated `CREATE IF NOT EXISTS DATABASE` statements along with `CREATE IF NOT EXISTS TABLE` statements, allowing tables to be referenced as `<schema>.<table>`. I had dropped this logic in the new version of the planner, but it ends up being useful. Without fully-qualified table names, it becomes difficult to distinguish between tables, fields, and `t1.foo` field aliases in generated SQL. In particular, joins across tables with the same field name where incorrectly being rewritten like `foo = foo`, instead of `t1.foo = t2.foo`.

## Testing

Integration tests pass with and without the Flink engine installed.

Manually tested a query with the fink engine installed:

```
0: Hoptimator> select * from ads.audience;
INFO Open session to http://localhost:8083 with connection version: V2.
INFO DDL: CREATE DATABASE IF NOT EXISTS `ADS` WITH ()
INFO DDL: CREATE TABLE IF NOT EXISTS `ADS`.`PAGE_VIEWS` (`PAGE_URN` VARCHAR, `MEMBER_URN` VARCHAR) WITH ('connector'='datagen', 'number-of-rows'='10')
INFO DDL: CREATE DATABASE IF NOT EXISTS `PROFILE` WITH ()
INFO DDL: CREATE TABLE IF NOT EXISTS `PROFILE`.`MEMBERS` (`FIRST_NAME` VARCHAR, `LAST_NAME` VARCHAR, `MEMBER_URN` VARCHAR, `COMPANY_URN` VARCHAR) WITH ('connector'='datagen', 'number-of-rows'='10')
INFO SQL: SELECT * FROM (SELECT `MEMBER_URN`
         FROM `ADS`.`PAGE_VIEWS`) AS `t`
     INNER JOIN (SELECT `FIRST_NAME`, `LAST_NAME`, `MEMBER_URN`
         FROM `PROFILE`.`MEMBERS`) AS `t0` ON `t`.`MEMBER_URN` = `t0`.`MEMBER_URN`
+------------+-----------+
| FIRST_NAME | LAST_NAME |
+------------+-----------+
No rows selected (52.114 seconds)
```

N.B. the query references view `ads.audience`, which is properly expanded as a join in the generated SQL. The join runs now.