### PR TITLE
Add retriable/transient exceptions

### DIFF
--- a/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/DemoDriver.java
+++ b/hoptimator-demodb/src/main/java/com/linkedin/hoptimator/demodb/DemoDriver.java
@@ -3,6 +3,8 @@ package com.linkedin.hoptimator.demodb;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientException;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
@@ -63,8 +65,11 @@ public class DemoDriver extends Driver {
         rootSchema.add("ADS", new AdsSchema());
       }
       return connection;
+    } catch (IOException e) {
+      throw new SQLTransientException("Problem loading " + url, e);
     } catch (Exception e) {
-      throw new SQLException("Problem loading " + url, e);
+      throw new SQLNonTransientException("Problem loading " + url, e);
     }
+ 
   }
 }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
@@ -5,6 +5,9 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientConnectionException;
+import java.sql.SQLTransientException;
 import java.util.Properties;
 import java.util.logging.LogManager;
 
@@ -127,10 +130,11 @@ public class HoptimatorDriver implements java.sql.Driver {
           CatalogService.catalog(catalog).register(wrapped);
         }
       }
-
       return hoptimatorConnection;
+    } catch (IOException|SQLTransientException e) {
+      throw new SQLTransientConnectionException("Problem loading " + url, e);
     } catch (Exception e) {
-      throw new SQLException("Problem loading " + url, e);
+      throw new SQLNonTransientException("Problem loading " + url, e);
     }
   }
 

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ValidationService.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ValidationService.java
@@ -1,6 +1,7 @@
 package com.linkedin.hoptimator.jdbc;
 
 import java.sql.Connection;
+import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -53,7 +54,7 @@ public final class ValidationService {
     Validator.Issues issues = new Validator.Issues("");
     validate(obj, issues);
     if (!issues.valid()) {
-      throw new SQLException("Failed validation:\n" + issues.toString());
+      throw new SQLDataException("Failed validation:\n" + issues.toString());
     }
   }
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
@@ -48,13 +48,13 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     } else {
       resp = context.<T, U>generic(endpoint).get(context.namespace(), name);
     }
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error getting " + name, resp);
     return resp.getObject();
   }
 
   public T get(String namespace, String name) throws SQLException {
     KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).get(namespace, name);
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error getting " + name, resp);
     return resp.getObject();
   }
 
@@ -68,7 +68,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     } else {
       resp  = context.<T, U>generic(endpoint).get(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
     }
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error getting " + obj.getMetadata().getName(), resp);
     return resp.getObject();
   }
 
@@ -95,7 +95,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     if (resp.getHttpStatusCode() == 404) {
       return Collections.emptyList();
     }
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error selecting " + labelSelector, resp);
     return (Collection<T>) resp.getObject().getItems();
   }
 
@@ -106,7 +106,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     }
     context.own(obj);
     KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).create(obj);
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error creating " + obj.getMetadata().getName(), resp);
     log.info("Created K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
 
@@ -117,7 +117,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     }
     KubernetesApiResponse<T> resp =
         context.<T, U>generic(endpoint).delete(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error deleting " + obj.getMetadata().getName(), resp);
     log.info("Deleted K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
 
@@ -161,7 +161,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
       context.own(obj);
       resp = context.<T, U>generic(endpoint).create(obj);
     }
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error updating " + obj.getMetadata().getName(), resp);
     log.info("Updated K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
 
@@ -170,13 +170,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
       obj.getMetadata().namespace(context.namespace());
     }
     KubernetesApiResponse<T> resp = context.<T, U>generic(endpoint).updateStatus(obj, x -> status);
-    checkResponse(resp);
+    K8sUtils.checkResponse("Error updating status of " + obj.getMetadata().getName(), resp);
     log.info("Updated K8s obj status: {}:{}", obj.getKind(), obj.getMetadata().getName());
-  }
-
-  private void checkResponse(KubernetesApiResponse<?> resp) throws SQLException {
-    if (!resp.isSuccess()) {
-      throw new SQLException(resp.getStatus().getMessage() + ": " + context, null, resp.getHttpStatusCode());
-    }
   }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sConnector.java
