### PR TITLE
Fix Zeppelin k8s connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ deploy-flink: deploy
 	helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.9.0/
 	helm upgrade --install --atomic --set webhook.create=false,image.pullPolicy=Never,image.repository=docker.io/library/hoptimator-flink-operator,image.tag=latest --set-json='watchNamespaces=["default","flink"]' flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
 	kubectl apply -f deploy/dev/flink-session-cluster.yaml
+	kubectl apply -f deploy/dev/flink-sql-gateway.yaml
 	kubectl apply -f deploy/samples/flink-template.yaml
 
 undeploy-flink:
@@ -132,6 +133,7 @@ build-zeppelin: build
 
 # attaches to terminal (not run as daemon)
 run-zeppelin: build-zeppelin
+	kubectl apply -f deploy/docker/zeppelin/zeppelin-flink-engine.yaml
 	docker run --rm -p 8080:8080 \
 	  --volume=${HOME}/.kube/config:/opt/zeppelin/.kube/config \
 	  --add-host=docker-for-desktop:host-gateway \

--- a/deploy/docker/zeppelin/Dockerfile-zeppelin
+++ b/deploy/docker/zeppelin/Dockerfile-zeppelin
@@ -18,10 +18,7 @@ USER root
 RUN chmod 660 /opt/zeppelin/conf/interpreter.json \
     /opt/zeppelin/conf/zeppelin-site.xml
 
-# Add overrides for K8s (see: com.linkedin.hoptimator.k8s.K8sConfig)
-# host must match docker argument --add-host=<host>:host-gateway
-ENV KUBECONFIG_BASEPATH="https://docker-for-desktop:6443" \
-    ZEPPELIN_HOME="/opt/zeppelin"
+ENV ZEPPELIN_HOME="/opt/zeppelin"
 
 # restore settings from upstream Dockerfile
 USER 1000

--- a/deploy/docker/zeppelin/interpreter.json
+++ b/deploy/docker/zeppelin/interpreter.json
@@ -515,7 +515,7 @@
       "properties": {
         "default.url": {
           "name": "default.url",
-          "value": "jdbc:hoptimator://",
+          "value": "jdbc:hoptimator://k8s.server=https://docker-for-desktop:6443",
           "type": "string",
           "description": "The URL for JDBC."
         },

--- a/deploy/docker/zeppelin/zeppelin-flink-engine.yaml
+++ b/deploy/docker/zeppelin/zeppelin-flink-engine.yaml
@@ -1,0 +1,10 @@
+# This is required as long as zeppelin is run via docker
+# If started via k8s we can remove this in favor of the standard flink-engine.yaml
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: Engine
+metadata:
+  name: flink-engine
+spec:
+  url: jdbc:flink://host.docker.internal:8083
+  dialect: Flink
+


### PR DESCRIPTION
Likely will need to make similar new yaml files to get Kafka & Venice working through Zeppelin, will add separately if needed