### PR TITLE
Add source/sink configs to resolve output

### DIFF
--- a/hoptimator-cli/src/main/java/sqlline/HoptimatorAppConfig.java
+++ b/hoptimator-cli/src/main/java/sqlline/HoptimatorAppConfig.java
@@ -170,8 +170,12 @@ public class HoptimatorAppConfig extends Application {
       HoptimatorConnection conn = (HoptimatorConnection) sqlline.getConnection();
       try {
         ResolvedTable resolved = conn.resolve(tablePath, Collections.emptyMap());
-        sqlline.output("Avro schema:\n");
-        sqlline.output(resolved.avroSchemaString());
+        sqlline.output("Avro schema:");
+        sqlline.output(resolved.avroSchemaString() + "\n");
+        sqlline.output("Source configs:");
+        sqlline.output(resolved.sourceConnectorConfigs().toString() + "\n");
+        sqlline.output("Sink configs:");
+        sqlline.output(resolved.sinkConnectorConfigs().toString() + "\n");
       } catch (SQLException e) {
         sqlline.error(e);
         dispatchCallback.setToFailure();


### PR DESCRIPTION
Expands #151 to add source/sink configs to the resolve output

If a given source or sink is not applicable an empty set of configs `{}` will be given.

```
0: Hoptimator> !resolve ADS.AD_CLICKS
Avro schema:
{
  "type" : "record",
  "name" : "ad_clicks",
  "namespace" : "com.linkedin.ads",
  "doc" : "RecordType(VARCHAR CAMPAIGN_URN, VARCHAR MEMBER_URN)",
  "fields" : [ {
    "name" : "CAMPAIGN_URN",
    "type" : [ "null", "string" ],
    "doc" : "CAMPAIGN_URN VARCHAR"
  }, {
    "name" : "MEMBER_URN",
    "type" : [ "null", "string" ],
    "doc" : "MEMBER_URN VARCHAR"
  } ]
}

Source configs:
{connector=datagen, number-of-rows=10}

Sink configs:
{connector=blackhole}

0: Hoptimator> !resolve KAFKA.existing-topic-1
Avro schema:
{
  "type" : "record",
  "name" : "existingtopic1",
  "namespace" : "com.linkedin.kafka",
  "doc" : "RecordType(VARCHAR KEY, BINARY(1) VALUE)",
  "fields" : [ {
    "name" : "KEY",
    "type" : [ "null", "string" ],
    "doc" : "KEY VARCHAR"
  }, {
    "name" : "VALUE",
    "type" : [ "null", {
      "type" : "fixed",
      "name" : "VALUE",
      "doc" : "BINARY(1)",
      "size" : 1
    } ],
    "doc" : "VALUE BINARY(1)"
  } ]
}

Source configs:
{connector=kafka, key.fields=KEY, key.format=raw, properties.bootstrap.servers=one-kafka-bootstrap.kafka.svc.cluster.local:9094, scan.startup.mode=earliest-offset, topic=existing-topic-1, value.fields-include=EXCEPT_KEY, value.format=json}

Sink configs:
{connector=kafka, key.fields=KEY, key.format=raw, properties.bootstrap.servers=one-kafka-bootstrap.kafka.svc.cluster.local:9094, scan.startup.mode=earliest-offset, topic=existing-topic-1, value.fields-include=EXCEPT_KEY, value.format=json}

0: Hoptimator> !resolve VENICE.test-store
Avro schema:
{
  "type" : "record",
  "name" : "teststore",
  "namespace" : "com.linkedin.venice",
  "doc" : "RecordType(INTEGER KEY_id, INTEGER intField, VARCHAR stringField)",
  "fields" : [ {
    "name" : "KEY_id",
    "type" : "int",
    "doc" : "KEY_id INTEGER NOT NULL"
  }, {
    "name" : "intField",
    "type" : [ "null", "int" ],
    "doc" : "intField INTEGER"
  }, {
    "name" : "stringField",
    "type" : [ "null", "string" ],
    "doc" : "stringField VARCHAR"
  } ]
}

Source configs:
{connector=venice, key.fields=KEY_id, key.fields-prefix=KEY_, key.type=RECORD, partial-update-mode=true, storeName=test-store, value.fields-include=EXCEPT_KEY}

Sink configs:
{connector=venice, key.fields=KEY_id, key.fields-prefix=KEY_, key.type=RECORD, partial-update-mode=true, storeName=test-store, value.fields-include=EXCEPT_KEY}
```