### PR TITLE
Fix mishandling of null types in output Avro schemas

### DIFF
--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
@@ -69,7 +69,9 @@ public final class AvroConverter {
               dataType.isNullable());
         case UNKNOWN:
         case NULL:
-          return createAvroSchemaWithNullability(Schema.createUnion(Schema.create(Schema.Type.NULL)), true);
+          // We can't have a union of null and null ["null", "null"], nor a nested union ["null",["null"]],
+          // so we ignore nullability and just use ["null"] here.
+          return Schema.createUnion(Schema.create(Schema.Type.NULL));
         default:
           throw new UnsupportedOperationException("No support yet for " + dataType.getSqlTypeName().toString());
       }

--- a/hoptimator-avro/src/test/java/com/linkedin/hoptimator/avro/AvroConverterTest.java
+++ b/hoptimator-avro/src/test/java/com/linkedin/hoptimator/avro/AvroConverterTest.java
@@ -82,6 +82,16 @@ public class AvroConverterTest {
   }
 
   @Test
+  public void supportsNullTypes() {
+    RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataType rel = typeFactory.createStructType(Collections.singletonList(typeFactory.createSqlType(SqlTypeName.NULL)),
+        Collections.singletonList("field1"));
+
+    Schema avroSchema = AvroConverter.avro("NS", "R", rel);
+    assertEquals(avroSchema.toString(), avroSchema.getFields().size(), rel.getFieldCount());
+  }
+
+  @Test
   public void testAvroKeyPayloadSchemaNoKeyOptions() {
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType dataType = typeFactory.createStructType(Collections.singletonList(typeFactory.createSqlType(SqlTypeName.VARCHAR)),


### PR DESCRIPTION
## Summary

- Fix `Nested union: ["null",["null"]]` bug

## Details

Avro does not allow `["null",["null"]]` nor `["null", "null"]`. `AvroConverter` was generating `["null",["null"]]`, presumably in an attempt to represent a nullable null type. But of course the null type is implicitly nullable anyway.

## Testing

New unit test fails with `Nested union: ["null",["null"]]` without the fix. Passes with the fix.

