### PR TITLE
Assert column names for partial views

### DIFF
--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
@@ -141,6 +141,13 @@ public interface PipelineRel extends RelNode {
       RelDataType targetRowType = sinkRowType;
       if (targetRowType == null) {
         targetRowType = query.getRowType();
+      } else {
+        // Assert target fields exist in the sink schema when the sink schema is known (partial view use case)
+        for (String fieldName : targetFields.rightList()) {
+          if (!targetRowType.getFieldNames().contains(fieldName)) {
+            throw new IllegalArgumentException("Field " + fieldName + " not found in sink schema");
+          }
+        }
       }
       Map<String, String> sinkConfigs = ConnectionService.configure(sink, connectionProperties);
       script = script.database(sink.schema());


### PR DESCRIPTION
Adds validation for column names when doing a partial view (i.e. view on table that already exists).

Tests:
- New view, column names don't matter, no validation done
```
0: Hoptimator> create or replace materialized view venice."new-view" as select "KEY" as "KEY_id", "VALUE" as stringField from kafka."existing-topic-1";
No rows affected (0.517 seconds)
```

- Valid column names for partial view
```
0: Hoptimator> create or replace materialized view venice."test-store$my-view" as select "KEY" as "KEY_id", "VALUE" as "stringField" from kafka."existing-topic-1";
No rows affected (1.684 seconds)
```

- Invalid column name for partial view
```
0: Hoptimator> create or replace materialized view venice."test-store$my-view" as select "KEY" as "KEY_id", "VALUE" as stringField from kafka."existing-topic-1";
Error: Error while executing SQL "create or replace materialized view venice."test-store$my-view" as select "KEY" as "KEY_id", "VALUE" as stringField from kafka."existing-topic-1"": Cannot CREATE MATERIALIZED VIEW in VENICE: Field STRINGFIELD not found in sink schema (state=,code=0)

0: Hoptimator> create or replace materialized view "VENICE"."test-store-1$view" ("KEY_id", intField) as select "KEY_id", "stringField" from "VENICE"."test-store";
Error: Error while executing SQL "create or replace materialized view "VENICE"."test-store-1$view" ("KEY_id", intField) as select "KEY_id", "stringField" from "VENICE"."test-store"": Cannot CREATE MATERIALIZED VIEW in VENICE: Field INTFIELD not found in sink schema (state=,code=0)
```