### PR TITLE
Change config loading order to give URLs precedence

### DIFF
--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
@@ -77,7 +77,8 @@ public class HoptimatorDriver extends Driver {
 
       WrappedSchemaPlus wrappedRootSchema = new WrappedSchemaPlus(rootSchema);
 
-      // Load properties from url and from getConnection()
+      // Load properties from the URL and from getConnection()'s properties.
+      // URL properties take precedence.
       Properties properties = new Properties();
       properties.putAll(props); // via getConnection()
       properties.putAll(ConnectStringParser.parse(url.substring(getConnectStringPrefix().length())));

--- a/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
+++ b/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
@@ -35,8 +35,8 @@ public class KafkaDriver extends Driver {
       return null;
     }
     Properties properties = new Properties();
-    properties.putAll(ConnectStringParser.parse(url.substring(getConnectStringPrefix().length())));
     properties.putAll(props); // in case the driver is loaded via getConnection()
+    properties.putAll(ConnectStringParser.parse(url.substring(getConnectStringPrefix().length())));
     try {
       Connection connection = super.connect(url, props);
       if (connection == null) {

--- a/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
+++ b/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
@@ -39,8 +39,8 @@ public class VeniceDriver extends Driver {
     }
     // Connection string properties are given precedence over config properties
     Properties properties = new Properties();
-    properties.putAll(ConnectStringParser.parse(url.substring(getConnectStringPrefix().length())));
     properties.putAll(props); // in case the driver is loaded via getConnection()
+    properties.putAll(ConnectStringParser.parse(url.substring(getConnectStringPrefix().length())));
     String cluster = properties.getProperty("cluster");
     if (cluster == null) {
       throw new IllegalArgumentException("Missing required cluster property. Need: jdbc:venice://cluster=...");


### PR DESCRIPTION
## Summary

Change config loading order in JDBC drivers to consistently give URL properties precedence over `getConnection()`'s properties.

## Details

JDBC drivers may be loaded via the older `DriverManager` mechanism or via the newer `DataSource` mechanism. With the former, drivers may be loaded as `getConnection(url, props)`, where `props` are optional connection properties. The URL itself very often includes connection properties, raising the question of which source of properties takes precdence.

The JDBC docs do not specify what should happen here, explicitly leaving it to the drivers to decide.

Given that end users can often _only_ control and see the URL, we think it makes sense to given the URL precedence here. In that case, the `props` supplied to `getConnection()` should be considered defaults rather than overrides.

The opposite approach would yield surprising behavior, when e.g. a log showed `jdbc:foo://bar=qux` while the driver silently overwrote `bar`.

## Testing

None. Integration tests should cover this trivial change.