### PR TITLE
Remove incorrect operator namespace

### DIFF
--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/HoptimatorOperatorApp.java
@@ -92,7 +92,6 @@ public class HoptimatorOperatorApp {
 
     Properties connectionProperties = new Properties();
     connectionProperties.putAll(properties);
-    connectionProperties.put("k8s.namespace", watchNamespace);
     K8sContext context = new K8sContext(connectionProperties);
 
     ApiClient apiClient = context.apiClient();


### PR DESCRIPTION
Watch namspace != the namespace we want to connect to. Removing this will default the operator pod to use environment variable: `POD_NAMESPACE_FILEPATH`