### PR TITLE
Fix exception when reconciling object deletion

### DIFF
--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
@@ -103,9 +103,9 @@ public final class K8sUtils {
       case 409: // conflict
       case 410: // gone
       case 412: // precondition failed
-        throw new SQLTransientException(msgSupplier.get(), e);
+        throw new SQLTransientException(msgSupplier.get(), null, resp.getHttpStatusCode(), e);
       default:
-        throw new SQLNonTransientException(msgSupplier.get(), e);
+        throw new SQLNonTransientException(msgSupplier.get(), null, resp.getHttpStatusCode(), e);
       }
     }
   }

--- a/hoptimator-k8s/src/testFixtures/java/com/linkedin/hoptimator/k8s/FakeK8sApi.java
+++ b/hoptimator-k8s/src/testFixtures/java/com/linkedin/hoptimator/k8s/FakeK8sApi.java
@@ -26,7 +26,7 @@ public class FakeK8sApi<T extends KubernetesObject, U extends KubernetesListObje
   @Override
   public T get(String name) throws SQLException {
     return objects.stream().filter(x -> x.getMetadata().getName().equals(name)).findFirst()
-        .orElseThrow(() -> new SQLException("No object named " + name));
+        .orElseThrow(() -> new SQLException("No object named " + name, null, 404));
   }
 
   @Override

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/trigger/TableTriggerReconciler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/trigger/TableTriggerReconciler.java
@@ -82,7 +82,7 @@ public final class TableTriggerReconciler implements Reconciler {
     this.tableTriggerApi = tableTriggerApi;
     this.jobApi = jobApi;
     this.yamlApi = yamlApi;
-  } 
+  }
 
   @Override
   public Result reconcile(Request request) {
@@ -91,11 +91,15 @@ public final class TableTriggerReconciler implements Reconciler {
     String namespace = request.getNamespace();
 
     try {
-      V1alpha1TableTrigger object = tableTriggerApi.get(namespace, name);
-
-      if (object == null) {
-        log.info("Object {} deleted. Skipping.", name);
-        return new Result(false);
+      V1alpha1TableTrigger object;
+      try {
+        object = tableTriggerApi.get(namespace, name);
+      } catch (SQLException e) {
+        if (e.getErrorCode() == 404) {
+          log.info("Object {} deleted. Skipping.", name);
+          return new Result(false);
+        }
+        throw e;
       }
 
       V1alpha1TableTriggerStatus status = object.getStatus();


### PR DESCRIPTION
The exception code from kubernetes was not being passed through to the SqlException we throw. Checking for `object == null` was the old way of doing things through the operator interface. We need to catch the exception now and check the correct code.