### PR TITLE
Fix pipeline ownership on update

### DIFF
--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
@@ -4,6 +4,8 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import io.kubernetes.client.common.KubernetesListObject;
@@ -137,7 +139,17 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
       }
       existing.getObject().getMetadata().setLabels(labels);
 
+      List<V1OwnerReference> owners = new LinkedList<>();
+      if (existing.getObject().getMetadata().getOwnerReferences() != null) {
+        owners.addAll(existing.getObject().getMetadata().getOwnerReferences());
+      }
+      if (obj.getMetadata().getOwnerReferences() != null) {
+        owners.addAll(obj.getMetadata().getOwnerReferences());
+      }
+      existing.getObject().getMetadata().setOwnerReferences(owners);
+
       obj.getMetadata().resourceVersion(existing.getObject().getMetadata().getResourceVersion());
+      context.own(obj);
       resp = context.<T, U>generic(endpoint).update(obj);
     } else {
       context.own(obj);

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
@@ -137,7 +137,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
       if (obj.getMetadata().getLabels() != null) {
         labels.putAll(obj.getMetadata().getLabels());
       }
-      existing.getObject().getMetadata().setLabels(labels);
+      obj.getMetadata().setLabels(labels);
 
       List<V1OwnerReference> owners = new LinkedList<>();
       if (existing.getObject().getMetadata().getOwnerReferences() != null) {
@@ -146,7 +146,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
       if (obj.getMetadata().getOwnerReferences() != null) {
         owners.addAll(obj.getMetadata().getOwnerReferences());
       }
-      existing.getObject().getMetadata().setOwnerReferences(owners);
+      obj.getMetadata().setOwnerReferences(owners);
 
       obj.getMetadata().resourceVersion(existing.getObject().getMetadata().getResourceVersion());
       context.own(obj);


### PR DESCRIPTION
There was a bug if you recreate the same materialized view, the pipeline ownership to the view was getting thrown out.

```
0: Hoptimator> create or replace materialized view venice."test-store$my-view4" as select "KEY" as "KEY_id", "VALUE" as "stringField" from kafka."existing-topic-1";
No rows affected (1.9 seconds)

kind: Pipeline
metadata:
  creationTimestamp: "2025-03-17T21:34:56Z"
  generation: 1
  name: venice-test-store-my-view4
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: View
    name: venice-test-store-my-view4
    uid: 80db4704-02a8-4a5f-af63-8167ea2b213a
```