### PR TITLE
Add support of java.sql.PreparedStatement to HoptimatorConnection

### DIFF
--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorConnection.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorConnection.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator.jdbc;
 
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -30,6 +31,11 @@ public class HoptimatorConnection extends DelegatingConnection {
   @Override
   public Statement createStatement() throws SQLException {
     return connection.createStatement();
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql) throws SQLException {
+    return connection.prepareStatement(sql);
   }
 
   public Properties connectionProperties() {

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
@@ -1,5 +1,7 @@
 package com.linkedin.hoptimator.jdbc;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 
@@ -21,6 +23,8 @@ public class TestBasicSql extends JdbcTestBase {
     sql("CREATE TABLE T2 (A VARCHAR, B INT)");
     sql("INSERT INTO T2 SELECT * FROM T1");
     assertQueriesEqual("SELECT * FROM T1", "SELECT * FROM T2");
+    assertResultSetsEqual(query("SELECT * FROM T1 WHERE X = 'one'"),
+        queryUsingPreparedStatement("SELECT * FROM T1 WHERE X = ?", Arrays.asList("one")));
     sql("DROP TABLE T1");
     sql("DROP TABLE T2");
   }


### PR DESCRIPTION
## Problem
There is no support for PreparedStatement in the hoptimator-jdbc yet, thus its clients would face SQL injection attack risk if allowing queries with parameters.

## Solution
This PR is to add another option to send SQL statements with many advantages, particularly preventing SQL injection attacks: https://docs.oracle.com/javase/tutorial/jdbc/basics/prepared.html

## Testing done

- Unit test: add query using PreparedStatement to com.linkedin.hoptimator.jdbc.TestBasicSql.insertIntoSelectFrom()
- Local integration test: queried "k8s" metadata tables using java client with PreparedStatement created by HoptimatorConnection and verified that the returned ResultSet is as expected.