### PR TITLE
Add PIPELINES metadata table

### DIFF
--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMetadata.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMetadata.java
@@ -13,14 +13,17 @@ public class K8sMetadata extends AbstractSchema {
   private final Map<String, Table> tableMap = new HashMap<>();
   private final K8sDatabaseTable databaseTable;
   private final K8sEngineTable engineTable;
+  private final K8sPipelineTable pipelineTable;
   private final K8sViewTable viewTable;
 
   public K8sMetadata(K8sContext context) {
     this.engineTable = new K8sEngineTable(context);
     this.databaseTable = new K8sDatabaseTable(context, engineTable);
+    this.pipelineTable = new K8sPipelineTable(context);
     this.viewTable = new K8sViewTable(context);
     tableMap.put("DATABASES", databaseTable);
     tableMap.put("ENGINES", engineTable);
+    tableMap.put("PIPELINES", pipelineTable);
     tableMap.put("VIEWS", viewTable);
   }
 
@@ -34,6 +37,10 @@ public class K8sMetadata extends AbstractSchema {
 
   public K8sViewTable viewTable() {
     return viewTable;
+  }
+
+  public K8sPipelineTable pipelineTable() {
+    return pipelineTable;
   }
 
   @Override

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineTable.java
@@ -1,0 +1,42 @@
+package com.linkedin.hoptimator.k8s;
+
+import org.apache.calcite.schema.Schema;
+
+import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
+import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineSpec;
+
+
+public class K8sPipelineTable extends K8sTable<V1alpha1Pipeline, V1alpha1PipelineList, K8sPipelineTable.Row> {
+
+  // CHECKSTYLE:OFF
+  public static class Row {
+    public String NAME;
+    public String STATUS;
+
+    public Row(String name, String status) {
+      this.NAME = name;
+      this.STATUS = status;
+    }
+
+    @Override
+    public String toString() {
+      return String.join("\t", NAME, STATUS);
+    }
+  }
+  // CHECKSTYLE:ON
+
+  public K8sPipelineTable(K8sContext context) {
+    super(context, K8sApiEndpoints.PIPELINES, Row.class);
+  }
+
+  @Override
+  public Row toRow(V1alpha1Pipeline obj) {
+    return new Row(obj.getMetadata().getName(), obj.getStatus().getMessage());
+  }
+
+  @Override
+  public Schema.TableType getJdbcTableType() {
+    return Schema.TableType.SYSTEM_TABLE;
+  }
+}


### PR DESCRIPTION
## Summary

- Add k8s.PIPELINES metadata table.

## Details

So far, this is just for convenience purposes, and for symmetry with the other metadata tables. With this change, users can check on the status of their pipelines without dropping out of the CLI.

## Testing

```
0: Hoptimator> select * from "k8s".pipelines;
+---------------+-----------+
|     NAME      |  STATUS   |
+---------------+-----------+
| ads-audience2 | Deployed. |
| ads-target2   | Deployed. |
+---------------+-----------+
2 rows selected (0.593 seconds)
```