### PR TITLE
Support connector hint passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ These fields can then be added to templates as `{{kafka.partitions}}` or `{{flin
 
 2. Connector hints allow the user to pass configurations directly through to an Engine (e.g. Flink).
 
-Connector hints must be formatted as follows `<schema>.<source|sink>.<configName>`
+Connector hints must be formatted as follows `<engine-connector-name>.<source|sink>.<configName>`
 
 For example, to set a Kafka group id and startup mode to be used by Flink, you could add the following hints to the connection:
 ```
-jdbc:hoptimator://hints=KAFKA.source.properties.group.id=4,KAFKA.sink.sink.parallelism=2
+jdbc:hoptimator://hints=kafka.source.properties.group.id=4,kafka.sink.sink.parallelism=2
 ```
-Field `properties.group.id` will be applied if the `KAFKA` schema is used as a source, and `sink.parallelism`
-if the `KAFKA` schema is used as a sink.
+Field `properties.group.id` will be applied if the `kafka` connector is used by a source, and `sink.parallelism`
+if the `kafka` connector is used by a sink.
 
 Note that hints are simply recommendations, if the planner plans a different pipeline, they will be ignored.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,18 @@ This can be done by adding hints as JDBC properties.
 
 Hints are key-value pairs separated by an equals sign. Multiple hints are separated by a comma.
 
-For example, to specify the number of kafka partitions and the flink parallelism, you could add the following hints to the query:
+There are two ways to use hints.
+
+1. Hints prefixed with the schema name, will automatically be added as connector properties when that schema is used.
+For example, to set a Kafka group id and startup mode to be used by Flink, you could add the following hints to the connection:
+```
+jdbc:hoptimator://hints=KAFKA.source.properties.group.id=4,KAFKA.sink.sink.parallelism=2
+```
+Field `properties.group.id` will be applied if the `KAFKA` schema is used as a source, and `sink.parallelism`
+if the `KAFKA` schema is used as a sink.
+
+2. Hints can override template options for use cases where a default is required.
+For example, to specify the number of kafka partitions and the flink parallelism, you could add the following hints to the connection:
 ```
 jdbc:hoptimator://hints=kafka.partitions=4,flink.parallelism=2
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ In this case, any jobs created with this template will get deployed as `FlinkSes
 
 ### Configuration
 
-The ``{{ }}`` sections you see in the templates are variable placeholders that will be filled in by the Deployer.
+The `{{ }}` sections you see in the templates are variable placeholders that will be filled in by the Deployer.
 See [Template.java](hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java) for how to specify templates.
 
 While Deployers are extensible, today the primary deployer is to Kubernetes. These deployers 
@@ -182,19 +182,23 @@ Hints are key-value pairs separated by an equals sign. Multiple hints are separa
 
 There are two ways to use hints.
 
-1. Hints prefixed with the schema name, will automatically be added as connector properties when that schema is used.
+1. Template hints can be used to override the `{{ }}` template specifications. 
+
+For example, to specify the number of kafka partitions and the flink parallelism, you could add the following hints to the connection:
+```
+jdbc:hoptimator://hints=kafka.partitions=4,flink.parallelism=2
+```
+These fields can then be added to templates as `{{kafka.partitions}}` or `{{flink.parallelism}}` where applicable.
+
+2. Connector hints allow the user to pass configurations directly through to an Engine (e.g. Flink).
+
+Connector hints must be formatted as follows `<schema>.<source|sink>.<configName>`
+
 For example, to set a Kafka group id and startup mode to be used by Flink, you could add the following hints to the connection:
 ```
 jdbc:hoptimator://hints=KAFKA.source.properties.group.id=4,KAFKA.sink.sink.parallelism=2
 ```
 Field `properties.group.id` will be applied if the `KAFKA` schema is used as a source, and `sink.parallelism`
 if the `KAFKA` schema is used as a sink.
-
-2. Hints can override template options for use cases where a default is required.
-For example, to specify the number of kafka partitions and the flink parallelism, you could add the following hints to the connection:
-```
-jdbc:hoptimator://hints=kafka.partitions=4,flink.parallelism=2
-```
-These fields can then be added to templates as `{{kafka.partitions}}` or `{{flink.parallelism}}` where applicable.
 
 Note that hints are simply recommendations, if the planner plans a different pipeline, they will be ignored.

--- a/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
+++ b/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
@@ -11,6 +11,6 @@ public class TestSqlScripts extends QuidemTestBase {
   @Test
   @Tag("integration")
   public void kafkaDdlScript() throws Exception {
-    run("kafka-ddl.id", "hints=kafka.partitions=4,flink.parallelism=2,KAFKA.source.k1=v1,KAFKA.sink.k2=v2");
+    run("kafka-ddl.id", "hints=kafka.partitions=4,flink.parallelism=2,kafka.source.k1=v1,kafka.sink.k2=v2");
   }
 }

--- a/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
+++ b/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
@@ -11,6 +11,6 @@ public class TestSqlScripts extends QuidemTestBase {
   @Test
   @Tag("integration")
   public void kafkaDdlScript() throws Exception {
-    run("kafka-ddl.id", "hints=kafka.partitions=4,flink.parallelism=2");
+    run("kafka-ddl.id", "hints=kafka.partitions=4,flink.parallelism=2,KAFKA.source.k1=v1,KAFKA.sink.k2=v2");
   }
 }

--- a/hoptimator-kafka/src/test/resources/kafka-ddl.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl.id
@@ -12,9 +12,9 @@ spec:
     entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
     args:
     - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ()
-    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json')
+    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'k1'='v1', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json')
     - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ()
-    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json')
+    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'k2'='v2', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json')
     - INSERT INTO `KAFKA`.`existing-topic-1` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`
     jarURI: file:///opt/hoptimator-flink-runner.jar
     parallelism: 2

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
@@ -107,7 +107,7 @@ public interface Template {
     private String formatPropertiesAsString(Properties props) {
       StringBuilder stringBuilder = new StringBuilder();
       for (String key : props.stringPropertyNames()) {
-        stringBuilder.append(key).append(": ").append(props.getProperty(key)).append("\n");
+        stringBuilder.append(key).append(": '").append(props.getProperty(key)).append("'\n");
       }
       return stringBuilder.toString();
     }


### PR DESCRIPTION
Supports automatic connector hint passthrough without the need for templates.

Format is expected as `<engine-connector-name>.<source|sink>.<connectorConfigName>`

See README for more information

Also fixed a bug when applying sqljob yaml for configs where it would complain about ints or booleans because it wasn't surrounded in single quotes.