### PR TITLE
Add ownership references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ undeploy-dev-environment: undeploy-venice undeploy-kafka undeploy-flink undeploy
 # Integration test setup intended to be run locally
 integration-tests: deploy-dev-environment
 	kubectl wait kafka.kafka.strimzi.io/one --for=condition=Ready --timeout=10m -n kafka
-	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-1 --for=condition=Ready --timeout=10m -n kafka
-	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-2 --for=condition=Ready --timeout=10m -n kafka
+	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-1 --for=condition=Ready --timeout=10m
+	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-2 --for=condition=Ready --timeout=10m
 	kubectl port-forward -n kafka svc/one-kafka-external-bootstrap 9092 & echo $$! > port-forward.pid
 	kubectl port-forward -n flink svc/flink-sql-gateway 8083 & echo $$! > port-forward-2.pid
 	kubectl port-forward -n flink svc/basic-session-deployment-rest 8081 & echo $$! > port-forward-3.pid

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ deploy-kafka: deploy deploy-flink
 	kubectl apply -f ./deploy/samples/kafkadb.yaml
 
 undeploy-kafka:
-	kubectl delete kafkatopic.kafka.strimzi.io -n kafka --all || echo "skipping"
+	kubectl delete kafkatopic.kafka.strimzi.io --all || echo "skipping"
 	kubectl delete strimzi -n kafka --all || echo "skipping"
 	kubectl delete pvc -l strimzi.io/name=one-kafka -n kafka || echo "skipping"
 	kubectl delete -f "https://strimzi.io/install/latest?namespace=kafka" -n kafka || echo "skipping"
@@ -103,8 +103,8 @@ undeploy-dev-environment: undeploy-venice undeploy-kafka undeploy-flink undeploy
 # Integration test setup intended to be run locally
 integration-tests: deploy-dev-environment
 	kubectl wait kafka.kafka.strimzi.io/one --for=condition=Ready --timeout=10m -n kafka
-	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-1 --for=condition=Ready --timeout=10m
-	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-2 --for=condition=Ready --timeout=10m
+	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-1 --for=condition=Ready --timeout=10m
+	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-2 --for=condition=Ready --timeout=10m
 	kubectl port-forward -n kafka svc/one-kafka-external-bootstrap 9092 & echo $$! > port-forward.pid
 	kubectl port-forward -n flink svc/flink-sql-gateway 8083 & echo $$! > port-forward-2.pid
 	kubectl port-forward -n flink svc/basic-session-deployment-rest 8081 & echo $$! > port-forward-3.pid
@@ -116,8 +116,8 @@ integration-tests: deploy-dev-environment
 # kind cluster used in github workflow needs to have different routing set up, avoiding the need to forward kafka ports
 integration-tests-kind: deploy-dev-environment
 	kubectl wait kafka.kafka.strimzi.io/one --for=condition=Ready --timeout=10m -n kafka
-	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-1 --for=condition=Ready --timeout=10m -n kafka
-	kubectl wait kafkatopic.kafka.strimzi.io/existing-topic-2 --for=condition=Ready --timeout=10m -n kafka
+	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-1 --for=condition=Ready --timeout=10m 
+	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-2 --for=condition=Ready --timeout=10m 
 	./gradlew intTest -i
 
 generate-models:

--- a/deploy/dev/kafka.yaml
+++ b/deploy/dev/kafka.yaml
@@ -65,5 +65,41 @@ spec:
     storage:
       type: ephemeral
   entityOperator:
