### PR TITLE
Remove invalid hints from Properties inputs.

### DIFF
--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
@@ -29,7 +29,7 @@ import com.linkedin.hoptimator.util.planner.PipelineRules;
 
 public final class DeploymentService {
 
-  private static final String HINT_OPTION = "hints";
+  static final String HINT_OPTION = "hints";
   public static final String PIPELINE_OPTION = "pipeline";
 
   private DeploymentService() {
@@ -97,11 +97,19 @@ public final class DeploymentService {
   public static Map<String, String> parseHints(Properties connectionProperties) {
     Map<String, String> hints = new LinkedHashMap<>();
     if (connectionProperties.containsKey(HINT_OPTION)) {
-      hints.putAll(Splitter.on(',').withKeyValueSeparator('=').split(connectionProperties.getProperty(HINT_OPTION)));
+      String property = connectionProperties.getProperty(HINT_OPTION);
+      if (property != null && !property.isEmpty()) {
+        hints.putAll(Splitter.on(',').withKeyValueSeparator('=').split(property));
+      }
     }
+
     if (connectionProperties.containsKey(PIPELINE_OPTION)) {
-      hints.put(PIPELINE_OPTION, connectionProperties.getProperty(PIPELINE_OPTION));
+      String property = connectionProperties.getProperty(PIPELINE_OPTION);
+      if (property != null && !property.isEmpty()) {
+        hints.put(PIPELINE_OPTION, property);
+      }
     }
+
     return hints;
   }
 }

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
@@ -1,0 +1,50 @@
+package com.linkedin.hoptimator.util;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static com.linkedin.hoptimator.util.DeploymentService.HINT_OPTION;
+import static com.linkedin.hoptimator.util.DeploymentService.PIPELINE_OPTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+class DeploymentServiceTest {
+
+  /**
+   * "hint" keys <b>and</b> values are required to be non-{@code null}. A
+   * {@code null} or empty {@link Map} are considered invalid and should
+   * <b>not</b> be added to the {@link Properties} object.
+   * <br/>
+   * nb. "pipeline" values are <b>always</b> added when present.
+   */
+  @Test
+  void parseHints() {
+    Map<String, String> empty = DeploymentService.parseHints(new Properties());
+    assertTrue(empty.isEmpty(), "An empty map should not add `hints`.");
+
+    Map<String, String> nokey = DeploymentService.parseHints(new Properties() {{
+      put(HINT_OPTION, "");
+    }});
+    assertTrue(nokey.isEmpty(), "A map without keys should not add `hints`.");
+
+    Map<String, String> defined = DeploymentService.parseHints(new Properties() {{
+      put(HINT_OPTION, "key=value");
+    }});
+    assertEquals("value", defined.get("key"), "Did not match expected key value pair: `key=value`.");
+
+    Map<String, String> pipelineOnly = DeploymentService.parseHints(new Properties() {{
+      putAll(nokey);
+      put(PIPELINE_OPTION, "pipeline");
+    }});
+    assertEquals("pipeline", pipelineOnly.get(PIPELINE_OPTION), "Did not match expected `pipeline` value.");
+
+    Map<String, String> both = DeploymentService.parseHints(new Properties() {{
+      putAll(defined);
+      put(PIPELINE_OPTION, "pipeline");
+    }});
+    assertEquals("pipeline", both.get(PIPELINE_OPTION), "Did not match expected `pipeline` value.");
+  }
+}

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
@@ -1,5 +1,9 @@
 package com.linkedin.hoptimator.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -9,14 +13,15 @@ import static com.linkedin.hoptimator.util.DeploymentService.HINT_OPTION;
 import static com.linkedin.hoptimator.util.DeploymentService.PIPELINE_OPTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
 class DeploymentServiceTest {
 
   /**
-   * "hint" keys <b>and</b> values are required to be non-{@code null}. A
-   * {@code null} or empty {@link Map} are considered invalid and should
-   * <b>not</b> be added to the {@link Properties} object.
+   * "hint" keys <b>and</b> values are required to be non-{@code null}. An
+   * empty {@link Map} is considered invalid and should <b>not</b> be added
+   * to the {@link Properties} object.
    * <br/>
    * nb. "pipeline" values are <b>always</b> added when present.
    */
@@ -25,18 +30,17 @@ class DeploymentServiceTest {
     Map<String, String> empty = DeploymentService.parseHints(new Properties());
     assertTrue(empty.isEmpty(), "An empty map should not add `hints`.");
 
-    Map<String, String> nokey = DeploymentService.parseHints(new Properties() {{
-      put(HINT_OPTION, "");
-    }});
-    assertTrue(nokey.isEmpty(), "A map without keys should not add `hints`.");
-
     Map<String, String> defined = DeploymentService.parseHints(new Properties() {{
       put(HINT_OPTION, "key=value");
     }});
     assertEquals("value", defined.get("key"), "Did not match expected key value pair: `key=value`.");
 
+    Map<String, String> nokey = DeploymentService.parseHints(new Properties() {{
+      put(HINT_OPTION, "flag0=,flag1=");
+    }});
+    assertTrue(nokey.keySet().containsAll(Arrays.asList("flag0", "flag1")), "Expected to find flags.");
+
     Map<String, String> pipelineOnly = DeploymentService.parseHints(new Properties() {{
-      putAll(nokey);
       put(PIPELINE_OPTION, "pipeline");
     }});
     assertEquals("pipeline", pipelineOnly.get(PIPELINE_OPTION), "Did not match expected `pipeline` value.");


### PR DESCRIPTION
Validate contents of `Properties` object used for "hints". This is related to an issue (error below) reported by clients after deploying #117. The expected use of the "hints" and "pipeline" options are unchanged. The unit test validate the following conditions:
1. An empty "hints" map is ignored.
1. Non-empty "hints" are valid as either key value pairs **or** flags.
1. Parsing of "pipeline" occurs regardless of "hints" (no collision detection).

----
The input `Properties` parameter for `parseHints` included a "hints" key with an empty value.

```
Caused by: java.lang.IllegalArgumentException: Chunk [] is not a valid entry
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218) ~[com.google.guava.guava-33.3.1-jre.jar:?]
        at com.google.common.base.Splitter$MapSplitter.split(Splitter.java:523) ~[com.google.guava.guava-33.3.1-jre.jar:?]
        at com.linkedin.hoptimator.util.DeploymentService.parseHints(DeploymentService.java:100) ~[com.linkedin.hoptimator.hoptimator-util-0.0.37-alpha.jar:?]
        at com.linkedin.hoptimator.util.DeploymentService.plan(DeploymentService.java:90) ~[com.linkedin.hoptimator.hoptimator-util-0.0.37-alpha.jar:?]
...
```