### PR TITLE
Enable validating SqlCreateView and SqlCreateMaterializedView

### DIFF
--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -19,6 +19,13 @@
  */
 package com.linkedin.hoptimator.jdbc;
 
+import com.linkedin.hoptimator.Database;
+import com.linkedin.hoptimator.MaterializedView;
+import com.linkedin.hoptimator.Pipeline;
+import com.linkedin.hoptimator.View;
+import com.linkedin.hoptimator.util.DeploymentService;
+import com.linkedin.hoptimator.util.planner.HoptimatorJdbcTable;
+import com.linkedin.hoptimator.util.planner.PipelineRel;
 import java.io.Reader;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -27,7 +34,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.rel.RelRoot;
@@ -62,14 +68,6 @@ import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-import com.linkedin.hoptimator.Database;
-import com.linkedin.hoptimator.MaterializedView;
-import com.linkedin.hoptimator.Pipeline;
-import com.linkedin.hoptimator.View;
-import com.linkedin.hoptimator.util.DeploymentService;
-import com.linkedin.hoptimator.util.planner.HoptimatorJdbcTable;
-import com.linkedin.hoptimator.util.planner.PipelineRel;
-
 
 public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
 
@@ -100,6 +98,12 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
   /** Executes a {@code CREATE VIEW} command. */
   @Override
   public void execute(SqlCreateView create, CalcitePrepare.Context context) {
+    try {
+      ValidationService.validateOrThrow(create);
+    } catch (SQLException e) {
+      throw new DdlException(create, e.getMessage(), e);
+    }
+
     final Pair<CalciteSchema, String> pair = schema(context, true, create.name);
     if (pair.left == null) {
       throw new DdlException(create, "Schema for " + create.name + " not found.");
@@ -118,6 +122,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         pair.left.removeFunction(pair.right);
       }
     }
+
     final SqlNode q = renameColumns(create.columnList, create.query);
     final String sql = q.toSqlString(CalciteSqlDialect.DEFAULT).getSql();
     List<String> schemaPath = pair.left.path(null);
@@ -146,6 +151,12 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
   /** Executes a {@code CREATE MATERIALIZED VIEW} command. */
   @Override
   public void execute(SqlCreateMaterializedView create, CalcitePrepare.Context context) {
+    try {
+      ValidationService.validateOrThrow(create);
+    } catch (SQLException e) {
+      throw new DdlException(create, e.getMessage(), e);
+    }
+
     final Pair<CalciteSchema, String> pair = schema(context, true, create.name);
     if (pair.left == null) {
       throw new DdlException(create, "Schema for " + create.name + " not found.");

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestSqlScripts.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestSqlScripts.java
@@ -1,6 +1,19 @@
 package com.linkedin.hoptimator.jdbc;
 
+import com.linkedin.hoptimator.Validator;
+import com.linkedin.hoptimator.ValidatorProvider;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import org.apache.calcite.sql.ddl.SqlCreateMaterializedView;
+import org.apache.calcite.sql.ddl.SqlCreateView;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 
 public class TestSqlScripts extends QuidemTestBase {
@@ -8,5 +21,73 @@ public class TestSqlScripts extends QuidemTestBase {
   @Test
   public void basicDdlScript() throws Exception {
     run("basic-ddl.id");
+  }
+
+  @Test
+  public void createViewWithAValidatorRejectingCreateViewThrowsException() throws Exception {
+    // Runs the test in a separate thread to isolate the context class loader changes.
+    Thread testThread = new Thread(() -> {
+      useTestValidatorsUnchecked();
+
+      AssertionFailedError exception = Assertions.assertThrows(AssertionFailedError.class, () -> run("basic-ddl.id"));
+      Assertions.assertTrue(exception.getMessage().contains(SqlCreateViewValidator.ERROR_MESSAGE),
+          "Expected error message not found: " + exception.getMessage());
+    });
+    testThread.start();
+    testThread.join(); // Wait for the thread to finish
+  }
+
+  @Test
+  public void createMaterializedViewWithAValidatorRejectingCreateViewThrowsException() throws Exception {
+    // Runs the test in a separate thread to isolate the context class loader changes.
+    Thread testThread = new Thread(() -> {
+      useTestValidatorsUnchecked();
+
+      AssertionFailedError exception =
+          Assertions.assertThrows(AssertionFailedError.class, () -> run("create-materialized-view-ddl.id"));
+      Assertions.assertTrue(exception.getMessage().contains(SqlCreateViewValidator.ERROR_MESSAGE),
+          "Expected error message not found: " + exception.getMessage());
+    });
+    testThread.start();
+    testThread.join(); // Wait for the thread to finish
+  }
+
+  private void useTestValidatorsUnchecked() {
+    try {
+      useTestValidators();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to set up test validators", e);
+    }
+  }
+
+  private void useTestValidators() throws IOException {
+    Path tempDir = Files.createTempDirectory("spi-test");
+    Path servicesDir = tempDir.resolve("META-INF/services");
+    Files.createDirectories(servicesDir);
+    Files.writeString(servicesDir.resolve("com.linkedin.hoptimator.ValidatorProvider"),
+        "com.linkedin.hoptimator.jdbc.TestSqlScripts$CreateViewValidatorProvider\n");
+
+    URLClassLoader cl = new URLClassLoader(new URL[]{tempDir.toUri().toURL()}, getClass().getClassLoader());
+    Thread.currentThread().setContextClassLoader(cl);
+  }
+
+  @SuppressWarnings("unused")
+  public static class CreateViewValidatorProvider implements ValidatorProvider {
+    @Override
+    public <T> Collection<Validator> validators(T obj) {
+      if (obj instanceof SqlCreateView || obj instanceof SqlCreateMaterializedView) {
+        return List.of(new SqlCreateViewValidator());
+      }
+      return List.of();
+    }
+  }
+
+  static class SqlCreateViewValidator implements Validator {
+    static final String ERROR_MESSAGE = "Create view is not allowed in this test.";
+
+    @Override
+    public void validate(Issues issues) {
+      issues.error(ERROR_MESSAGE);
+    }
   }
 }

--- a/hoptimator-jdbc/src/test/resources/create-materialized-view-ddl.id
+++ b/hoptimator-jdbc/src/test/resources/create-materialized-view-ddl.id
@@ -1,0 +1,12 @@
+!set outputformat mysql
+!use util
+
+create table foo (id VARCHAR(128), a VARCHAR, c INT);
+(0 rows modified)
+
+!update
+
+create materialized view foo_edge as select * from foo;
+(0 rows modified)
+
+!update


### PR DESCRIPTION
## Problem and Solution
Currently HoptimatorDdlExecutor only do validation in a later stage against the planned deployable objects created from validates SqlCreateView and SqlCreateMaterializedView.

The ValidationService doesn't validate create view commands directly.

This PR is to make ValidationService validate create view commands early. No validators are registered for those commands by default. They can be extended by users of hoptimator-jdbc library.

# Testing Done
Add new quidem test cases with a test validator to validating that create view commands are validated.