-    topicOperator: {}
+    topicOperator:
+      watchedNamespace: default
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: kafka
+  name: kafka-operator
+rules:
+- apiGroups: ["kafka.strimzi.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["*"]
+
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-operator
+  namespace: kafka
+subjects:
+- kind: ServiceAccount
+  name: one-entity-operator
+  namespace: kafka
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: kafka
+roleRef:
+  kind: ClusterRole
+  name: kafka-operator
+  apiGroup: rbac.authorization.k8s.io
 

--- a/deploy/samples/flink-template.yaml
+++ b/deploy/samples/flink-template.yaml
@@ -10,7 +10,6 @@ spec:
     kind: FlinkSessionJob
     metadata:
       name: {{name}}
-      namespace: flink
     spec:
       deploymentName: basic-session-deployment
       job:

--- a/deploy/samples/kafkadb.yaml
+++ b/deploy/samples/kafkadb.yaml
@@ -45,10 +45,11 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: existing-topic-1
+  name: kafka-database-existing-topic-1
   labels:
     strimzi.io/cluster: one
 spec:
+  topicName: existing-topic-1
   partitions: 1
   replicas: 1
   config:
@@ -60,10 +61,11 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: existing-topic-2
+  name: kafka-database-existing-topic-2
   labels:
     strimzi.io/cluster: one
 spec:
+  topicName: existing-topic-2
   partitions: 1
   replicas: 1
   config:

--- a/deploy/samples/kafkadb.yaml
+++ b/deploy/samples/kafkadb.yaml
@@ -21,7 +21,6 @@ spec:
     kind: KafkaTopic
     metadata:
       name: {{name}}
-      namespace: kafka
       labels:
         strimzi.io/cluster: one
     spec:
@@ -47,7 +46,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: existing-topic-1
-  namespace: kafka
   labels:
     strimzi.io/cluster: one
 spec:
@@ -63,7 +61,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: existing-topic-2
-  namespace: kafka
   labels:
     strimzi.io/cluster: one
 spec:

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Connector.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Connector.java
@@ -4,7 +4,7 @@ import java.sql.SQLException;
 import java.util.Map;
 
 
-public interface Connector<T> {
+public interface Connector {
 
-  Map<String, String> configure(T t) throws SQLException;
+  Map<String, String> configure() throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ConnectorProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ConnectorProvider.java
@@ -6,5 +6,6 @@ import java.util.Properties;
 
 public interface ConnectorProvider {
 
-  <T> Collection<Connector<T>> connectors(Class<T> clazz, Properties connectionProperties);
+  /** Find connectors capable of configuring data plane connectors for the obj. */
+  <T> Collection<Connector> connectors(T obj, Properties connectionProperties);
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployable.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployable.java
@@ -1,17 +1,6 @@
 package com.linkedin.hoptimator;
 
-import java.sql.SQLException;
-import java.util.List;
-
 
 public interface Deployable {
 
-  void create() throws SQLException;
-
-  void delete() throws SQLException;
-
-  void update() throws SQLException;
-
-  /** Render a list of specs, usually YAML. */
-  List<String> specify() throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployer.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployer.java
@@ -4,13 +4,15 @@ import java.sql.SQLException;
 import java.util.List;
 
 
-public interface Deployer<T> {
+/** Deploys something. */
+public interface Deployer {
 
-  void create(T t) throws SQLException;
+  void create() throws SQLException;
 
-  void update(T t) throws SQLException;
+  void delete() throws SQLException;
 
-  void delete(T t) throws SQLException;
+  void update() throws SQLException;
 
-  List<String> specify(T t) throws SQLException;
+  /** Render a list of specs, usually YAML. */
+  List<String> specify() throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
@@ -6,5 +6,6 @@ import java.util.Properties;
 
 public interface DeployerProvider {
 
-  <T> Collection<Deployer<T>> deployers(Class<T> clazz, Properties connectionProperties);
+  /** Find deployers capable of deploying the obj. */
+  <T extends Deployable> Collection<Deployer> deployers(T obj, Properties connectionProperties);
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
@@ -3,7 +3,7 @@ package com.linkedin.hoptimator;
 import java.util.function.Function;
 
 
-public class Job {
+public class Job implements Deployable {
 
   private final String name;
   private final Sink sink;

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/MaterializedView.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/MaterializedView.java
@@ -5,26 +5,18 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
-public class MaterializedView {
+public class MaterializedView extends View implements Deployable {
 
   private final String database;
-  private final List<String> path;
-  private final String viewSql;
   private final Function<SqlDialect, String> pipelineSql;
   private final Pipeline pipeline;
 
   public MaterializedView(String database, List<String> path, String viewSql, Function<SqlDialect, String> pipelineSql,
       Pipeline pipeline) {
+    super(path, viewSql);
     this.database = database;
-    this.path = path;
-    this.viewSql = viewSql;
     this.pipelineSql = pipelineSql;
     this.pipeline = pipeline;
-  }
-
-  /** SQL query which defines this view, e.g. SELECT ... FROM ... */
-  public String viewSql() {
-    return viewSql;
   }
 
   public Pipeline pipeline() {
@@ -38,22 +30,6 @@ public class MaterializedView {
   /** The internal name for the database this table belongs to. Not necessary the same as schema. */
   public String database() {
     return database;
-  }
-
-  public String table() {
-    return path.get(path.size() - 1);
-  }
-
-  public String schema() {
-    return path.get(path.size() - 2);
-  }
-
-  public List<String> path() {
-    return path;
-  }
-
-  protected String pathString() {
-    return path.stream().collect(Collectors.joining("."));
   }
 
   @Override

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Pipeline.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Pipeline.java
@@ -1,48 +1,33 @@
 package com.linkedin.hoptimator;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 
 
 /**
- * A set of Deployable objects that work together to deliver data.
+ * A job, along with its sources and sink.
  */
-public class Pipeline implements Deployable {
+public class Pipeline {
 
-  private List<Deployable> deployables;
+  private Collection<Source> sources;
+  private Sink sink;
+  private Job job;
 
-  public Pipeline(List<Deployable> deployables) {
-    this.deployables = deployables;
+  public Pipeline(Collection<Source> sources, Sink sink, Job job) {
+    this.sources = sources;
+    this.sink = sink;
+    this.job = job;
   }
 
-  @Override
-  public void create() throws SQLException {
-    for (Deployable deployable : deployables) {
-      deployable.create();
-    }
+  public Collection<Source> sources() {
+    return sources;
   }
 
-  @Override
-  public void delete() throws SQLException {
-    for (Deployable deployable : deployables) {
-      deployable.delete();
-    }
+  public Sink sink() {
+    return sink;
   }
 
-  @Override
-  public void update() throws SQLException {
-    for (Deployable deployable : deployables) {
-      deployable.update();
-    }
-  }
-
-  @Override
-  public List<String> specify() throws SQLException {
-    List<String> specs = new ArrayList<>();
-    for (Deployable deployable : deployables) {
-      specs.addAll(deployable.specify());
-    }
-    return specs;
+  public Job job() {
+    return job;
   }
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Sink.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Sink.java
@@ -4,7 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 
-public class Sink extends Source {
+// Unclear if Sink will always extend Source
+public class Sink extends Source implements Deployable {
 
   public Sink(String database, List<String> path, Map<String, String> options) {
     super(database, path, options);

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Source.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Source.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 
-public class Source {
+public class Source implements Deployable {
 
   private final String database;
   private final List<String> path;

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Validator.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Validator.java
@@ -11,9 +11,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 
-public interface Validator<T> {
-
-  void validate(T t, Issues issues);
+public interface Validator extends Validated {
 
   static void validateSubdomainName(String s, Issues issues) {
     // N.B. we don't aim to be efficient here; rather, as verbose as possible.
@@ -44,15 +42,18 @@ public interface Validator<T> {
     issues.warn("Validation not implemented for this object");
   }
 
-  /** Validator that invokes `Validated.validate()`. */
-  class DefaultValidator<T> implements Validator<T> {
+  /** Validator that invokes `validate()` on the target object. */
+  class DefaultValidator<T extends Validated> implements Validator {
+
+    private final T t;
+
+    public DefaultValidator(T t) {
+      this.t = t;
+    }
 
     @Override
-    public void validate(T t, Issues issues) {
-      if (t instanceof Validated) {
-        Validated v = (Validated) t;
-        v.validate(issues.child(t.getClass().getSimpleName()));
-      }
+    public void validate(Issues issues) {
+      t.validate(issues.child(t.getClass().getSimpleName()));
     }
   }
 

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ValidatorProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ValidatorProvider.java
@@ -5,5 +5,5 @@ import java.util.Collection;
 
 public interface ValidatorProvider {
 
-  <T> Collection<Validator<T>> validators(Class<T> clazz);
+  <T> Collection<Validator> validators(T obj);
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/View.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/View.java
@@ -1,0 +1,42 @@
+package com.linkedin.hoptimator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class View implements Deployable {
+
+  private final List<String> path;
+  private final String viewSql;
+
+  public View(List<String> path, String viewSql) {
+    this.path = path;
+    this.viewSql = viewSql;
+  }
+
+  /** SQL query which defines this view, e.g. SELECT ... FROM ... */
+  public String viewSql() {
+    return viewSql;
+  }
+
+  public String table() {
+    return path.get(path.size() - 1);
+  }
+
+  public String schema() {
+    return path.get(path.size() - 2);
+  }
+
+  public List<String> path() {
+    return path;
+  }
+
+  protected String pathString() {
+    return path.stream().collect(Collectors.joining("."));
+  }
+
+  @Override
+  public String toString() {
+    return "View[" + pathString() + "]";
+  }
+}

--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroTableValidator.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroTableValidator.java
@@ -20,10 +20,16 @@ import com.linkedin.hoptimator.Validator;
 
 
 /** Validates that tables follow Avro schema evolution rules.  */
-class AvroTableValidator implements Validator<SchemaPlus> {
+class AvroTableValidator implements Validator {
+
+  private final SchemaPlus schema;
+
+  public AvroTableValidator(SchemaPlus schema) {
+    this.schema = schema;
+  }
 
   @Override
-  public void validate(SchemaPlus schema, Issues issues) {
+  public void validate(Issues issues) {
     try {
       CalciteSchema originalSchema = schema.unwrap(CalciteSchema.class);
       if (originalSchema == null || originalSchema.schema == null) {

--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroValidatorProvider.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroValidatorProvider.java
@@ -14,9 +14,9 @@ public class AvroValidatorProvider implements ValidatorProvider {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> Collection<Validator<T>> validators(Class<T> clazz) {
-    if (SchemaPlus.class.isAssignableFrom(clazz)) {
-      return Collections.singletonList((Validator<T>) new AvroTableValidator());
+  public <T> Collection<Validator> validators(T obj) {
+    if (obj instanceof SchemaPlus) {
+      return Collections.singletonList(new AvroTableValidator((SchemaPlus) obj));
     } else {
       return Collections.emptyList();
     }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/BackwardCompatibilityValidator.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/BackwardCompatibilityValidator.java
@@ -4,12 +4,17 @@ import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 
 
 /** Validates that tables follow backwards-compatible schema evolution rules.  */
 class BackwardCompatibilityValidator extends CompatibilityValidatorBase {
+
+  BackwardCompatibilityValidator(SchemaPlus schema) {
+    super(schema);
+  }
 
   @Override
   protected void validate(Table table, Table originalTable, Issues issues) {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorBase.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorBase.java
@@ -8,10 +8,16 @@ import com.linkedin.hoptimator.Validator;
 
 
 /** Base class for shared schema evolution validators.  */
-abstract class CompatibilityValidatorBase implements Validator<SchemaPlus> {
+abstract class CompatibilityValidatorBase implements Validator {
+
+  private final SchemaPlus schema;
+
+  public CompatibilityValidatorBase(SchemaPlus schema) {
+    this.schema = schema;
+  }
 
   @Override
-  public void validate(SchemaPlus schema, Issues issues) {
+  public void validate(Issues issues) {
     try {
       CalciteSchema originalSchema = schema.unwrap(CalciteSchema.class);
       if (originalSchema == null || originalSchema.schema == null) {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorProvider.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorProvider.java
@@ -15,10 +15,10 @@ public class CompatibilityValidatorProvider implements ValidatorProvider {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> Collection<Validator<T>> validators(Class<T> clazz) {
-    if (SchemaPlus.class.isAssignableFrom(clazz)) {
-      return Arrays.asList(new Validator[]{(Validator<T>) new BackwardCompatibilityValidator(),
-          (Validator<T>) new ForwardCompatibilityValidator()});
+  public <T> Collection<Validator> validators(T obj) {
+    if (obj instanceof SchemaPlus) {
+      return Arrays.asList(new Validator[]{new BackwardCompatibilityValidator((SchemaPlus) obj),
+          new ForwardCompatibilityValidator((SchemaPlus) obj)});
     } else {
       return Collections.emptyList();
     }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DefaultValidatorProvider.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DefaultValidatorProvider.java
@@ -3,6 +3,7 @@ package com.linkedin.hoptimator.jdbc;
 import java.util.Collection;
 import java.util.Collections;
 
+import com.linkedin.hoptimator.Validated;
 import com.linkedin.hoptimator.Validator;
 import com.linkedin.hoptimator.ValidatorProvider;
 
@@ -11,7 +12,11 @@ import com.linkedin.hoptimator.ValidatorProvider;
 public class DefaultValidatorProvider implements ValidatorProvider {
 
   @Override
-  public <T> Collection<Validator<T>> validators(Class<T> clazz) {
-    return Collections.singletonList(new Validator.DefaultValidator<T>());
+  public <T> Collection<Validator> validators(T obj) {
+    if (obj instanceof Validated) {
+      return Collections.singletonList(new Validator.DefaultValidator<>((Validated) obj));
+    } else {
+      return Collections.emptyList();
+    }
   }
 }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ForwardCompatibilityValidator.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ForwardCompatibilityValidator.java
@@ -4,12 +4,17 @@ import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 
 
 /** Validates that tables follow forwards-compatible schema evolution rules.  */
 class ForwardCompatibilityValidator extends CompatibilityValidatorBase {
+
+  ForwardCompatibilityValidator(SchemaPlus schema) {
+    super(schema);
+  }
 
   @Override
   protected void validate(Table table, Table originalTable, Issues issues) {

--- a/hoptimator-jdbc/src/testFixtures/java/com/linkedin/hoptimator/jdbc/QuidemTestBase.java
+++ b/hoptimator-jdbc/src/testFixtures/java/com/linkedin/hoptimator/jdbc/QuidemTestBase.java
@@ -81,14 +81,14 @@ public abstract class QuidemTestBase {
                 RelRoot root = HoptimatorDriver.convert(conn, sql).root;
                 String []parts = line.split(" ", 2);
                 String pipelineName = parts.length == 2 ? parts[1] : "test";
-                Pipeline pipeline = DeploymentService.plan(root).pipeline("sink", conn.connectionProperties());
+                Pipeline pipeline = DeploymentService.plan(root).pipeline(pipelineName, conn.connectionProperties());
                 List<String> specs = new ArrayList<>();
                 for (Source source : pipeline.sources()) {
                   specs.addAll(DeploymentService.specify(source, conn.connectionProperties()));
                 }
                 specs.addAll(DeploymentService.specify(pipeline.sink(), conn.connectionProperties()));
                 specs.addAll(DeploymentService.specify(pipeline.job(), conn.connectionProperties()));
-                String joined = specs.stream().collect(Collectors.joining("---\n"));
+                String joined = specs.stream().sorted().collect(Collectors.joining("---\n"));
                 String[] lines = joined.replaceAll(";\n", "\n").split("\n");
                 context.echo(Arrays.asList(lines));
               }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
@@ -17,16 +17,18 @@ import com.linkedin.hoptimator.util.Template;
 
 
 /** Configures an abstract Source/Sink by applying TableTemplates */
-class K8sConnector implements Connector<Source> {
+class K8sConnector implements Connector {
 
+  private final Source source;
   private final K8sApi<V1alpha1TableTemplate, V1alpha1TableTemplateList> tableTemplateApi;
 
-  K8sConnector(K8sContext context) {
+  K8sConnector(Source source, K8sContext context) {
+    this.source = source;
     this.tableTemplateApi = new K8sApi<>(context, K8sApiEndpoints.TABLE_TEMPLATES);
   }
 
   @Override
-  public Map<String, String> configure(Source source) throws SQLException {
+  public Map<String, String> configure() throws SQLException {
     Template.Environment env =
         new Template.SimpleEnvironment().with("name", source.database() + "-" + source.table().toLowerCase(Locale.ROOT))
             .with("database", source.database())

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnectorProvider.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnectorProvider.java
@@ -12,13 +12,12 @@ import com.linkedin.hoptimator.Source;
 
 public class K8sConnectorProvider implements ConnectorProvider {
 
-  @SuppressWarnings("unchecked")
   @Override
-  public <T> Collection<Connector<T>> connectors(Class<T> clazz, Properties connectionProperties) {
+  public <T> Collection<Connector> connectors(T obj, Properties connectionProperties) {
     K8sContext context = new K8sContext(connectionProperties);
-    List<Connector<T>> list = new ArrayList<>();
-    if (Source.class.isAssignableFrom(clazz)) {
-      list.add((Connector<T>) new K8sConnector(context));
+    List<Connector> list = new ArrayList<>();
+    if (obj instanceof Source) {
+      list.add(new K8sConnector((Source) obj, context));
     }
     return list;
   }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployer.java
@@ -7,38 +7,52 @@ import java.util.List;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.util.Yaml;
+import io.kubernetes.client.openapi.models.V1OwnerReference;
+
 
 import com.linkedin.hoptimator.Deployer;
 
 
-public abstract class K8sDeployer<T, U extends KubernetesObject, V extends KubernetesListObject>
-    implements Deployer<T> {
+public abstract class K8sDeployer<T extends KubernetesObject, U extends KubernetesListObject>
+    implements Deployer {
 
-  private K8sApi<U, V> api;
+  private K8sApi<T, U> api;
 
-  K8sDeployer(K8sContext context, K8sApiEndpoint<U, V> endpoint) {
-    this.api = new K8sApi<U, V>(context, endpoint);
+  K8sDeployer(K8sContext context, K8sApiEndpoint<T, U> endpoint) {
+    this.api = new K8sApi<T, U>(context, endpoint);
   }
 
   @Override
-  public void create(T t) throws SQLException {
-    api.create(toK8sObject(t));
+  public void create() throws SQLException {
+    api.create(toK8sObject());
+  }
+
+  public V1OwnerReference createAndReference() throws SQLException {
+    T obj = toK8sObject();
+    api.create(obj);
+    return api.reference(obj);
   }
 
   @Override
-  public void delete(T t) throws SQLException {
-    api.delete(toK8sObject(t));
+  public void delete() throws SQLException {
+    api.delete(toK8sObject());
   }
 
   @Override
-  public void update(T t) throws SQLException {
-    api.update(toK8sObject(t));
+  public void update() throws SQLException {
+    api.update(toK8sObject());
+  }
+
+  public V1OwnerReference updateAndReference() throws SQLException {
+    T obj = toK8sObject();
+    api.update(obj);
+    return api.reference(obj);
   }
 
   @Override
-  public List<String> specify(T t) throws SQLException {
-    return Collections.singletonList(Yaml.dump(toK8sObject(t)));
+  public List<String> specify() throws SQLException {
+    return Collections.singletonList(Yaml.dump(toK8sObject()));
   }
 
-  protected abstract U toK8sObject(T t) throws SQLException;
+  protected abstract T toK8sObject() throws SQLException;
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -15,19 +15,21 @@ import com.linkedin.hoptimator.util.Template;
 
 
 /** Specifies an abstract Job with concrete YAML by applying JobTemplates. */
-class K8sJobDeployer extends K8sYamlDeployer<Job> {
+class K8sJobDeployer extends K8sYamlDeployer {
 
   private static final String FLINK_CONFIG = "flink.config";
 
+  private final Job job;
   private final K8sApi<V1alpha1JobTemplate, V1alpha1JobTemplateList> jobTemplateApi;
 
-  K8sJobDeployer(K8sContext context) {
+  K8sJobDeployer(Job job, K8sContext context) {
     super(context);
+    this.job = job;
     this.jobTemplateApi = new K8sApi<>(context, K8sApiEndpoints.JOB_TEMPLATES);
   }
 
   @Override
-  public List<String> specify(Job job) throws SQLException {
+  public List<String> specify() throws SQLException {
     Properties properties = ConfigService.config(null, false, FLINK_CONFIG);
     properties.putAll(job.sink().options());
     Function<SqlDialect, String> sql = job.sql();

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
@@ -1,28 +1,85 @@
 package com.linkedin.hoptimator.k8s;
 
-import java.util.LinkedList;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
-
+import com.linkedin.hoptimator.Deployer;
+import com.linkedin.hoptimator.Job;
 import com.linkedin.hoptimator.MaterializedView;
-import com.linkedin.hoptimator.k8s.models.V1alpha1View;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
-import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
+import com.linkedin.hoptimator.Sink;
+import com.linkedin.hoptimator.Source;
+import com.linkedin.hoptimator.SqlDialect;
+import com.linkedin.hoptimator.util.DeploymentService;
+
+import io.kubernetes.client.openapi.models.V1OwnerReference;
 
 
-class K8sMaterializedViewDeployer extends K8sDeployer<MaterializedView, V1alpha1View, V1alpha1ViewList> {
+/** Deploys View and Pipeline objects, along with all the pipeline elements. */
+class K8sMaterializedViewDeployer implements Deployer {
 
-  K8sMaterializedViewDeployer(K8sContext context) {
-    super(context, K8sApiEndpoints.VIEWS);
+  private final MaterializedView view;
+  private final K8sContext context;
+  private final Properties connectionProperties;
+
+  K8sMaterializedViewDeployer(MaterializedView view, K8sContext context, Properties connectionProperties) {
+    this.view = view;
+    this.context = context;
+    this.connectionProperties = connectionProperties;
   }
 
   @Override
-  protected V1alpha1View toK8sObject(MaterializedView view) {
-    String name = K8sUtils.canonicalizeName(view.path());
-    LinkedList<String> q = new LinkedList<>(view.path());
-    return new V1alpha1View().kind(K8sApiEndpoints.VIEWS.kind())
-        .apiVersion(K8sApiEndpoints.VIEWS.apiVersion())
-        .metadata(new V1ObjectMeta().name(name))
-        .spec(new V1alpha1ViewSpec().view(q.pollLast()).schema(q.pollLast()).sql(view.viewSql()).materialized(true));
+  public void create() throws SQLException {
+    String name = name();
+    List<String> pipelineSpecs = pipelineSpecs();
+    V1OwnerReference viewRef = new K8sViewDeployer(view, true, context).createAndReference();
+    K8sContext viewContext = context.withOwner(viewRef);
+    V1OwnerReference pipelineRef = new K8sPipelineDeployer(name, pipelineSpecs, sql(), viewContext).createAndReference();
+    K8sContext pipelineContext = viewContext.withLabel("pipeline", name).withOwner(pipelineRef);
+    new K8sYamlDeployerImpl(pipelineContext, pipelineSpecs).update();  // update, cuz some elements may already exist
+  }
+
+  @Override
+  public void update() throws SQLException {
+    String name = name();
+    List<String> pipelineSpecs = pipelineSpecs();
+    V1OwnerReference viewRef = new K8sViewDeployer(view, true, context).updateAndReference();
+    K8sContext viewContext = context.withOwner(viewRef);
+    V1OwnerReference pipelineRef = new K8sPipelineDeployer(name, pipelineSpecs, sql(), viewContext).updateAndReference();
+    K8sContext pipelineContext = viewContext.withLabel("pipeline", name).withOwner(pipelineRef);
+    new K8sYamlDeployerImpl(pipelineContext, pipelineSpecs).update();
+  }
+
+  @Override
+  public void delete() throws SQLException {
+    // The delete will cascade to any owned objects, including the Pipeline object.
+    new K8sViewDeployer(view, true, context).delete();
+  }
+
+  List<String> pipelineSpecs() throws SQLException {
+    List<String> specs = new ArrayList<>();
+    for (Source source : view.pipeline().sources()) {
+      specs.addAll(DeploymentService.specify(source, connectionProperties));
+    }
+    specs.addAll(DeploymentService.specify(view.pipeline().sink(), connectionProperties));
+    specs.addAll(DeploymentService.specify(view.pipeline().job(), connectionProperties));
+    return specs;
+  }
+
+  String name() {
+    return K8sUtils.canonicalizeName(view.path());
+  }
+
+  String sql() {
+    return view.pipelineSql().apply(SqlDialect.ANSI);
+  }
+
+  @Override
+  public List<String> specify() throws SQLException {
+    // Users don't care about the MaterializedView and Pipeline objects.
+    // We just return the pipeline elements here. This will be what
+    // renders when the `!specify` command is called.
+    return pipelineSpecs();
   }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSourceDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSourceDeployer.java
@@ -11,17 +11,19 @@ import com.linkedin.hoptimator.util.Template;
 
 
 /** Specifies an abstract Source with concrete YAML by applying TableTemplates. */
-class K8sSourceDeployer extends K8sYamlDeployer<Source> {
+class K8sSourceDeployer extends K8sYamlDeployer {
 
+  private final Source source;
   private final K8sApi<V1alpha1TableTemplate, V1alpha1TableTemplateList> tableTemplateApi;
 
-  K8sSourceDeployer(K8sContext context) {
+  K8sSourceDeployer(Source source, K8sContext context) {
     super(context);
+    this.source = source;
     this.tableTemplateApi = new K8sApi<>(context, K8sApiEndpoints.TABLE_TEMPLATES);
   }
 
   @Override
-  public List<String> specify(Source source) throws SQLException {
+  public List<String> specify() throws SQLException {
     String name = K8sUtils.canonicalizeName(source.database(), source.table());
     Template.Environment env =
         new Template.SimpleEnvironment()

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
@@ -61,7 +61,11 @@ public final class K8sUtils {
   }
 
   public static String guessPlural(KubernetesType obj) {
-    String lower = obj.getKind().toLowerCase(Locale.ROOT);
+    return guessPlural(obj.getKind());
+  }
+
+  public static String guessPlural(String kind) {
+    String lower = kind.toLowerCase(Locale.ROOT);
     if (lower.endsWith("y")) {
       return lower.substring(0, lower.length() - 1) + "ies";
     } else {

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sViewDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sViewDeployer.java
@@ -2,29 +2,39 @@ package com.linkedin.hoptimator.k8s;
 
 import java.util.LinkedList;
 
-import org.apache.calcite.schema.impl.ViewTable;
-
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
+import com.linkedin.hoptimator.View;
 import com.linkedin.hoptimator.k8s.models.V1alpha1View;
 import com.linkedin.hoptimator.k8s.models.V1alpha1ViewList;
 import com.linkedin.hoptimator.k8s.models.V1alpha1ViewSpec;
 
 
-class K8sViewDeployer extends K8sDeployer<ViewTable, V1alpha1View, V1alpha1ViewList> {
+/** Deploys a View object. */
+class K8sViewDeployer extends K8sDeployer<V1alpha1View, V1alpha1ViewList> {
 
-  K8sViewDeployer(K8sContext context) {
+  private final View view;
+  private final boolean materialized;
+
+  K8sViewDeployer(View view, boolean materialized, K8sContext context) {
     super(context, K8sApiEndpoints.VIEWS);
+    this.view = view;
+    this.materialized = materialized;
   }
 
   @Override
-  protected V1alpha1View toK8sObject(ViewTable view) {
-    String name = K8sUtils.canonicalizeName(view.getViewPath());
-    LinkedList<String> q = new LinkedList<>(view.getViewPath());
-    return new V1alpha1View().kind(K8sApiEndpoints.VIEWS.kind())
+  protected V1alpha1View toK8sObject() {
+    String name = K8sUtils.canonicalizeName(view.path());
+    LinkedList<String> q = new LinkedList<>(view.path());
+    return new V1alpha1View()
+        .kind(K8sApiEndpoints.VIEWS.kind())
         .apiVersion(K8sApiEndpoints.VIEWS.apiVersion())
-        .metadata(new V1ObjectMeta().name(name))
-        .spec(
-            new V1alpha1ViewSpec().view(q.pollLast()).schema(q.pollLast()).sql(view.getViewSql()).materialized(false));
+        .metadata(new V1ObjectMeta()
+          .name(name))
+        .spec(new V1alpha1ViewSpec()
+            .view(q.pollLast())
+            .schema(q.pollLast())
+            .sql(view.viewSql())
+            .materialized(materialized));
   }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployer.java
@@ -5,7 +5,7 @@ import java.sql.SQLException;
 import com.linkedin.hoptimator.Deployer;
 
 
-public abstract class K8sYamlDeployer<T> implements Deployer<T> {
+public abstract class K8sYamlDeployer implements Deployer {
 
   private K8sYamlApi api;
 
@@ -14,22 +14,22 @@ public abstract class K8sYamlDeployer<T> implements Deployer<T> {
   }
 
   @Override
-  public void create(T t) throws SQLException {
-    for (String spec : specify(t)) {
+  public void create() throws SQLException {
+    for (String spec : specify()) {
       api.create(spec);
     }
   }
 
   @Override
-  public void delete(T t) throws SQLException {
-    for (String spec : specify(t)) {
+  public void delete() throws SQLException {
+    for (String spec : specify()) {
       api.delete(spec);
     }
   }
 
   @Override
-  public void update(T t) throws SQLException {
-    for (String spec : specify(t)) {
+  public void update() throws SQLException {
+    for (String spec : specify()) {
       api.update(spec);
     }
   }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployerImpl.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployerImpl.java
@@ -1,0 +1,20 @@
+package com.linkedin.hoptimator.k8s;
+
+import java.util.List;
+
+
+/** Deploys a set of objects specified in YAML */
+public class K8sYamlDeployerImpl extends K8sYamlDeployer {
+
+  private final List<String> specs;
+
+  public K8sYamlDeployerImpl(K8sContext context, List<String> specs) {
+    super(context); 
+    this.specs = specs;
+  }
+
+  @Override
+  public List<String> specify() {
+    return specs;
+  }
+}

--- a/hoptimator-kafka/src/test/resources/kafka-ddl.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl.id
@@ -6,7 +6,6 @@ apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob
 metadata:
   name: kafka-database-existing-topic-1
-  namespace: flink
 spec:
   deploymentName: basic-session-deployment
   job:
@@ -26,7 +25,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-1
-  namespace: kafka
   labels:
     strimzi.io/cluster: one
 spec:
@@ -41,7 +39,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-2
-  namespace: kafka
   labels:
     strimzi.io/cluster: one
 spec:

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConnectionService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConnectionService.java
@@ -19,11 +19,11 @@ public final class ConnectionService {
   private ConnectionService() {
   }
 
-  public static <T> Map<String, String> configure(T object, Class<T> clazz, Properties connectionProperties)
+  public static <T> Map<String, String> configure(T obj, Properties connectionProperties)
         throws SQLException {
     Map<String, String> configs = new LinkedHashMap<>();
-    for (Connector<T> connector : connectors(clazz, connectionProperties)) {
-      configs.putAll(connector.configure(object));
+    for (Connector connector : connectors(obj, connectionProperties)) {
+      configs.putAll(connector.configure());
     }
     return configs;
   }
@@ -35,9 +35,9 @@ public final class ConnectionService {
     return providers;
   }
 
-  public static <T> Collection<Connector<T>> connectors(Class<T> clazz, Properties connectionProperties) {
+  public static <T> Collection<Connector> connectors(T obj, Properties connectionProperties) {
     return providers().stream()
-        .flatMap(x -> x.connectors(clazz, connectionProperties).stream())
+        .flatMap(x -> x.connectors(obj, connectionProperties).stream())
         .collect(Collectors.toList());
   }
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/RemoteToEnumerableConverter.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/RemoteToEnumerableConverter.java
@@ -92,8 +92,9 @@ public class RemoteToEnumerableConverter
   private SqlString generateSql(SqlDialect dialect) {
     RelRoot root = RelRoot.of(getInput(), SqlKind.SELECT);
     try {
-      PipelineRel.Implementor plan = DeploymentService.plan(root, connectionProperties);
-      return new SqlString(MysqlSqlDialect.DEFAULT, plan.query().apply(com.linkedin.hoptimator.SqlDialect.FLINK));  // TODO dialect
+      PipelineRel.Implementor plan = DeploymentService.plan(root);
+      return new SqlString(MysqlSqlDialect.DEFAULT, plan.query(connectionProperties)
+          .apply(com.linkedin.hoptimator.SqlDialect.FLINK));  // TODO dialect
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }

--- a/hoptimator-venice/src/test/resources/venice-ddl-insert-all.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-insert-all.id
@@ -6,7 +6,6 @@ apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob
 metadata:
   name: venice-test-store-1
-  namespace: flink
 spec:
   deploymentName: basic-session-deployment
   job:

--- a/hoptimator-venice/src/test/resources/venice-ddl-insert-partial.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-insert-partial.id
@@ -6,7 +6,6 @@ apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob
 metadata:
   name: venice-test-store-1
-  namespace: flink
 spec:
   deploymentName: basic-session-deployment
   job:

--- a/hoptimator-venice/src/test/resources/venice-ddl-select.id
+++ b/hoptimator-venice/src/test/resources/venice-ddl-select.id
@@ -6,7 +6,6 @@ apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob
 metadata:
   name: pipeline-sink
-  namespace: flink
 spec:
   deploymentName: basic-session-deployment
   job:


### PR DESCRIPTION
## Summary

- Add ownership references to pipeline elements.
- Defer specifying pipeline elements until they are deployed (instead of during planning).
- Simplify `Connector`, `Deployer`, `Validator`.
- Only support deploying objects that extend `Deployable`.
- Introduce `View` deployable.

## Details

`K8sMaterializedViewDeployer` now deploys the `View` and `Pipeline` objects, rather than having separate hooks deploying each. This enables us to create the `Pipeline` with an owner reference to the `View` object. It then goes on to deploy all the elements of the pipeline, creating/updating elements as needed. Each element is created/updated to include an owner reference to the `Pipeline` object.

Ownership thus is `View` --> `Pipeline` --> elements.

The deployer also tags deployed resources with a `pipeline` label, though this is not particularly useful.

Several small API changes were made to make this slightly easier.

N.B. ownership references cannot span namespaces. Creating an object with a non-existing owner causes the object to be immediately garbage-collected. This logic also applies if we try to create child objects in a different namespace, since the owner won't be found. To prevent this situation, the deployer enforces that pipeline elements all belong to the same namespace as the pipeline. In order to span namespaces, an operator _must_ be used in between. For example, I've configured the K8s operator to watch the `default` namespace, while deploying Kafka itself in the `kafka` namespace. This means pipelines in `default` can effect Kafka in `kafka`, but only because there is an operator in between.

## Testing

```
0: Hoptimator> create or replace materialized view kafka."blam" as select * from kafka."existing-topic-1";
No rows affected (2.154 seconds)
```

Then:

```
% kubectl tree view kafka-blam
NAMESPACE  NAME                                            READY  REASON            AGE
default    View/kafka-blam                                 -                        5m5s
default    └─Pipeline/kafka-blam                           -                        5m5s
default      ├─FlinkSessionJob/kafka-database-blam         -                        5m5s
default      ├─KafkaTopic/kafka-database-blam              True                     5m5s
default      └─KafkaTopic/kafka-database-existing-topic-1  False  ResourceConflict  5m5s
```

Also verified that `drop view` cleans up the entire tree.