### PR TITLE
Fix PipelineReconciler namespace

### DIFF
--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorBase.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CompatibilityValidatorBase.java
@@ -12,7 +12,7 @@ abstract class CompatibilityValidatorBase implements Validator {
 
   private final SchemaPlus schema;
 
-  public CompatibilityValidatorBase(SchemaPlus schema) {
+  CompatibilityValidatorBase(SchemaPlus schema) {
     this.schema = schema;
   }
 

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -20,7 +20,6 @@
 package com.linkedin.hoptimator.jdbc;
 
 import java.io.Reader;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +46,6 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
-import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.ddl.SqlCreateMaterializedView;
 import org.apache.calcite.sql.ddl.SqlCreateView;
 import org.apache.calcite.sql.ddl.SqlDropObject;
@@ -68,8 +66,6 @@ import com.linkedin.hoptimator.Pipeline;
 import com.linkedin.hoptimator.View;
 import com.linkedin.hoptimator.util.DeploymentService;
 import com.linkedin.hoptimator.util.planner.PipelineRel;
-
-import static org.apache.calcite.util.Static.RESOURCE;
 
 
 public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
@@ -135,7 +131,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       schemaPlus.add(viewName, viewTable);
     } catch (Exception e) {
       throw new DdlException(create, e.getMessage(), e);
-    } 
+    }
   }
 
   // N.B. copy-pasted from Apache Calcite

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDriver.java
@@ -131,7 +131,7 @@ public class HoptimatorDriver implements java.sql.Driver {
         }
       }
       return hoptimatorConnection;
-    } catch (IOException|SQLTransientException e) {
+    } catch (IOException | SQLTransientException e) {
       throw new SQLTransientConnectionException("Problem loading " + url, e);
     } catch (Exception e) {
       throw new SQLNonTransientException("Problem loading " + url, e);

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sContext.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sContext.java
@@ -43,7 +43,7 @@ public class K8sContext {
 
   private final String namespace;
   private final String clientInfo;
-  private ApiClient apiClient;
+  private final ApiClient apiClient;
   private final SharedInformerFactory informerFactory;
   private final V1OwnerReference ownerReference;
   private final Map<String, String> labels;

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
@@ -1,16 +1,16 @@
 package com.linkedin.hoptimator.k8s;
 
 import java.sql.SQLException;
-import java.sql.SQLTransientException;
 import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientException;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.kubernetes.client.common.KubernetesType;
-import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.util.generic.KubernetesApiResponse;
 
 import com.linkedin.hoptimator.Sink;
 import com.linkedin.hoptimator.Source;

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
@@ -1,8 +1,6 @@
 package com.linkedin.hoptimator.k8s;
 
 import java.sql.SQLException;
-import java.sql.SQLNonTransientException;
-import java.sql.SQLTransientException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -10,7 +8,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 import io.kubernetes.client.util.generic.dynamic.Dynamics;

--- a/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
+++ b/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDriver.java
@@ -5,7 +5,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
 import java.sql.SQLTransientConnectionException;
-import java.sql.SQLTransientException;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
@@ -57,7 +56,7 @@ public class VeniceDriver extends Driver {
       schema.populate();
       rootSchema.add(CATALOG_NAME, schema);
       return connection;
-    } catch (IOException|ExecutionException|InterruptedException e) {
+    } catch (IOException | ExecutionException | InterruptedException e) {
       throw new SQLTransientConnectionException("Problem loading " + url, e);
     } catch (Exception e) {
       throw new SQLNonTransientException("Problem loading " + url, e);


### PR DESCRIPTION
An incorrect assumption was made that the yaml of each sub-resource inside the pipeline object will contain its own namespace information. While this can be true if the corresponding table/job template explicitly set their own namespace, in most cases the namespace is set automatically at resource creation time to be the same as the pipeline object.
- The explicit setting of namespaces will only ever be needed if deploying resources across namespaces, which isn't supported today anyway as this breaks the Kubernetes ownership model.

Also fix various checkstyle issues