### PR TITLE
Add ResolvedTable

### DIFF
--- a/hoptimator-jdbc/build.gradle
+++ b/hoptimator-jdbc/build.gradle
@@ -6,7 +6,9 @@ plugins {
 
 dependencies {
   implementation project(':hoptimator-api')
+  implementation project(':hoptimator-avro')
   implementation project(':hoptimator-util')
+  implementation libs.avro
   implementation libs.calcite.core
   implementation libs.calcite.server
   implementation libs.slf4j.api

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ResolvedTable.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ResolvedTable.java
@@ -1,0 +1,37 @@
+package com.linkedin.hoptimator.jdbc;
+
+import java.util.List;
+import java.util.Map;
+
+/** Metadata required to access a table in the data plane. */
+public class ResolvedTable {
+
+  private final List<String> tablePath;
+  private org.apache.avro.Schema avroSchema;
+  private final Map<String, String> sourceConnectorConfigs;
+  private final Map<String, String> sinkConnectorConfigs;
+
+  public ResolvedTable(List<String> tablePath, org.apache.avro.Schema avroSchema,
+      Map<String, String> sourceConnectorConfigs, Map<String, String> sinkConnectorConfigs) {
+    this.tablePath = tablePath;
+    this.avroSchema = avroSchema;
+    this.sourceConnectorConfigs = sourceConnectorConfigs;
+    this.sinkConnectorConfigs = sinkConnectorConfigs;
+  }
+
+  public Map<String, String> sourceConnectorConfigs() {
+    return sourceConnectorConfigs;
+  }
+
+  public Map<String, String> sinkConnectorConfigs() {
+    return sinkConnectorConfigs;
+  }
+
+  public org.apache.avro.Schema avroSchema() {
+    return avroSchema;
+  }
+
+  public String avroSchemaString() {
+    return avroSchema.toString(true);
+  }
+}


### PR DESCRIPTION
## Summary

- Added `ResolvedTable` class.
- Added `HoptimatorConnection.resolve()` method.
- Added `!resolve foo.bar` CLI command.

## Details

In order to use Hoptimator's table resolution machinery in external catalog implementations (e.g. a Flink catalog), we need the ability to resolve table schemas / row types and connector configurations over a JDBC connection. For convenience purposes, this PR pulls together such metadata into a new `ResolvedTable` class, including an Avro-encoded schema.

Connector configurations are left as a TODO, since this machinery is still a work in progress elsewhere.

A new `!resolve` CLI command dumps this new metadata.

## Testing done

```
: Hoptimator> !resolve ADS.AD_CLICKS
Avro schema:

{
  "type" : "record",
  "name" : "ad_clicks",
  "namespace" : "com.linkedin.ads",
  "doc" : "RecordType(VARCHAR CAMPAIGN_URN, VARCHAR MEMBER_URN)",
  "fields" : [ {
    "name" : "CAMPAIGN_URN",
    "type" : [ "null", "string" ],
    "doc" : "CAMPAIGN_URN VARCHAR"
  }, {
    "name" : "MEMBER_URN",
    "type" : [ "null", "string" ],
    "doc" : "MEMBER_URN VARCHAR"
  } ]
}
```