### PR TITLE
Refactor status prediction logic in PipelineReconciler to a common package

### DIFF
--- a/hoptimator-k8s/build.gradle
+++ b/hoptimator-k8s/build.gradle
@@ -18,6 +18,9 @@ dependencies {
   testImplementation(testFixtures(project(':hoptimator-jdbc')))
   testImplementation(platform('org.junit:junit-bom:5.11.3'))
   testImplementation 'org.junit.jupiter:junit-jupiter'
+  testImplementation 'org.mockito:mockito-junit-jupiter:5.+'
+  testImplementation 'org.mockito:mockito-core:5.+'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.+'
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testRuntimeOnly libs.slf4j.simple

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatus.java
@@ -1,0 +1,48 @@
+package com.linkedin.hoptimator.k8s.status;
+
+/** Represents status of an element which belongs to a {@link com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline}. */
+public class K8sPipelineElementStatus {
+  private final String name;
+  private final boolean ready;
+  private final boolean failed;
+  private final String message;
+
+  public K8sPipelineElementStatus(String name, boolean ready, boolean failed, String message) {
+    this.name = name;
+    this.ready = ready;
+    this.failed = failed;
+    this.message = message;
+  }
+
+  /** Returns the name of this element. */
+  public String getName() {
+    return name;
+  }
+
+  /** Returns true if this element is ready. */
+  public boolean isReady() {
+    return ready;
+  }
+
+  /** Returns true if this element has failed . */
+  public boolean isFailed() {
+    return failed;
+  }
+
+  /** Returns the detail message string of this element . */
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class K8sPipelineElementStatus {\n");
+    sb.append("    name: ").append(ready).append("\n");
+    sb.append("    ready: ").append(ready).append("\n");
+    sb.append("    failed: ").append(failed).append("\n");
+    sb.append("    message: ").append(message).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+}

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatusEstimator.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatusEstimator.java
@@ -1,0 +1,159 @@
+package com.linkedin.hoptimator.k8s.status;
+
+import com.google.gson.JsonObject;
+import com.linkedin.hoptimator.k8s.K8sContext;
+import com.linkedin.hoptimator.k8s.K8sUtils;
+import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
+import io.kubernetes.client.util.generic.KubernetesApiResponse;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import io.kubernetes.client.util.generic.dynamic.Dynamics;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Estimates or guesses the status of an element of a {@link com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline} by inspecting its internal state.
+ */
+public class K8sPipelineElementStatusEstimator {
+  private final static Logger log = LoggerFactory.getLogger(K8sPipelineElementStatusEstimator.class);
+
+  private final K8sContext context;
+
+  public K8sPipelineElementStatusEstimator(K8sContext context) {
+    this.context = context;
+  }
+
+  /**
+   * Returns statuses of all elements specified in the given pipeline.
+   */
+  public List<K8sPipelineElementStatus> estimateStatuses(V1alpha1Pipeline pipeline) {
+    String namespace = pipeline.getMetadata().getNamespace();
+    return Arrays.stream(pipeline.getSpec().getYaml().split("\n---\n"))
+        .map(String::trim)
+        .filter(x -> !x.isEmpty())
+        .map(yaml -> estimateElementStatus(yaml, namespace))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Estimates status of an element. If we can not retrieve it from K8s, we assume that it's not ready and not failed yet.
+   */
+  private K8sPipelineElementStatus estimateElementStatus(String elementYaml, String pipelineNamespace) {
+    DynamicKubernetesObject obj = Dynamics.newFromYaml(elementYaml);
+    String name = obj.getMetadata().getName();
+    String namespace = obj.getMetadata().getNamespace() == null ? pipelineNamespace : obj.getMetadata().getNamespace();
+    String kind = obj.getKind();
+    try {
+      KubernetesApiResponse<DynamicKubernetesObject> existing =
+          context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).get(namespace, name);
+      String failureMessage =
+          String.format("Failed to fetch %s/%s in namespace %s: %s.", kind, name, namespace, existing.toString());
+      existing.onFailure((code, status) -> log.warn(failureMessage));
+      if (!existing.isSuccess()) {
+        return defaultUnreadyStatusOnK8sObjectRetrievalFailure(name, failureMessage);
+      }
+      K8sPipelineElementStatus elementStatus = estimateDynamicObjectStatus(name, existing.getObject());
+      if (elementStatus.isReady()) {
+        log.info("{}/{} is ready.", kind, name);
+      } else {
+        log.info("{}/{} is NOT ready.", kind, name);
+      }
+      return elementStatus;
+    } catch (Exception e) {
+      String failureMessage =
+          String.format("Encountered exception while checking status of %s/%s in namespace %s: %s", kind, name,
+              namespace, e);
+      log.error(failureMessage);
+      return defaultUnreadyStatusOnK8sObjectRetrievalFailure(name, failureMessage);
+    }
+  }
+
+  public static K8sPipelineElementStatus estimateDynamicObjectStatus(String name, DynamicKubernetesObject obj) {
+    // We make a best effort to guess the status of the dynamic object. By default, it's ready.
+    if (obj == null || obj.getRaw() == null) {
+      return defaultUnreadyStatusOnK8sObjectRetrievalFailure(name, "Returned K8s object is null or has no json");
+    }
+
+    K8sPipelineElementStatus status = estimateBasedOnTopLevelStatusField(name, obj);
+    if (status != null) {
+      return status;
+    }
+
+    // TODO: Look for common Conditions
+    String message =
+        String.format("Object %s/%s/%s considered ready by default.", obj.getMetadata().getNamespace(), obj.getKind(),
+            obj.getMetadata().getName());
+    log.warn(message);
+    return new K8sPipelineElementStatus(name, true, false, message);
+  }
+
+  private static K8sPipelineElementStatus estimateBasedOnTopLevelStatusField(String name, DynamicKubernetesObject obj) {
+    if (!obj.getRaw().has("status")) {
+      return null;
+    }
+
+    JsonObject statusJson = obj.getRaw().get("status").getAsJsonObject();
+    K8sPipelineElementStatus elementStatus;
+    elementStatus = estimateBasedOnStatusReadyField(name, statusJson);
+    if (elementStatus == null) {
+      elementStatus = estimateBasedOnStatusStateField(name, statusJson);
+    }
+    if (elementStatus == null) {
+      elementStatus = estimateBasedOnJobStatusStateField(name, statusJson);
+    }
+
+    return elementStatus;
+  }
+
+  private static K8sPipelineElementStatus estimateBasedOnStatusReadyField(String elementName, JsonObject statusJson) {
+    try {
+      boolean ready = statusJson.get("ready").getAsBoolean();
+      boolean failed = statusJson.has("failed") && statusJson.get("failed").getAsBoolean();
+      String message = statusJson.has("message") ? statusJson.get("message").getAsString() : "";
+      return new K8sPipelineElementStatus(elementName, ready, failed, message);
+    } catch (Exception e) {
+      log.debug("Exception looking for .status.ready. Swallowing.", e);
+    }
+    return null;
+  }
+
+  private static K8sPipelineElementStatus estimateBasedOnStatusStateField(String elementName, JsonObject statusJson) {
+    try {
+      String statusState = statusJson.get("state").getAsString();
+      return fromStateString(elementName, statusState);
+    } catch (Exception e) {
+      log.debug("Exception looking for .status.state. Swallowing.", e);
+    }
+    return null;
+  }
+
+  private static K8sPipelineElementStatus fromStateString(String elementName, String state) {
+    boolean ready = state.matches("(?i)READY|RUNNING|FINISHED");
+    boolean failed = state.matches("(?i)CRASHLOOPBACKOFF|FAILED");
+    return new K8sPipelineElementStatus(elementName, ready, failed, state);
+  }
+
+  private static K8sPipelineElementStatus estimateBasedOnJobStatusStateField(String elementName,
+      JsonObject statusJson) {
+    try {
+      String jobState = statusJson.get("jobStatus").getAsJsonObject().get("state").getAsString();
+      return fromStateString(elementName, jobState);
+    } catch (Exception e) {
+      log.debug("Exception looking for .status.jobStatus.state. Swallowing.", e);
+    }
+    return null;
+  }
+
+  /**
+   * Defaults to unready state when we cannot retrieve the object from K8s.
+   */
+  private static K8sPipelineElementStatus defaultUnreadyStatusOnK8sObjectRetrievalFailure(String elementName,
+      String errorMessage) {
+    return new K8sPipelineElementStatus(elementName, false, false, errorMessage);
+  }
+}

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatusEstimatorTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatusEstimatorTest.java
@@ -1,0 +1,235 @@
+package com.linkedin.hoptimator.k8s.status;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.linkedin.hoptimator.k8s.K8sContext;
+import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
+import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineSpec;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.util.generic.KubernetesApiResponse;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+public class K8sPipelineElementStatusEstimatorTest {
+  @Mock
+  private K8sContext context;
+  private K8sPipelineElementStatusEstimator estimator;
+  @Mock
+  private V1alpha1Pipeline pipeline;
+  @Mock
+  private V1ObjectMeta pipelineMetadata;
+  @Mock
+  private V1alpha1PipelineSpec pipelineSpec;
+  @Mock
+  private DynamicKubernetesApi dynamicKubernetesApi;
+  @Mock
+  KubernetesApiResponse<DynamicKubernetesObject> jobDynamicKubernetesApiResponse;
+  @Mock
+  KubernetesApiResponse<DynamicKubernetesObject> kafkaDynamicKubernetesApiResponse;
+
+  @Mock
+  DynamicKubernetesObject jobDynamicObject;
+
+  @Mock
+  JsonObject jobDynamicObjectRawJsonObject;
+
+  @Mock
+  JsonElement jobDynamicObjectStatusJsonElement;
+
+  @Mock
+  JsonObject jobDynamicObjectStatusJsonObject;
+
+  private static final String FAKE_JOB_SPEC =
+      "apiVersion: foo.org/v1beta1\n" + "kind: FakeJob\n" + "metadata:\n" + "  name: fake-job-name\n" + "spec:\n"
+          + "  deploymentName: fake-deployment\n" + "  job:\n" + "    entryClass: com.runner.FakeRunner";
+  private static final String FAKE_KAFKA_TOPIC_SPEC =
+      "apiVersion: kafka.strimzi.io/v1beta2\n" + "kind: KafkaTopic\n" + "metadata:\n" + "      name: fake-kafka-topic\n"
+          + "      labels:\n" + "        strimzi.io/cluster: one\n" + "spec:\n" + "      topicName: existing-topic-1\n"
+          + "      partitions: 1";
+
+  private static final String FAKE_MULTIPLE_SPECS = FAKE_JOB_SPEC + "\n---\n"
+
+      + FAKE_KAFKA_TOPIC_SPEC + "\n";
+
+  private static final Set<String> READY_STRINGS = ImmutableSet.of("READY", "RUNNING", "FINISHED");
+  private static final Set<String> FAILED_STRINGS = ImmutableSet.of("CRASHLOOPBACKOFF", "FAILED");
+
+  @BeforeEach
+  void setUp() {
+    estimator = new K8sPipelineElementStatusEstimator(context);
+    when(pipelineMetadata.getNamespace()).thenReturn("fake-namespace");
+    when(pipeline.getMetadata()).thenReturn(pipelineMetadata);
+    when(pipeline.getSpec()).thenReturn(pipelineSpec);
+    when(pipelineSpec.getYaml()).thenReturn(FAKE_JOB_SPEC);
+    when(context.dynamic(any(), any())).thenReturn(dynamicKubernetesApi);
+    when(dynamicKubernetesApi.get(anyString(), anyString())).thenReturn(jobDynamicKubernetesApiResponse);
+    when(jobDynamicKubernetesApiResponse.isSuccess()).thenReturn(true);
+  }
+
+  @Test
+  void testEstimateWhenPipelineHasMultipleElements() {
+    when(pipelineSpec.getYaml()).thenReturn(FAKE_MULTIPLE_SPECS);
+    // Set up: failed to get kafka object from K8s.
+    when(kafkaDynamicKubernetesApiResponse.isSuccess()).thenReturn(false);
+    // Set up: successfully get job object from K8s, and it contains status field as ready.
+    mockJobDynamicObjectWithStatusField();
+    JsonElement readyElement = mock(JsonElement.class);
+    when(readyElement.getAsBoolean()).thenReturn(true);
+    when(jobDynamicObjectStatusJsonObject.get("ready")).thenReturn(readyElement);
+    when(jobDynamicObjectStatusJsonObject.has("failed")).thenReturn(false);
+    when(jobDynamicObjectStatusJsonObject.has("message")).thenReturn(false);
+    when(dynamicKubernetesApi.get(anyString(), anyString())).thenReturn(jobDynamicKubernetesApiResponse)
+        .thenReturn(kafkaDynamicKubernetesApiResponse);
+
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    assertEquals(2, statuses.size());
+    K8sPipelineElementStatus jobStatus = statuses.get(0);
+    assertTrue(jobStatus.isReady());
+    assertFalse(jobStatus.isFailed());
+    assertEquals("", jobStatus.getMessage());
+
+    K8sPipelineElementStatus kafkaStatus = statuses.get(1);
+    assertFalse(kafkaStatus.isReady());
+    assertFalse(kafkaStatus.isFailed());
+    assertTrue(
+        kafkaStatus.getMessage().startsWith("Failed to fetch KafkaTopic/fake-kafka-topic in namespace fake-namespace"));
+  }
+
+  @Test
+  void testEstimateWhenPipelineHasSingleElementWithK8sObjectHavingStatusFieldWithReadyInfo() {
+    mockJobDynamicObjectWithStatusField();
+    JsonElement readyElement = mock(JsonElement.class);
+    when(readyElement.getAsBoolean()).thenReturn(true);
+    when(jobDynamicObjectStatusJsonObject.get("ready")).thenReturn(readyElement);
+    when(jobDynamicObjectStatusJsonObject.has("failed")).thenReturn(false);
+
+    JsonElement messageElement = mock(JsonElement.class);
+    when(messageElement.getAsString()).thenReturn("fake-message");
+    when(jobDynamicObjectStatusJsonObject.has("message")).thenReturn(true);
+    when(jobDynamicObjectStatusJsonObject.get("message")).thenReturn(messageElement);
+
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    K8sPipelineElementStatus status = Iterables.getOnlyElement(statuses);
+    assertTrue(status.isReady());
+    assertFalse(status.isFailed());
+    assertEquals("fake-message", status.getMessage());
+  }
+
+  private void mockJobDynamicObjectWithStatusField() {
+    when(jobDynamicObjectRawJsonObject.has("status")).thenReturn(true);
+    when(jobDynamicObjectRawJsonObject.get("status")).thenReturn(jobDynamicObjectStatusJsonElement);
+    when(jobDynamicObjectStatusJsonElement.getAsJsonObject()).thenReturn(jobDynamicObjectStatusJsonObject);
+    when(jobDynamicKubernetesApiResponse.getObject()).thenReturn(jobDynamicObject);
+    when(jobDynamicObject.getRaw()).thenReturn(jobDynamicObjectRawJsonObject);
+    when(jobDynamicKubernetesApiResponse.getObject()).thenReturn(jobDynamicObject);
+  }
+
+  @ParameterizedTest
+  @FieldSource("READY_STRINGS")
+  @FieldSource("FAILED_STRINGS")
+  void testEstimateWhenPipelineHasSingleElementWithK8sObjectHavingStatusFieldWithStateInfo(String state) {
+    mockJobDynamicObjectWithStatusField();
+    JsonElement stateElement = mock(JsonElement.class);
+    when(stateElement.getAsString()).thenReturn(state);
+    when(jobDynamicObjectStatusJsonObject.get("ready")).thenReturn(null);
+    when(jobDynamicObjectStatusJsonObject.get("state")).thenReturn(stateElement);
+
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    K8sPipelineElementStatus status = Iterables.getOnlyElement(statuses);
+    assertEquals(READY_STRINGS.contains(state), status.isReady());
+    assertEquals(FAILED_STRINGS.contains(state), status.isFailed());
+    assertEquals(state, status.getMessage());
+  }
+
+  @ParameterizedTest
+  @FieldSource("READY_STRINGS")
+  @FieldSource("FAILED_STRINGS")
+  void testEstimateWhenPipelineHasSingleElementWithK8sObjectHavingStatusFieldWithJobStatusStateInfo(String state) {
+    mockJobDynamicObjectWithStatusField();
+    JsonElement stateElement = mock(JsonElement.class);
+    when(stateElement.getAsString()).thenReturn(state);
+    JsonObject jobStatusJsonObject = mock(JsonObject.class);
+    when(jobStatusJsonObject.get("state")).thenReturn(stateElement);
+    JsonElement jobStatusJsonElement = mock(JsonElement.class);
+    when(jobStatusJsonElement.getAsJsonObject()).thenReturn(jobStatusJsonObject);
+    when(jobDynamicObjectStatusJsonObject.get("ready")).thenReturn(null);
+    when(jobDynamicObjectStatusJsonObject.get("state")).thenReturn(null);
+    when(jobDynamicObjectStatusJsonObject.get("jobStatus")).thenReturn(jobStatusJsonElement);
+
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    K8sPipelineElementStatus status = Iterables.getOnlyElement(statuses);
+    assertEquals(READY_STRINGS.contains(state), status.isReady());
+    assertEquals(FAILED_STRINGS.contains(state), status.isFailed());
+    assertEquals(state, status.getMessage());
+  }
+
+  @Test
+  void testEstimateWhenPipelineHasSingleElementWithK8sObjectHavingNoStatusField() {
+    when(jobDynamicObjectRawJsonObject.has("status")).thenReturn(false);
+    mockDynamicObjectWithMetadata();
+
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    K8sPipelineElementStatus status = Iterables.getOnlyElement(statuses);
+    assertTrue(status.isReady());
+    assertFalse(status.isFailed());
+    assertEquals("Object fake-namespace/fake-kind/fake-job-name considered ready by default.", status.getMessage());
+  }
+
+  private void mockDynamicObjectWithMetadata() {
+    when(jobDynamicObject.getRaw()).thenReturn(jobDynamicObjectRawJsonObject);
+    V1ObjectMeta metadata = mock(V1ObjectMeta.class);
+    when(metadata.getName()).thenReturn("fake-job-name");
+    when(metadata.getNamespace()).thenReturn("fake-namespace");
+    when(jobDynamicObject.getMetadata()).thenReturn(metadata);
+    when(jobDynamicObject.getKind()).thenReturn("fake-kind");
+    when(jobDynamicKubernetesApiResponse.getObject()).thenReturn(jobDynamicObject);
+  }
+
+  @Test
+  void testEstimateWhenCallToK8sFails() {
+    when(jobDynamicKubernetesApiResponse.isSuccess()).thenReturn(false);
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    K8sPipelineElementStatus status = Iterables.getOnlyElement(statuses);
+    assertFalse(status.isReady());
+    assertFalse(status.isFailed());
+    assertTrue(status.getMessage().startsWith("Failed to fetch FakeJob/fake-job-name"));
+  }
+
+  @Test
+  void testEstimateWhenK8sReturnsNullObject() {
+    when(jobDynamicKubernetesApiResponse.getObject()).thenReturn(null);
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    K8sPipelineElementStatus status = Iterables.getOnlyElement(statuses);
+    assertFalse(status.isReady());
+    assertFalse(status.isFailed());
+    assertEquals(status.getMessage(), "Returned K8s object is null or has no json");
+  }
+
+  @Test
+  void testEstimateWhenPipelineHasSingleElementWithK8sObjectHavingNoRawJson() {
+    when(jobDynamicKubernetesApiResponse.getObject()).thenReturn(jobDynamicObject);
+    when(jobDynamicObject.getRaw()).thenReturn(null);
+    List<K8sPipelineElementStatus> statuses = estimator.estimateStatuses(pipeline);
+    K8sPipelineElementStatus status = Iterables.getOnlyElement(statuses);
+    assertFalse(status.isReady());
+    assertFalse(status.isFailed());
+    assertEquals(status.getMessage(), "Returned K8s object is null or has no json");
+  }
+}

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/pipeline/PipelineReconciler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/pipeline/PipelineReconciler.java
@@ -1,28 +1,23 @@
 package com.linkedin.hoptimator.operator.pipeline;
 
-import java.sql.SQLException;
-import java.time.Duration;
-import java.util.Arrays;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.linkedin.hoptimator.k8s.K8sApi;
+import com.linkedin.hoptimator.k8s.K8sApiEndpoints;
+import com.linkedin.hoptimator.k8s.K8sContext;
+import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
+import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineStatus;
+import com.linkedin.hoptimator.k8s.status.K8sPipelineElementStatus;
+import com.linkedin.hoptimator.k8s.status.K8sPipelineElementStatusEstimator;
 import io.kubernetes.client.extended.controller.Controller;
 import io.kubernetes.client.extended.controller.builder.ControllerBuilder;
 import io.kubernetes.client.extended.controller.reconciler.Reconciler;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.extended.controller.reconciler.Result;
-import io.kubernetes.client.util.generic.KubernetesApiResponse;
-import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
-import io.kubernetes.client.util.generic.dynamic.Dynamics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.linkedin.hoptimator.k8s.K8sApi;
-import com.linkedin.hoptimator.k8s.K8sApiEndpoints;
-import com.linkedin.hoptimator.k8s.K8sContext;
-import com.linkedin.hoptimator.k8s.K8sUtils;
-import com.linkedin.hoptimator.k8s.models.V1alpha1Pipeline;
-import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineList;
-import com.linkedin.hoptimator.k8s.models.V1alpha1PipelineStatus;
+import java.sql.SQLException;
+import java.time.Duration;
 
 
 /**
@@ -33,10 +28,12 @@ public final class PipelineReconciler implements Reconciler {
 
   private final K8sContext context;
   private final K8sApi<V1alpha1Pipeline, V1alpha1PipelineList> pipelineApi;
+  private final K8sPipelineElementStatusEstimator elementStatusEstimator;
 
   private PipelineReconciler(K8sContext context) {
     this.context = context;
     this.pipelineApi = new K8sApi<>(context, K8sApiEndpoints.PIPELINES);
+    this.elementStatusEstimator = new K8sPipelineElementStatusEstimator(context);
   }
 
   @Override
@@ -62,9 +59,8 @@ public final class PipelineReconciler implements Reconciler {
 
       log.info("Checking status of Pipeline {}...", name);
 
-      boolean ready = Arrays.stream(object.getSpec().getYaml().split("\n---\n"))
-          .filter(x -> x != null && !x.isEmpty())
-          .allMatch(x -> isReady(x, namespace));
+      boolean ready =
+          elementStatusEstimator.estimateStatuses(object).stream().allMatch(K8sPipelineElementStatus::isReady);
 
       if (ready) {
         status.setReady(true);
@@ -112,71 +108,6 @@ public final class PipelineReconciler implements Reconciler {
         .withWorkerCount(1)
         .watch(x -> ControllerBuilder.controllerWatchBuilder(V1alpha1Pipeline.class, x).build())
         .build();
-  }
-
-  private boolean isReady(String yaml, String pipelineNamespace) {
-    DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
-    String name = obj.getMetadata().getName();
-    String namespace = obj.getMetadata().getNamespace() == null ? pipelineNamespace : obj.getMetadata().getNamespace();
-    String kind = obj.getKind();
-    try {
-      KubernetesApiResponse<DynamicKubernetesObject> existing =
-          context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).get(namespace, name);
-      existing.onFailure((code, status) ->
-          log.warn("Failed to fetch {}/{} in namespace {}: {}.", kind, name, namespace, status.getMessage())
-      );
-      if (!existing.isSuccess()) {
-        return false;
-      }
-      if (guessReady(existing.getObject())) {
-        log.info("{}/{} is ready.", kind, name);
-        return true;
-      } else {
-        log.info("{}/{} is NOT ready.", kind, name);
-        return false;
-      }
-    } catch (Exception e) {
-      log.error("Encountered exception while checking status of {}/{} in namespace {}", kind, name, namespace, e);
-      return false;
-    }
-  }
-
-  public static boolean guessReady(DynamicKubernetesObject obj) {
-    // We make a best effort to guess the status of the dynamic object. By default, it's ready.
-    if (obj == null || obj.getRaw() == null) {
-      return false;
-    }
-    try {
-      return obj.getRaw().get("status").getAsJsonObject().get("ready").getAsBoolean();
-    } catch (Exception e) {
-      log.debug("Exception looking for .status.ready. Swallowing.", e);
-    }
-    try {
-      return obj.getRaw()
-          .get("status")
-          .getAsJsonObject()
-          .get("state")
-          .getAsString()
-          .matches("(?i)READY|RUNNING|FINISHED");
-    } catch (Exception e) {
-      log.debug("Exception looking for .status.state. Swallowing.", e);
-    }
-    try {
-      return obj.getRaw()
-          .get("status")
-          .getAsJsonObject()
-          .get("jobStatus")
-          .getAsJsonObject()
-          .get("state")
-          .getAsString()
-          .matches("(?i)READY|RUNNING|FINISHED");
-    } catch (Exception e) {
-      log.debug("Exception looking for .status.jobStatus.state. Swallowing.", e);
-    }
-    // TODO: Look for common Conditions
-    log.warn("Object {}/{}/{} considered ready by default.", obj.getMetadata().getNamespace(), obj.getKind(),
-        obj.getMetadata().getName());
-    return true;
   }
 }
 


### PR DESCRIPTION
## Problem & Solution Overview

We would like to expose statues of pipeline and its elements as new K8s metadata status tables.
This PR is to refactor the common status estimating logic to be reused in another PR - see:
https://github.com/linkedin/Hoptimator/tree/trung/status-table

## Testing Done
- K8sPipelineElementStatusEstimatorTest
- Created a new pipeline in hoptimator and verified logs in hoptimator-operator-deployment pod