### PR TITLE
Add logging function to HoptimatorConnection so its clients can retrieve logs by registering hooks

### DIFF
--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorConnection.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorConnection.java
@@ -32,7 +32,7 @@ public class HoptimatorConnection extends DelegatingConnection {
   private final Properties connectionProperties;
   private final List<RelOptMaterialization> materializations = new ArrayList<>();
 
-  private final List<Consumer<String>> hooks = new ArrayList<>();
+  private final List<Consumer<String>> logHooks = new ArrayList<>();
 
   public HoptimatorConnection(CalciteConnection connection, Properties connectionProperties) {
     super(connection);
@@ -100,7 +100,7 @@ public class HoptimatorConnection extends DelegatingConnection {
    * Returns a logger for a client of this connection. The logger logs to both SLF4J and hooks.
    */
   HoptimatorConnectionDualLogger getLogger(Class<?> clazz) {
-    return new HoptimatorConnectionDualLogger(clazz, hooks);
+    return new HoptimatorConnectionDualLogger(clazz, logHooks);
   }
 
   /**
@@ -108,7 +108,7 @@ public class HoptimatorConnection extends DelegatingConnection {
    * TODO: Revise to allow hooks to be added per statement.
    */
   public void addLogHook(Consumer<String> hook) {
-    hooks.add(hook);
+    logHooks.add(hook);
   }
 
   private void registerMaterialization(List<String> viewPath, RelNode tableRel, RelNode queryRel) {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -146,10 +146,11 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       deployers = DeploymentService.deployers(view, connection);
       ValidationService.validateOrThrow(deployers);
       logger.info("Validated view {}", viewName);
-      logger.info("Deploying view {}", viewName);
       if (create.getReplace()) {
+        logger.info("Deploying update view {}", viewName);
         DeploymentService.update(deployers);
       } else {
+        logger.info("Deploying create view {}", viewName);
         DeploymentService.create(deployers);
       }
       logger.info("Deployed view {}", viewName);
@@ -269,10 +270,11 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       logger.info("Validating view {} with deployers", viewName);
       ValidationService.validateOrThrow(deployers);
       logger.info("Validated view {}", viewName);
-      logger.info("Deploying view {}", viewName);
       if (create.getReplace()) {
+        logger.info("Deploying update view {}", viewName);
         DeploymentService.update(deployers);
       } else {
+        logger.info("Deploying create view {}", viewName);
         DeploymentService.create(deployers);
       }
       logger.info("Deployed view {}", viewName);

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/JdbcTestBase.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/JdbcTestBase.java
@@ -34,6 +34,15 @@ public abstract class JdbcTestBase {
     }
   }
 
+  protected List<String> sqlReturnsLogs(String sql) throws SQLException {
+    var logs = new ArrayList<String>();
+    ((HoptimatorConnection) conn).addLogHook(logs::add);
+    try (Statement stmt = conn.createStatement()) {
+      stmt.executeUpdate(sql);
+    }
+    return logs;
+  }
+
   protected void assertQueriesEqual(String q1, String q2) throws SQLException {
     assertResultSetsEqual(query(q1), query(q2));
   }

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
@@ -45,9 +45,12 @@ public class TestBasicSql extends JdbcTestBase {
     var expectedLogs = List.of(
         "[HoptimatorDdlExecutor] Validating statement: CREATE VIEW `V` AS\nSELECT *\nFROM `T`",
         "[HoptimatorDdlExecutor] Validated sql statement. The view is named V and has path [DEFAULT, V]",
-        "[HoptimatorDdlExecutor] Validating view V with deployers", "[HoptimatorDdlExecutor] Validated view V",
-        "[HoptimatorDdlExecutor] Deploying view V", "[HoptimatorDdlExecutor] Deployed view V",
-        "[HoptimatorDdlExecutor] Added view V to schema DEFAULT", "[HoptimatorDdlExecutor] CREATE VIEW V completed");
+        "[HoptimatorDdlExecutor] Validating view V with deployers",
+        "[HoptimatorDdlExecutor] Validated view V",
+        "[HoptimatorDdlExecutor] Deploying create view V",
+        "[HoptimatorDdlExecutor] Deployed view V",
+        "[HoptimatorDdlExecutor] Added view V to schema DEFAULT",
+        "[HoptimatorDdlExecutor] CREATE VIEW V completed");
     Assertions.assertEquals(expectedLogs, logs);
   }
 }

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TestBasicSql.java
@@ -2,7 +2,10 @@ package com.linkedin.hoptimator.jdbc;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 
 public class TestBasicSql extends JdbcTestBase {
@@ -27,5 +30,24 @@ public class TestBasicSql extends JdbcTestBase {
         queryUsingPreparedStatement("SELECT * FROM T1 WHERE X = ?", Arrays.asList("one")));
     sql("DROP TABLE T1");
     sql("DROP TABLE T2");
+  }
+
+  @Test
+  public void createView() throws Exception {
+    sql("CREATE TABLE T (X VARCHAR, Y VARCHAR)");
+    sql("INSERT INTO T VALUES ('one', 'two')");
+    assertQueriesEqual("SELECT * FROM T", "VALUES ('one', 'two')");
+    var logs = sqlReturnsLogs("CREATE VIEW V AS SELECT * FROM T");
+    assertResultSetsEqual(query("SELECT * FROM V"), query("SELECT * FROM T"));
+    sql("DROP VIEW V");
+    sql("DROP TABLE T");
+
+    var expectedLogs = List.of(
+        "[HoptimatorDdlExecutor] Validating statement: CREATE VIEW `V` AS\nSELECT *\nFROM `T`",
+        "[HoptimatorDdlExecutor] Validated sql statement. The view is named V and has path [DEFAULT, V]",
+        "[HoptimatorDdlExecutor] Validating view V with deployers", "[HoptimatorDdlExecutor] Validated view V",
+        "[HoptimatorDdlExecutor] Deploying view V", "[HoptimatorDdlExecutor] Deployed view V",
+        "[HoptimatorDdlExecutor] Added view V to schema DEFAULT", "[HoptimatorDdlExecutor] CREATE VIEW V completed");
+    Assertions.assertEquals(expectedLogs, logs);
   }
 }


