### PR TITLE
Support nested arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ undeploy-samples: undeploy
 deploy-flink: deploy
 	kubectl create namespace flink || echo "skipping"
 	kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml || echo "skipping"
-	helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.9.0/
+	helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.11.0/
 	helm upgrade --install --atomic --set webhook.create=false,image.pullPolicy=Never,image.repository=docker.io/library/hoptimator-flink-operator,image.tag=latest --set-json='watchNamespaces=["default","flink"]' flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
 	kubectl apply -f deploy/dev/flink-session-cluster.yaml
 	kubectl apply -f deploy/dev/flink-sql-gateway.yaml

--- a/hoptimator-flink-runner/Dockerfile-flink-operator
+++ b/hoptimator-flink-runner/Dockerfile-flink-operator
@@ -1,2 +1,2 @@
-FROM apache/flink-kubernetes-operator:1.9.0
+FROM apache/flink-kubernetes-operator:1.11.0
 COPY ./build/libs/hoptimator-flink-runner-all.jar /opt/hoptimator-flink-runner.jar

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DataTypeUtils.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DataTypeUtils.java
@@ -16,9 +16,9 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 public final class DataTypeUtils {
 
-  private static final String ARRAY_TYPE = "arrType";
-  private static final String MAP_KEY_TYPE = "keyType";
-  private static final String MAP_VALUE_TYPE = "valueType";
+  private static final String ARRAY_TYPE = "__ARRTYPE__";
+  private static final String MAP_KEY_TYPE = "__MAPKEYTYPE__";
+  private static final String MAP_VALUE_TYPE = "__MAPVALUETYPE__";
 
   private DataTypeUtils() {
   }

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
@@ -1,9 +1,6 @@
 package com.linkedin.hoptimator.util;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -13,7 +10,6 @@ import static com.linkedin.hoptimator.util.DeploymentService.HINT_OPTION;
 import static com.linkedin.hoptimator.util.DeploymentService.PIPELINE_OPTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
 class DeploymentServiceTest {

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestDataTypeUtils.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestDataTypeUtils.java
@@ -75,12 +75,10 @@ public class TestDataTypeUtils {
     Assertions.assertEquals(9, flattenedType.getFieldList().size());
     List<String> flattenedNames = flattenedType.getFieldList().stream().map(RelDataTypeField::getName)
         .collect(Collectors.toList());
-    System.out.println(flattenedNames);
     Assertions.assertIterableEquals(Arrays.asList("FOO", "FOO$QUX", "FOO$QIZ", "BAR", "BAR$BAZ", "CAR", "DAY",
             "DAY$__ARRTYPE__", "DAY$__ARRTYPE__$__ARRTYPE__"), flattenedNames);
     String flattenedConnector = new ScriptImplementor.ConnectorImplementor("S", "T1",
         flattenedType, Collections.emptyMap()).sql();
-    System.out.println(flattenedConnector);
     Assertions.assertEquals("CREATE TABLE IF NOT EXISTS `S`.`T1` ("
             + "`FOO` ANY ARRAY, `FOO_QUX` VARCHAR, `FOO_QIZ` VARCHAR ARRAY, "
             + "`BAR` ANY ARRAY, `BAR_BAZ` VARCHAR, "

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestDataTypeUtils.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestDataTypeUtils.java
@@ -77,7 +77,7 @@ public class TestDataTypeUtils {
         .collect(Collectors.toList());
     System.out.println(flattenedNames);
     Assertions.assertIterableEquals(Arrays.asList("FOO", "FOO$QUX", "FOO$QIZ", "BAR", "BAR$BAZ", "CAR", "DAY",
-            "DAY$arrType", "DAY$arrType$arrType"), flattenedNames);
+            "DAY$__ARRTYPE__", "DAY$__ARRTYPE__$__ARRTYPE__"), flattenedNames);
     String flattenedConnector = new ScriptImplementor.ConnectorImplementor("S", "T1",
         flattenedType, Collections.emptyMap()).sql();
     System.out.println(flattenedConnector);
@@ -85,7 +85,7 @@ public class TestDataTypeUtils {
             + "`FOO` ANY ARRAY, `FOO_QUX` VARCHAR, `FOO_QIZ` VARCHAR ARRAY, "
             + "`BAR` ANY ARRAY, `BAR_BAZ` VARCHAR, "
             + "`CAR` FLOAT ARRAY, "
-            + "`DAY` ANY ARRAY, `DAY_arrType` ANY ARRAY, `DAY_arrType_arrType` VARCHAR ARRAY) WITH ();",
+            + "`DAY` ANY ARRAY, `DAY___ARRTYPE__` ANY ARRAY, `DAY___ARRTYPE_____ARRTYPE__` VARCHAR ARRAY) WITH ();",
         flattenedConnector, "Flattened connector should have simplified arrays");
 
     RelDataType unflattenedType = DataTypeUtils.unflatten(flattenedType, typeFactory);
@@ -124,13 +124,13 @@ public class TestDataTypeUtils {
     Assertions.assertEquals(3, flattenedType.getFieldList().size());
     List<String> flattenedNames = flattenedType.getFieldList().stream().map(RelDataTypeField::getName)
         .collect(Collectors.toList());
-    Assertions.assertIterableEquals(Arrays.asList("FOO$keyType", "FOO$valueType$QIZ$BAR", "FOO$valueType$QIZ$CAR"), flattenedNames);
+    Assertions.assertIterableEquals(Arrays.asList("FOO$__MAPKEYTYPE__", "FOO$__MAPVALUETYPE__$QIZ$BAR", "FOO$__MAPVALUETYPE__$QIZ$CAR"), flattenedNames);
     String flattenedConnector = new ScriptImplementor.ConnectorImplementor("S", "T1",
         flattenedType, Collections.emptyMap()).sql();
     Assertions.assertEquals("CREATE TABLE IF NOT EXISTS `S`.`T1` ("
-            + "`FOO_keyType` ROW(`QUX` VARCHAR), "
-            + "`FOO_valueType_QIZ_BAR` VARCHAR, "
-            + "`FOO_valueType_QIZ_CAR` INTEGER) WITH ();", flattenedConnector,
+            + "`FOO___MAPKEYTYPE__` ROW(`QUX` VARCHAR), "
+            + "`FOO___MAPVALUETYPE___QIZ_BAR` VARCHAR, "
+            + "`FOO___MAPVALUETYPE___QIZ_CAR` INTEGER) WITH ();", flattenedConnector,
         "Flattened connector should have simplified map");
 
     RelDataType unflattenedType = DataTypeUtils.unflatten(flattenedType, typeFactory);


### PR DESCRIPTION
#95 was responsible for handling arrays of several types and arrays of row types however there was a gap supporting arrays of arrays i.e. `Array<Array<Varchar>`

This change handles support for any number of nested arrays. Nested arrays are "flattened" into separate types for each level and are reconstructed when unflattened back into the nested type