### PR TITLE
Block read only mode from running DDL

### DIFF
--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -62,6 +62,13 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
   private final HoptimatorConnection.HoptimatorConnectionDualLogger logger;
 
   public HoptimatorDdlExecutor(HoptimatorConnection connection) {
+    try {
+      if (connection.isReadOnly()) {
+        throw new DdlException("Cannot execute DDL in read-only mode");
+      }
+    } catch (SQLException e) {
+      throw new DdlException("Failed to check read-only mode", e);
+    }
     this.connection = connection;
     this.logger = connection.getLogger(HoptimatorDdlExecutor.class);
   }
@@ -314,12 +321,20 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
           + ": " + msg, cause);
     }
 
+    DdlException(String msg, Throwable cause) {
+      super(msg, cause);
+    }
+
     DdlException(SqlNode node, String msg, Throwable cause) {
       this(node, node.getParserPosition(), msg, cause);
     }
 
     DdlException(SqlNode node, String msg) {
       this(node, msg, null);
+    }
+
+    DdlException(String msg) {
+      this(msg, null);
     }
   }
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DelegatingConnection.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DelegatingConnection.java
@@ -135,12 +135,12 @@ public class DelegatingConnection implements Connection {
 
   @Override
   public void setReadOnly(boolean readOnly) throws SQLException {
-    // nop
+    connection.setReadOnly(readOnly);
   }
 
   @Override
   public boolean isReadOnly() throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return connection.isReadOnly();
   }
 
   @Override


### PR DESCRIPTION
Block connection in read only mode from running DDL statements.

Tested by enabling sqlline.readOnly=true locally.