### PR DESCRIPTION
**Problem:**
Currently Hoptimator jdbc doesn't provide execution details such as validations or deployment steps other than the number of modified rows. Some clients are interested in those details to help users understand what happen behind the scene.

**Solution:**
This PR add logging function to HoptimatorConnection for create (materialized) view statements so its clients can retrieve logs at HoptimatorDdlExecutor level by registering hooks. It has a pending TODO to add statement execution log isolation in the future.

Logging at lower level than the HoptimatorDdlExecutor could be added in another PR if desired.

With this PR, when executing "create materialized view \"QUEUING\".test_view_00 as select * from \"QUEUING\".\"test-source\"" statement, hoptimator client would get the following log lines:
```
"[HoptimatorDdlExecutor] Validating statement: CREATE MATERIALIZED VIEW `QUEUING`.`TEST_VIEW_00` AS\nSELECT *\nFROM `QUEUING`.`test-source`",
"[HoptimatorDdlExecutor] Validated sql statement. The view is named TEST_VIEW_00 and has path [QUEUING, TEST_VIEW_00]",
"[HoptimatorDdlExecutor] Pipeline name for view TEST_VIEW_00 is kafka-queuing-TEST_VIEW_00",
"[HoptimatorDdlExecutor] Added view TEST_VIEW_00 to schema QUEUING",
"[HoptimatorDdlExecutor] Validating view TEST_VIEW_00 with deployers",
"[HoptimatorDdlExecutor] Validated view TEST_VIEW_00",
"[HoptimatorDdlExecutor] Deploying view TEST_VIEW_00",
"[HoptimatorDdlExecutor] Deployed view TEST_VIEW_00",
"[HoptimatorDdlExecutor] CREATE MATERIALIZED VIEW TEST_VIEW_00 completed"
```


**Testing Done:**

- Add new unit test: com.linkedin.hoptimator.jdbc.TestBasicSql.createView
- Manual run a hoptimator jdbc client and verify logs
