### PR TITLE
Fix issue with complex union avro record

### DIFF
--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
@@ -123,9 +123,11 @@ public final class AvroConverter {
           Schema innerType = schema.getTypes().stream().filter(x -> x.getType() != Schema.Type.NULL).findFirst().get();
           return typeFactory.createTypeWithNullability(rel(innerType, typeFactory, true), true);
         }
+        // Since we collapse complex unions into separate fields, each of these fields needs to be nullable
+        // as only one of the group will be present in any given record.
         return typeFactory.createTypeWithNullability(typeFactory.createStructType(schema.getTypes().stream()
             .filter(x -> x.getType() != Schema.Type.NULL)
-            .map(x -> new AbstractMap.SimpleEntry<>(x.getName(), rel(x, typeFactory, isNullable)))
+            .map(x -> new AbstractMap.SimpleEntry<>(x.getName(), rel(x, typeFactory, true)))
             .filter(x -> x.getValue().getSqlTypeName() != SqlTypeName.NULL)
             .filter(x -> x.getValue().getSqlTypeName() != unknown.getSqlTypeName())
             .collect(Collectors.toList())), isNullable);


### PR DESCRIPTION
Unions of several types are flattened into a structured type when we create an Avro schema. These fields need to be nullable inside of this type. We already handle complex arrays in this manner, was just missing for unions.

Below describes the before & after for this change, fields are obfuscated from the actual schemas.

Before change:
```
!specify INSERT INTO venice."my_store" ("KEY", "arrayField") SELECT CASE WHEN "union"['type1']['keyField'] IS NOT NULL THEN "union"['type1]['keyField'] ELSE "event"['type2']['keyField'] END AS "KEY", CASE WHEN "union"['type1']['arrayField'] IS NOT NULL THEN "union"['type1']['arrayField'] ELSE "union"['type2']['arrayField'] END AS "arrayField" FROM "kafka"."my_topic"

...
- CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
- CREATE TABLE IF NOT EXISTS `KAFKA`.`my_topic` ...
- CREATE DATABASE IF NOT EXISTS `VENICE` WITH ();
- CREATE TABLE IF NOT EXISTS `VENICE`.`my_store` ...
- INSERT INTO `VENICE`.`paths_to_roots` (`KEY`, `arrayField`) SELECT `union`['type1']['keyField'] AS `KEY`, CASE WHEN `union`['type1']['arrayField'] IS NOT NULL THEN `union`['type1']['arrayField'] ELSE `union`['type2']['arrayField'] END AS `arrayField` FROM `kafka`.`my_topic`;
```

After change:
```
!specify INSERT INTO venice."my_store" ("KEY", "arrayField") SELECT CASE WHEN "union"['type1']['keyField'] IS NOT NULL THEN "union"['type1]['keyField'] ELSE "event"['type2']['keyField'] END AS "KEY", CASE WHEN "union"['type1']['arrayField'] IS NOT NULL THEN "union"['type1']['arrayField'] ELSE "union"['type2']['arrayField'] END AS "arrayField" FROM "kafka"."my_topic"

- CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
- CREATE TABLE IF NOT EXISTS `KAFKA`.`my_topic` ...
- CREATE DATABASE IF NOT EXISTS `VENICE` WITH ();
- CREATE TABLE IF NOT EXISTS `VENICE`.`my_store` ...
- INSERT INTO `VENICE`.`paths_to_roots` (`KEY`, `ancestor_entity_urn_set`) SELECT CASE WHEN `union`['type1']['keyField'] IS NOT NULL THEN `union`['type1']['keyField'] ELSE `union`['type2']['keyField'] END AS `KEY`, CASE WHEN `union`['type1']['arrayField'] IS NOT NULL THEN `union`['type1']['arrayField'] ELSE `union`['type2']['arrayField'] END AS `arrayField` FROM `kafka`.`my_topic`;
```
