### PR TITLE
Fix AvroConverter when multiple Array of Struct schemas is converted

### DIFF
--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
@@ -62,10 +62,14 @@ public final class AvroConverter {
         case BOOLEAN:
           return createAvroTypeWithNullability(Schema.Type.BOOLEAN, dataType.isNullable());
         case ARRAY:
-          return createAvroSchemaWithNullability(Schema.createArray(avro(null, "arrayElement", Objects.requireNonNull(dataType.getComponentType()))),
+          return createAvroSchemaWithNullability(
+              Schema.createArray(avro(null, sanitize(name) + "ArrayElement",
+                  Objects.requireNonNull(dataType.getComponentType()))),
               dataType.isNullable());
         case MAP:
-          return createAvroSchemaWithNullability(Schema.createMap(avro(null, "mapElement", Objects.requireNonNull(dataType.getValueType()))),
+          return createAvroSchemaWithNullability(
+              Schema.createMap(avro(null, sanitize(name) + "MapElement",
+                  Objects.requireNonNull(dataType.getValueType()))),
               dataType.isNullable());
         case UNKNOWN:
         case NULL:


### PR DESCRIPTION
When a schema with multiple Array of Structs is converted, AvroConverter runs into a error "arrayElement can't be redefined", This PR fixes the issue by adding the name of the struct as prefix to make the record names unique