### PR TITLE
Adds snapshot and restore functionality

### DIFF
--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
@@ -8,4 +8,7 @@ public interface DeployerProvider {
 
   /** Find deployers capable of deploying the obj. */
   <T extends Deployable> Collection<Deployer> deployers(T obj, Properties connectionProperties);
+
+  /** A DeployerProvider with lower priority will execute first */
+  int priority();
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/SnapshotProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/SnapshotProvider.java
@@ -1,0 +1,13 @@
+package com.linkedin.hoptimator;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+
+
+public interface SnapshotProvider {
+
+  void snapshot(List<String> specs, Properties connectionProperties) throws SQLException;
+
+  void restore();
+}

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -19,6 +19,7 @@
  */
 package com.linkedin.hoptimator.jdbc;
 
+import com.linkedin.hoptimator.util.SnapshotService;
 import java.io.Reader;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -231,7 +232,8 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       }
 
       schemaPlus.add(viewName, materializedViewTable);
-    } catch (SQLException e) {
+    } catch (SQLException | RuntimeException e) {
+      SnapshotService.restore();
       throw new DdlException(create, e.getMessage(), e);
     }
   }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sContext.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sContext.java
@@ -47,15 +47,17 @@ public final class K8sContext {
   private final SharedInformerFactory informerFactory;
   private final V1OwnerReference ownerReference;
   private final Map<String, String> labels;
+  private final Properties connectionProperties;
 
-  private K8sContext(String namespace, String clientInfo, ApiClient apiClient,
-      SharedInformerFactory informerFactory, V1OwnerReference ownerReference, Map<String, String> labels) {
+  private K8sContext(String namespace, String clientInfo, ApiClient apiClient, SharedInformerFactory informerFactory,
+      V1OwnerReference ownerReference, Map<String, String> labels, Properties connectionProperties) {
     this.namespace = namespace;
     this.clientInfo = clientInfo;
     this.apiClient = apiClient;
     this.informerFactory = informerFactory;
     this.ownerReference = ownerReference;
     this.labels = labels;
+    this.connectionProperties = connectionProperties;
   }
 
   public static K8sContext create(Properties connectionProperties) {
@@ -136,19 +138,19 @@ public final class K8sContext {
     }
 
     return new K8sContext(namespace, info, apiClient, new SharedInformerFactory(apiClient),
-        null, Collections.emptyMap());
+        null, Collections.emptyMap(), connectionProperties);
   }
 
   public K8sContext withOwner(V1OwnerReference owner) {
     return new K8sContext(namespace, clientInfo + " Owner is " + owner.getName() + ".", apiClient,
-        informerFactory, owner, labels);
+        informerFactory, owner, labels, connectionProperties);
   }
 
   public K8sContext withLabel(String key, String value) {
     Map<String, String> newLabels = new HashMap<>(labels);
     newLabels.put(key, value);
     return new K8sContext(namespace, clientInfo + " Label " + key + "=" + value + ".", apiClient,
-        informerFactory, ownerReference, newLabels);
+        informerFactory, ownerReference, newLabels, connectionProperties);
   }
 
   public ApiClient apiClient() {
@@ -161,6 +163,10 @@ public final class K8sContext {
 
   public SharedInformerFactory informerFactory() {
     return informerFactory;
+  }
+
+  public Properties connectionProperties() {
+    return connectionProperties;
   }
 
   public <T extends KubernetesObject, U extends KubernetesListObject> void registerInformer(

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployer.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator.k8s;
 
+import com.linkedin.hoptimator.util.SnapshotService;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -16,36 +17,50 @@ public abstract class K8sDeployer<T extends KubernetesObject, U extends Kubernet
     implements Deployer {
 
   private final K8sApi<T, U> api;
+  private final K8sContext context;
 
   K8sDeployer(K8sContext context, K8sApiEndpoint<T, U> endpoint) {
     this.api = new K8sApi<>(context, endpoint);
+    this.context = context;
   }
 
   @Override
   public void create() throws SQLException {
-    api.create(toK8sObject());
+    create(toK8sObject());
   }
 
   public V1OwnerReference createAndReference() throws SQLException {
     T obj = toK8sObject();
-    api.create(obj);
+    create(obj);
     return api.reference(obj);
+  }
+
+  private void create(T obj) throws SQLException {
+    SnapshotService.snapshot(Collections.singletonList(Yaml.dump(obj)), context.connectionProperties());
+    api.create(obj);
   }
 
   @Override
   public void delete() throws SQLException {
-    api.delete(toK8sObject());
+    T obj = toK8sObject();
+    SnapshotService.snapshot(Collections.singletonList(Yaml.dump(obj)), context.connectionProperties());
+    api.delete(obj);
   }
 
   @Override
   public void update() throws SQLException {
-    api.update(toK8sObject());
+    update(toK8sObject());
   }
 
   public V1OwnerReference updateAndReference() throws SQLException {
     T obj = toK8sObject();
-    api.update(obj);
+    update(obj);
     return api.reference(obj);
+  }
+
+  private void update(T obj) throws SQLException {
+    SnapshotService.snapshot(Collections.singletonList(Yaml.dump(obj)), context.connectionProperties());
+    api.update(obj);
   }
 
   @Override

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployerProvider.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDeployerProvider.java
@@ -32,4 +32,9 @@ public class K8sDeployerProvider implements DeployerProvider {
 
    return list;
   }
+
+  @Override
+  public int priority() {
+    return 1;
+  }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSnapshotProvider.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sSnapshotProvider.java
@@ -1,0 +1,70 @@
+package com.linkedin.hoptimator.k8s;
+
+import com.linkedin.hoptimator.SnapshotProvider;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+// Grabs information from each K8s spec to snapshot the current state of the resource.
+// On restore, the last state of each spec will be reapplied.
+// Handles deletion if the resource previously did not exist.
+public class K8sSnapshotProvider implements SnapshotProvider {
+  private static final Logger log = LoggerFactory.getLogger(K8sSnapshotProvider.class);
+
+  // Mapping of new Kubernetes yaml to existing object
+  private final Map<String, DynamicKubernetesObject> newToOldMap = new HashMap<>();
+
+  private K8sYamlApi api;
+
+  // Needed for ServiceLoader
+  public K8sSnapshotProvider() {
+  }
+
+  // Used for testing purposes
+  K8sSnapshotProvider(K8sYamlApi api) {
+    this.api = api;
+  }
+
+  @Override
+  public void snapshot(List<String> specs, Properties connectionProperties) throws SQLException {
+    if (api == null) {
+      this.api = new K8sYamlApi(K8sContext.create(connectionProperties));
+    }
+    for (String spec : specs) {
+      DynamicKubernetesObject existing = api.get(spec, false);
+      newToOldMap.put(spec, existing);
+      log.info("Successfully snapshot K8s YAML: {}", spec);
+    }
+  }
+
+  @Override
+  public void restore() {
+    if (api == null) {
+      log.warn("K8sSnapshotProvider not initialized. Skipping restore operation.");
+      return;
+    }
+    for (Map.Entry<String, DynamicKubernetesObject> entry : newToOldMap.entrySet()) {
+      try {
+        String newYaml = entry.getKey();
+        DynamicKubernetesObject oldObj = entry.getValue();
+
+        if (oldObj == null) {
+          api.delete(newYaml);
+          log.info("Removed K8s YAML: {}", newYaml);
+        } else {
+          api.update(oldObj);
+          log.info("Restored K8s obj: {}:{}", oldObj.getKind(), oldObj.getMetadata().getName());
+        }
+      } catch (SQLException e) {
+        log.warn("Error restoring K8s YAML. This may be expected if the owner object was already deleted: {}", entry.getKey(), e);
+      }
+    }
+    newToOldMap.clear();
+  }
+}

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlDeployer.java
@@ -1,21 +1,26 @@
 package com.linkedin.hoptimator.k8s;
 
+import com.linkedin.hoptimator.util.SnapshotService;
 import java.sql.SQLException;
 
 import com.linkedin.hoptimator.Deployer;
+import java.util.Collections;
 
 
 public abstract class K8sYamlDeployer implements Deployer {
 
   private final K8sYamlApi api;
+  private final K8sContext context;
 
   public K8sYamlDeployer(K8sContext context) {
     this.api = new K8sYamlApi(context);
+    this.context = context;
   }
 
   @Override
   public void create() throws SQLException {
     for (String spec : specify()) {
+      SnapshotService.snapshot(Collections.singletonList(spec), context.connectionProperties());
       api.create(spec);
     }
   }
@@ -23,6 +28,7 @@ public abstract class K8sYamlDeployer implements Deployer {
   @Override
   public void delete() throws SQLException {
     for (String spec : specify()) {
+      SnapshotService.snapshot(Collections.singletonList(spec), context.connectionProperties());
       api.delete(spec);
     }
   }
@@ -30,6 +36,7 @@ public abstract class K8sYamlDeployer implements Deployer {
   @Override
   public void update() throws SQLException {
     for (String spec : specify()) {
+      SnapshotService.snapshot(Collections.singletonList(spec), context.connectionProperties());
       api.update(spec);
     }
   }

--- a/hoptimator-k8s/src/main/resources/META-INF/services/com.linkedin.hoptimator.SnapshotProvider
+++ b/hoptimator-k8s/src/main/resources/META-INF/services/com.linkedin.hoptimator.SnapshotProvider
@@ -1,0 +1,1 @@
+com.linkedin.hoptimator.k8s.K8sSnapshotProvider

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/TestK8sSnapshotProvider.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/TestK8sSnapshotProvider.java
@@ -1,0 +1,68 @@
+package com.linkedin.hoptimator.k8s;
+
+import com.linkedin.hoptimator.k8s.models.V1alpha1SqlJob;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.util.Yaml;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class TestK8sSnapshotProvider {
+  private FakeK8sYamlApi fakeApi;
+  private K8sSnapshotProvider snapshotProvider;
+  private Map<String, String> yamls;
+
+  @BeforeEach
+  void setUp() {
+    yamls = new HashMap<>();
+    fakeApi = new FakeK8sYamlApi(yamls);
+    snapshotProvider = new K8sSnapshotProvider(fakeApi);
+  }
+
+  @Test
+  void testSnapshotRestoreDelete() throws SQLException {
+    V1alpha1SqlJob sqlJob = new V1alpha1SqlJob();
+    sqlJob.setApiVersion("hoptimator.linkedin.com/v1alpha1");
+    sqlJob.setKind("SqlJob");
+    sqlJob.setMetadata(new V1ObjectMeta().name("test-sql-job"));
+
+    snapshotProvider.snapshot(Collections.singletonList(Yaml.dump(sqlJob)), new Properties());
+    fakeApi.create(Yaml.dump(sqlJob));
+    assertEquals(yamls.size(), 1);
+    assertEquals(yamls.get("test-sql-job"), Yaml.dump(sqlJob));
+
+    snapshotProvider.restore();
+    assertTrue(yamls.isEmpty());
+  }
+
+  @Test
+  void testRestoreWithUpdate() throws SQLException {
+    V1alpha1SqlJob oldSqlJob = new V1alpha1SqlJob();
+    oldSqlJob.setApiVersion("hoptimator.linkedin.com/v1alpha1");
+    oldSqlJob.setKind("SqlJob");
+    oldSqlJob.setMetadata(new V1ObjectMeta().name("test-sql-job").putAnnotationsItem("key", "old-value"));
+
+    V1alpha1SqlJob newSqlJob = new V1alpha1SqlJob();
+    newSqlJob.setApiVersion("hoptimator.linkedin.com/v1alpha1");
+    newSqlJob.setKind("SqlJob");
+    newSqlJob.setMetadata(new V1ObjectMeta().name("test-sql-job").putAnnotationsItem("key", "new-value"));
+
+    fakeApi.create(Yaml.dump(oldSqlJob));
+    snapshotProvider.snapshot(Collections.singletonList(Yaml.dump(newSqlJob)), new Properties());
+    fakeApi.create(Yaml.dump(newSqlJob));
+    assertEquals(yamls.size(), 1);
+    assertEquals(yamls.get("test-sql-job"), Yaml.dump(newSqlJob));
+
+    snapshotProvider.restore();
+    assertEquals(yamls.get("test-sql-job"), Yaml.dump(oldSqlJob));
+  }
+
+}

--- a/hoptimator-k8s/src/testFixtures/java/com/linkedin/hoptimator/k8s/FakeK8sYamlApi.java
+++ b/hoptimator-k8s/src/testFixtures/java/com/linkedin/hoptimator/k8s/FakeK8sYamlApi.java
@@ -1,7 +1,7 @@
 package com.linkedin.hoptimator.k8s;
 
 import java.sql.SQLException;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.kubernetes.client.util.Yaml;
@@ -11,41 +11,69 @@ import io.kubernetes.client.util.generic.dynamic.Dynamics;
 
 public class FakeK8sYamlApi extends K8sYamlApi {
 
-  private final List<String> yamls;
+  private final Map<String, String> nameToYaml;
 
-  public FakeK8sYamlApi(List<String> yamls) {
+  public FakeK8sYamlApi(Map<String, String> yamls) {
     super(null);
-    this.yamls = yamls;
+    this.nameToYaml = yamls;
+  }
+
+  @Override
+  public DynamicKubernetesObject get(String yaml, boolean throwIfNotExists) throws SQLException {
+    DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
+    String name = obj.getMetadata().getName();
+
+    if (throwIfNotExists && !nameToYaml.containsKey(name)) {
+      throw new SQLException("Object not found: " + name);
+    }
+    return nameToYaml.containsKey(name) ? Dynamics.newFromYaml(nameToYaml.get(name)) : null;
   }
 
   @Override
   public void create(String yaml) throws SQLException {
-    createWithAnnotationsAndLabels(yaml, null, null);
+    createWithAnnotationsAndLabels(yaml, new HashMap<>(), new HashMap<>());
   }
 
   @Override
   public void createWithAnnotationsAndLabels(String yaml, Map<String, String> annotations,
       Map<String, String> labels) throws SQLException {
     DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
-    obj.setMetadata(obj.getMetadata().annotations(annotations).labels(labels));
+    if (obj.getMetadata().getAnnotations() == null) {
+      obj.getMetadata().setAnnotations(annotations);
+    } else {
+      obj.getMetadata().getAnnotations().putAll(annotations);
+    }
+
+    if (obj.getMetadata().getLabels() == null) {
+      obj.getMetadata().setLabels(labels);
+    } else {
+      obj.getMetadata().getLabels().putAll(labels);
+    }
+
     String dump = Yaml.dump(obj);
     System.out.println("Created:");
     System.out.println(dump);
     System.out.println();
-    yamls.add(dump);
+    nameToYaml.put(obj.getMetadata().getName(), dump);
   }
 
   @Override
   public void delete(String yaml) throws SQLException {
+    DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
     System.out.println("Deleted:");
     System.out.println(yaml);
     System.out.println();
-    yamls.remove(yaml);
+    nameToYaml.remove(obj.getMetadata().getName());
   }
 
   @Override
   public void update(String yaml) throws SQLException {
-    yamls.remove(yaml);
-    yamls.add(yaml);
+    DynamicKubernetesObject obj = Dynamics.newFromYaml(yaml);
+    update(obj);
+  }
+
+  @Override
+  public void update(DynamicKubernetesObject obj) throws SQLException {
+    nameToYaml.put(obj.getMetadata().getName(), Yaml.dump(obj));
   }
 }

--- a/hoptimator-operator/src/test/java/com/linkedin/hoptimator/operator/trigger/TestTableTriggerReconciler.java
+++ b/hoptimator-operator/src/test/java/com/linkedin/hoptimator/operator/trigger/TestTableTriggerReconciler.java
@@ -27,15 +27,15 @@ import com.linkedin.hoptimator.k8s.models.V1alpha1TableTriggerStatus;
 
 
 class TestTableTriggerReconciler {
- 
+
   private List<V1Job> jobs = new ArrayList<>();
   private List<V1alpha1TableTrigger> triggers = new ArrayList<>();
-  private List<String> yamls = new ArrayList<>();
+  private Map<String, String> yamls = new HashMap<>();
   private final TableTriggerReconciler reconciler = new TableTriggerReconciler(null,
       new FakeK8sApi<V1alpha1TableTrigger, V1alpha1TableTriggerList>(triggers),
       new FakeK8sApi<V1Job, V1JobList>(jobs),
       new FakeK8sYamlApi(yamls));
- 
+
   @BeforeEach
   void beforeEach() {
     jobs.clear();

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
@@ -4,6 +4,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,7 @@ public final class DeploymentService {
     ServiceLoader<DeployerProvider> loader = ServiceLoader.load(DeployerProvider.class);
     List<DeployerProvider> providers = new ArrayList<>();
     loader.iterator().forEachRemaining(providers::add);
+    providers.sort(Comparator.comparingInt(DeployerProvider::priority));
     return providers;
   }
 

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/SnapshotService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/SnapshotService.java
@@ -1,0 +1,42 @@
+package com.linkedin.hoptimator.util;
+
+import com.linkedin.hoptimator.SnapshotProvider;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.ServiceLoader;
+
+
+public final class SnapshotService {
+
+  // SnapshotProviders are effectively singletons.
+  // Snapshots of different elements can be taken at different points in the workflow and all can be restored at any point.
+  private static List<SnapshotProvider> providers = null;
+
+  private SnapshotService() {
+  }
+
+  public static void snapshot(List<String> specs, Properties connectionProperties) throws SQLException {
+    for (SnapshotProvider provider : providers()) {
+      provider.snapshot(specs, connectionProperties);
+    }
+  }
+
+  public static void restore() {
+    for (SnapshotProvider provider : providers()) {
+      provider.restore();
+    }
+  }
+
+  private static synchronized Collection<SnapshotProvider> providers() {
+    if (providers != null) {
+      return providers;
+    }
+    providers = new ArrayList<>();
+    ServiceLoader<SnapshotProvider> loader = ServiceLoader.load(SnapshotProvider.class);
+    loader.iterator().forEachRemaining(providers::add);
+    return providers;
+  }
+}


### PR DESCRIPTION
This is an attempt at treating a materialized view as a transaction with atomicity guarantees.

Add `K8sSnapshotProvider` which is responsible for tracking all of the changes we make to K8s objects during deployment.

Errors at different points in the workflow can either leave K8s objects stranded or in an inconsistent state if errors happen after some yaml has been applied but not others. This is especially a problem as we introduce more deployers, the standard K8s deployer may succeed in applying YAML but we could have another Deployer responsible for making more advanced checks, and on failure it should clean up everything that was already created/updated.

There is another known problem that is tangential but not solved here. If a materialized view is updated in such a way that it plans different resources, it can leave existing resources orphaned. When this is solved, the snapshot provider will need to be updated to recreate those resources.

Also added a priority to Deployers to be able to give an order to them during execution. It is likely we will always want the K8s deployer first, which deploys out all the table template yaml and then we can have subsequent deployers execute after and fetch the deployed yaml.

Tests:
Added some unit tests but also tested manually adding exceptions and breakpoints to verify behavior:

1. Restore existing pipeline
```
K8S OBJECTS BEFORE PIPELINE UPDATE:
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get views kafka-new-topic-2 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: View
metadata:
  creationTimestamp: "2025-05-14T21:57:26Z"
  generation: 6
  name: kafka-new-topic-2
  namespace: default
  resourceVersion: "722399"
  uid: e46e47b1-3a0f-4d5d-bcb7-bc6e943943bf
spec:
  materialized: true
  schema: KAFKA
  sql: |-
    SELECT *
    FROM "KAFKA"."new-topic"
  view: new-topic-2
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get pipelines kafka-new-topic-2 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: Pipeline
metadata:
  creationTimestamp: "2025-05-14T21:57:51Z"
  generation: 5
  name: kafka-new-topic-2
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: View
    name: kafka-new-topic-2
    uid: e46e47b1-3a0f-4d5d-bcb7-bc6e943943bf
  resourceVersion: "722400"
  uid: 6f17f91f-802c-4761-877f-1a2db907fbb5
spec:
  sql: |-
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`;
  yaml: |
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-existing-topic-2
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: existing-topic-2
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-new-topic-2
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: new-topic-2
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: flink.apache.org/v1beta1
    kind: FlinkSessionJob
    metadata:
      name: kafka-database-new-topic-2
    spec:
      deploymentName: basic-session-deployment
      job:
        entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
        args:
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`;
        jarURI: file:///opt/hoptimator-flink-runner.jar
        parallelism: 1
        upgradeMode: stateless
        state: running
status:
  failed: false
  message: Deployed.
  ready: false
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get flinksessionjobs kafka-database-new-topic-2 -o yaml
apiVersion: flink.apache.org/v1beta1
kind: FlinkSessionJob
metadata:
  creationTimestamp: "2025-05-14T21:57:51Z"
  finalizers:
  - flinksessionjobs.flink.apache.org/finalizer
  generation: 5
  name: kafka-database-new-topic-2
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: Pipeline
    name: kafka-new-topic-2
    uid: 6f17f91f-802c-4761-877f-1a2db907fbb5
  resourceVersion: "722401"
  uid: 5d2c56b8-01cd-4eff-b49c-1c533eb15f53
spec:
  deploymentName: basic-session-deployment
  job:
    args:
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE`
      BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY)
      WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`;
    entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
    jarURI: file:///opt/hoptimator-flink-runner.jar
    parallelism: 1
    state: running
    upgradeMode: stateless
status:
  error: '{"type":"io.fabric8.kubernetes.client.KubernetesClientException","additionalMetadata":{},"throwableList":[{"type":"java.util.concurrent.TimeoutException","additionalMetadata":{}}]}'
  jobStatus:
    checkpointInfo:
      lastPeriodicCheckpointTimestamp: 0
    savepointInfo:
      lastPeriodicSavepointTimestamp: 0
      savepointHistory: []
  lifecycleState: FAILED
  reconciliationStatus:
    reconciliationTimestamp: 0
    state: UPGRADING


K8S OBJECTS DURING WORKFLOW:
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get views kafka-new-topic-2 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: View
metadata:
  creationTimestamp: "2025-05-14T21:57:26Z"
  generation: 7
  name: kafka-new-topic-2
  namespace: default
  resourceVersion: "722735"
  uid: e46e47b1-3a0f-4d5d-bcb7-bc6e943943bf
spec:
  materialized: true
  schema: KAFKA
  sql: |-
    SELECT *
    FROM "KAFKA"."existing-topic-1"
  view: new-topic-2
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get pipelines kafka-new-topic-2 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: Pipeline
metadata:
  creationTimestamp: "2025-05-14T21:57:51Z"
  generation: 6
  name: kafka-new-topic-2
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: View
    name: kafka-new-topic-2
    uid: e46e47b1-3a0f-4d5d-bcb7-bc6e943943bf
  resourceVersion: "722737"
  uid: 6f17f91f-802c-4761-877f-1a2db907fbb5
spec:
  sql: |-
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-1`;
  yaml: |
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-existing-topic-1
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: existing-topic-1
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-new-topic-2
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: new-topic-2
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: flink.apache.org/v1beta1
    kind: FlinkSessionJob
    metadata:
      name: kafka-database-new-topic-2
    spec:
      deploymentName: basic-session-deployment
      job:
        entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
        args:
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-1`;
        jarURI: file:///opt/hoptimator-flink-runner.jar
        parallelism: 1
        upgradeMode: stateless
        state: running
status:
  failed: false
  message: Deployed.
  ready: false
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get flinksessionjobs kafka-database-new-topic-2 -o yaml
apiVersion: flink.apache.org/v1beta1
kind: FlinkSessionJob
metadata:
  creationTimestamp: "2025-05-14T21:57:51Z"
  finalizers:
  - flinksessionjobs.flink.apache.org/finalizer
  generation: 6
  name: kafka-database-new-topic-2
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: Pipeline
    name: kafka-new-topic-2
    uid: 6f17f91f-802c-4761-877f-1a2db907fbb5
  resourceVersion: "722741"
  uid: 5d2c56b8-01cd-4eff-b49c-1c533eb15f53
spec:
  deploymentName: basic-session-deployment
  job:
    args:
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE`
      BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY)
      WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-1`;
    entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
    jarURI: file:///opt/hoptimator-flink-runner.jar
    parallelism: 1
    state: running
    upgradeMode: stateless
status:
  error: '{"type":"io.fabric8.kubernetes.client.KubernetesClientException","additionalMetadata":{},"throwableList":[{"type":"java.util.concurrent.TimeoutException","additionalMetadata":{}}]}'
  jobStatus:
    checkpointInfo:
      lastPeriodicCheckpointTimestamp: 0
    savepointInfo:
      lastPeriodicSavepointTimestamp: 0
      savepointHistory: []
  lifecycleState: FAILED
  reconciliationStatus:
    reconciliationTimestamp: 0
    state: UPGRADING


K8S OBJECTS AFTER RESTORE:
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get views kafka-new-topic-2 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: View
metadata:
  creationTimestamp: "2025-05-14T21:57:26Z"
  generation: 8
  name: kafka-new-topic-2
  namespace: default
  resourceVersion: "722918"
  uid: e46e47b1-3a0f-4d5d-bcb7-bc6e943943bf
spec:
  materialized: true
  schema: KAFKA
  sql: |-
    SELECT *
    FROM "KAFKA"."new-topic"
  view: new-topic-2
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get pipelines kafka-new-topic-2 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: Pipeline
metadata:
  creationTimestamp: "2025-05-14T21:57:51Z"
  generation: 7
  name: kafka-new-topic-2
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: View
    name: kafka-new-topic-2
    uid: e46e47b1-3a0f-4d5d-bcb7-bc6e943943bf
  resourceVersion: "722923"
  uid: 6f17f91f-802c-4761-877f-1a2db907fbb5
spec:
  sql: |-
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`;
  yaml: |
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-existing-topic-2
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: existing-topic-2
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-new-topic-2
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: new-topic-2
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: flink.apache.org/v1beta1
    kind: FlinkSessionJob
    metadata:
      name: kafka-database-new-topic-2
    spec:
      deploymentName: basic-session-deployment
      job:
        entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
        args:
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`;
        jarURI: file:///opt/hoptimator-flink-runner.jar
        parallelism: 1
        upgradeMode: stateless
        state: running
status:
  failed: false
  message: Deployed.
  ready: false
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get flinksessionjobs kafka-database-new-topic-2 -o yaml
apiVersion: flink.apache.org/v1beta1
kind: FlinkSessionJob
metadata:
  creationTimestamp: "2025-05-14T21:57:51Z"
  finalizers:
  - flinksessionjobs.flink.apache.org/finalizer
  generation: 7
  name: kafka-database-new-topic-2
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: Pipeline
    name: kafka-new-topic-2
    uid: 6f17f91f-802c-4761-877f-1a2db907fbb5
  resourceVersion: "722925"
  uid: 5d2c56b8-01cd-4eff-b49c-1c533eb15f53
spec:
  deploymentName: basic-session-deployment
  job:
    args:
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-2` (`KEY` VARCHAR, `VALUE`
      BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-2', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`new-topic-2` (`KEY` VARCHAR, `VALUE` BINARY)
      WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='new-topic-2', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - INSERT INTO `KAFKA`.`new-topic-2` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-2`;
    entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
    jarURI: file:///opt/hoptimator-flink-runner.jar
    parallelism: 1
    state: running
    upgradeMode: stateless
status:
  error: '{"type":"io.fabric8.kubernetes.client.KubernetesClientException","additionalMetadata":{},"throwableList":[{"type":"java.util.concurrent.TimeoutException","additionalMetadata":{}}]}'
  jobStatus:
    checkpointInfo:
      lastPeriodicCheckpointTimestamp: 0
    savepointInfo:
      lastPeriodicSavepointTimestamp: 0
      savepointHistory: []
  lifecycleState: FAILED
  reconciliationStatus:
    reconciliationTimestamp: 0
    state: UPGRADING
```

2. Restore new pipeline
```
K8S OBJECTS BEFORE PIPELINE CREATION:
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get views kafka-my-topic-3 -o yaml
Error from server (NotFound): views.hoptimator.linkedin.com "kafka-my-topic-3" not found
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get pipelines kafka-my-topic-3 -o yaml
Error from server (NotFound): pipelines.hoptimator.linkedin.com "kafka-my-topic-3" not found
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get flinksessionjobs kafka-database-my-topic-3 -o yaml
Error from server (NotFound): flinksessionjobs.flink.apache.org "kafka-database-my-topic-3" not found


K8S OBJECTS DURING WORKFLOW:
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get views kafka-my-topic-3 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: View
metadata:
  creationTimestamp: "2025-05-22T18:40:46Z"
  generation: 1
  name: kafka-my-topic-3
  namespace: default
  resourceVersion: "726697"
  uid: f7d51d65-fdb2-4bd2-95d9-8f26ca572640
spec:
  materialized: true
  schema: KAFKA
  sql: |-
    SELECT *
    FROM "KAFKA"."existing-topic-1"
  view: my-topic-3
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get pipelines kafka-my-topic-3 -o yaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: Pipeline
metadata:
  creationTimestamp: "2025-05-22T18:40:46Z"
  generation: 1
  name: kafka-my-topic-3
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: View
    name: kafka-my-topic-3
    uid: f7d51d65-fdb2-4bd2-95d9-8f26ca572640
  resourceVersion: "726701"
  uid: 5122d226-63cd-4875-ae57-9d21a59bd75b
spec:
  sql: |-
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    CREATE TABLE IF NOT EXISTS `KAFKA`.`my-topic-3` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='my-topic-3', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
    INSERT INTO `KAFKA`.`my-topic-3` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-1`;
  yaml: |
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-existing-topic-1
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: existing-topic-1
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: kafka.strimzi.io/v1beta2
    kind: KafkaTopic
    metadata:
      name: kafka-database-my-topic-3
      labels:
        strimzi.io/cluster: one
    spec:
      topicName: my-topic-3
      partitions: 1
      replicas: 1
      config:
        retention.ms: 7200000
        segment.bytes: 1073741824

    ---
    apiVersion: flink.apache.org/v1beta1
    kind: FlinkSessionJob
    metadata:
      name: kafka-database-my-topic-3
    spec:
      deploymentName: basic-session-deployment
      job:
        entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
        args:
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
        - CREATE TABLE IF NOT EXISTS `KAFKA`.`my-topic-3` (`KEY` VARCHAR, `VALUE` BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094', 'scan.startup.mode'='earliest-offset', 'topic'='my-topic-3', 'value.fields-include'='EXCEPT_KEY', 'value.format'='json');
        - INSERT INTO `KAFKA`.`my-topic-3` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-1`;
        jarURI: file:///opt/hoptimator-flink-runner.jar
        parallelism: 1
        upgradeMode: stateless
        state: running
status:
  failed: false
  message: Deployed.
  ready: false
jogrogan@jogrogan-mn1:[~/proteus/Hoptimator]: (jogrogan/snapshot) $ k get flinksessionjobs kafka-database-my-topic-3 -o yaml
apiVersion: flink.apache.org/v1beta1
kind: FlinkSessionJob
metadata:
  creationTimestamp: "2025-05-22T18:40:50Z"
  finalizers:
  - flinksessionjobs.flink.apache.org/finalizer
  generation: 1
  name: kafka-database-my-topic-3
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: Pipeline
    name: kafka-my-topic-3
    uid: 5122d226-63cd-4875-ae57-9d21a59bd75b
  resourceVersion: "726717"
  uid: 51bafb3e-7af0-4403-98df-0e601620556f
spec:
  deploymentName: basic-session-deployment
  job:
    args:
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE`
      BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`my-topic-3` (`KEY` VARCHAR, `VALUE` BINARY)
      WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='my-topic-3', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - INSERT INTO `KAFKA`.`my-topic-3` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-1`;
    entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
    jarURI: file:///opt/hoptimator-flink-runner.jar
    parallelism: 1
    state: running
    upgradeMode: stateless


K8S OBJECTS AFTER RESTORE:
apiVersion: flink.apache.org/v1beta1
kind: FlinkSessionJob
metadata:
  creationTimestamp: "2025-05-22T18:40:50Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2025-05-22T18:43:24Z"
  finalizers:
  - flinksessionjobs.flink.apache.org/finalizer
  generation: 2
  name: kafka-database-my-topic-3
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: Pipeline
    name: kafka-my-topic-3
    uid: 5122d226-63cd-4875-ae57-9d21a59bd75b
  resourceVersion: "727098"
  uid: 51bafb3e-7af0-4403-98df-0e601620556f
spec:
  deploymentName: basic-session-deployment
  job:
    args:
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`existing-topic-1` (`KEY` VARCHAR, `VALUE`
      BINARY) WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='existing-topic-1', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - CREATE DATABASE IF NOT EXISTS `KAFKA` WITH ();
    - CREATE TABLE IF NOT EXISTS `KAFKA`.`my-topic-3` (`KEY` VARCHAR, `VALUE` BINARY)
      WITH ('connector'='kafka', 'key.fields'='KEY', 'key.format'='raw', 'properties.bootstrap.servers'='one-kafka-bootstrap.kafka.svc.cluster.local:9094',
      'scan.startup.mode'='earliest-offset', 'topic'='my-topic-3', 'value.fields-include'='EXCEPT_KEY',
      'value.format'='json');
    - INSERT INTO `KAFKA`.`my-topic-3` (`KEY`, `VALUE`) SELECT * FROM `KAFKA`.`existing-topic-1`;
    entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
    jarURI: file:///opt/hoptimator-flink-runner.jar
    parallelism: 1
    state: running
    upgradeMode: stateless
```

Note in Example 2, the `FlinkSessionJob` after restore has `deletionTimestamp` set and relies on the finalizer to clean it up.