@@ -48,7 +48,8 @@ class K8sConnector implements Connector {
     try {
       props.load(new StringReader(configs));
     } catch (IOException e) {
-      throw new SQLException(e);
+      // This doesn't seem possible.
+      throw new RuntimeException(e);
     }
     Map<String, String> map = new LinkedHashMap<>();
     props.stringPropertyNames().stream().sorted().forEach(k ->

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
@@ -1,6 +1,8 @@
 package com.linkedin.hoptimator.k8s;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +38,7 @@ public class K8sYamlApi implements Api<String> {
     context.own(obj);
     KubernetesApiResponse<DynamicKubernetesObject> resp =
         context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj);
-    checkResponse(yaml, resp);
+    K8sUtils.checkResponse("Error creating YAML:\n" + yaml, resp);
     log.info("Created K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
 
@@ -46,7 +48,7 @@ public class K8sYamlApi implements Api<String> {
     KubernetesApiResponse<DynamicKubernetesObject> resp =
         context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj))
             .delete(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
-    checkResponse(yaml, resp);
+    K8sUtils.checkResponse("Error deleting YAML:\n" + yaml, resp);
     log.info("Deleted K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
 
@@ -75,7 +77,7 @@ public class K8sYamlApi implements Api<String> {
       context.own(obj);
       resp = context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj);
     }
-    checkResponse(yaml, resp);
+    K8sUtils.checkResponse("Error updating YAML:\n" + yaml, resp);
     log.info("Updated K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
 
@@ -85,13 +87,5 @@ public class K8sYamlApi implements Api<String> {
       obj.setMetadata(obj.getMetadata().namespace(context.namespace()));
     }
     return obj;
-  }
-
-  private void checkResponse(String yaml, KubernetesApiResponse<?> resp) throws SQLException {
-    try {
-      resp.throwsApiException();
-    } catch (ApiException e) {
-      throw new SQLException("Error applying Kubernetes YAML:\n" + yaml, e);
-    }
   }
 }

--- a/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
+++ b/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDriver.java
@@ -3,6 +3,8 @@ package com.linkedin.hoptimator.kafka;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientException;
 import java.util.Properties;
 
 import org.apache.calcite.avatica.ConnectStringParser;
@@ -49,8 +51,10 @@ public class KafkaDriver extends Driver {
       schema.populate();
       rootSchema.add("KAFKA", schema);
       return connection;
+    } catch (IOException e) {
+      throw new SQLTransientException("Problem loading " + url, e);
     } catch (Exception e) {
-      throw new SQLException("Problem loading " + url, e);
+      throw new SQLNonTransientException("Problem loading " + url, e);
     }
   }
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
@@ -1,6 +1,7 @@
 package com.linkedin.hoptimator.util.planner;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -145,7 +146,7 @@ public interface PipelineRel extends RelNode {
         // Assert target fields exist in the sink schema when the sink schema is known (partial view use case)
         for (String fieldName : targetFields.rightList()) {
           if (!targetRowType.getFieldNames().contains(fieldName)) {
-            throw new IllegalArgumentException("Field " + fieldName + " not found in sink schema");
+            throw new SQLNonTransientException("Field " + fieldName + " not found in sink schema");
           }
         }
       }

--- a/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
+++ b/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
@@ -3,7 +3,11 @@ package com.linkedin.hoptimator.venice;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientConnectionException;
+import java.sql.SQLTransientException;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.calcite.avatica.ConnectStringParser;
 import org.apache.calcite.avatica.DriverVersion;
@@ -53,8 +57,10 @@ public class VeniceDriver extends Driver {
       schema.populate();
       rootSchema.add(CATALOG_NAME, schema);
       return connection;
+    } catch (IOException|ExecutionException|InterruptedException e) {
+      throw new SQLTransientConnectionException("Problem loading " + url, e);
     } catch (Exception e) {
-      throw new SQLException("Problem loading " + url, e);
+      throw new SQLNonTransientException("Problem loading " + url, e);
     }
   }
 


### PR DESCRIPTION
## Summary

- Throw `SQLNonTransientException` (or derivative) for validation errors, etc.
- Throw `SQLTransientConnectionException` for IO errors encountered when loading the catalog, etc.

## Details

Calcite frequently uses unchecked exceptions, and Hoptimator follows that pattern where necessary. Unfortunately, this means client code often receives opaque `RuntimeException`s. Where possible, we want to instead throw `SQL[Non]TransientException`, s.t. client code can decide whether to retry or surface an error to users.

## Testing

None. Client code will be tested externally.

N.B. we don't expect 100% coverage wrt this transient-vs-non-transient distinction at this point. As future `RuntimeException`s are encountered, we may need to revisit this problem.
