### PR TITLE
Simplify config loading

### DIFF
--- a/hoptimator-jdbc/src/testFixtures/java/com/linkedin/hoptimator/jdbc/QuidemTestBase.java
+++ b/hoptimator-jdbc/src/testFixtures/java/com/linkedin/hoptimator/jdbc/QuidemTestBase.java
@@ -42,7 +42,7 @@ public abstract class QuidemTestBase {
       Quidem.Config config = Quidem.configBuilder()
           .withReader(r)
           .withWriter(w)
-          .withConnectionFactory((x, y) -> DriverManager.getConnection("jdbc:hoptimator://" + x))
+          .withConnectionFactory((x, y) -> DriverManager.getConnection("jdbc:hoptimator://catalogs=" + x))
           .withCommandHandler(new CustomCommandHandler())
           .build();
       new Quidem(config).execute();

--- a/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
+++ b/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
@@ -11,8 +11,6 @@ import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.SchemaPlus;
 
-import com.linkedin.hoptimator.util.ConfigService;
-
 
 /** JDBC driver for Kafka topics. */
 public class KafkaDriver extends Driver {
@@ -36,9 +34,9 @@ public class KafkaDriver extends Driver {
     if (!url.startsWith(getConnectStringPrefix())) {
       return null;
     }
-    // Connection string properties are given precedence over config properties
-    Properties properties = ConfigService.config(null);
+    Properties properties = new Properties();
     properties.putAll(ConnectStringParser.parse(url.substring(getConnectStringPrefix().length())));
+    properties.putAll(props); // in case the driver is loaded via getConnection()
     try {
       Connection connection = super.connect(url, props);
       if (connection == null) {

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConfigService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConfigService.java
@@ -16,7 +16,6 @@ public final class ConfigService {
   private ConfigService() {
   }
 
-  // Null namespace will default to current namespace, may not be used by some ConfigProviders.
   // loadTopLevelConfigs=true loads top level configs and expands input fields as file-like properties
   // loadTopLevelConfigs=false will only expand input fields as file-like properties
   // Ex:

--- a/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
+++ b/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
@@ -12,8 +12,6 @@ import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.SchemaPlus;
 
-import com.linkedin.hoptimator.util.ConfigService;
-
 
 /** JDBC driver for Venice stores. */
 public class VeniceDriver extends Driver {
@@ -40,8 +38,9 @@ public class VeniceDriver extends Driver {
       return null;
     }
     // Connection string properties are given precedence over config properties
-    Properties properties = ConfigService.config(null, CONFIG_NAME);
+    Properties properties = new Properties();
     properties.putAll(ConnectStringParser.parse(url.substring(getConnectStringPrefix().length())));
+    properties.putAll(props); // in case the driver is loaded via getConnection()
     String cluster = properties.getProperty("cluster");
     if (cluster == null) {
       throw new IllegalArgumentException("Missing required cluster property. Need: jdbc:venice://cluster=...");


### PR DESCRIPTION
## Summary

- Do not load JDBC driver configuration from `ConfigService`. Instead, rely on connection properties.
- Add `catalogs` connection property to limit loaded catalogs.
- Properly load connection properties from JDBC URL or via `getConnection()` argument.

## Details

Previously, `ConfigService` was used within various plugins (e.g. JDBC drivers) to load dynamic configuration. Some of these cases are now obviated by #99's connection properties, which thread through to each plugin, _except_ JDBC drivers. For JDBC drivers, we prefer to use their respective URL, when possible, since relying on `ConfigService` may involve dynamically fetching configurations (e.g. ConfigMaps) when loading each database.

In addition, we will want to support a `CREATE DATABASE` eventually, which won't be able to provide the out-of-band configuration that `ConfigService` needs. For example, we can have `create database foo.bar location 'jdbc:foo://cluster=bar;fabric=prod'`, which fully specifies the external connection. We don't need to additionally supply a configmap out-of-band. 

## Testing

Verified manually with client.