### PR TITLE
Split mcp package to remove oss drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To use Hoptimator from an AI chat bot, agent, IDE, etc, you can use the Model Co
 {
   "mcpServers": {
     "Hoptimator": {
-      "command": "./hoptimator-mcp-server/start"
+      "command": "./start-mcp-server"
     }
 }
 ```

--- a/hoptimator-mcp-server-app/build.gradle
+++ b/hoptimator-mcp-server-app/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id 'java'
+  id 'application'
+  id 'idea'
+}
+
+dependencies {
+  implementation project(':hoptimator-mcp-server')
+
+  runtimeOnly project(':hoptimator-demodb')
+  runtimeOnly project(':hoptimator-kafka')
+  runtimeOnly project(':hoptimator-venice')
+}
+
+application {
+  mainClassName  = 'com.linkedin.hoptimator.mcp.server.HoptimatorMcpServer'
+}
+
+tasks.withType(JavaCompile).configureEach {
+  options.release = 17
+  options.compilerArgs << '-Xlint:deprecation'
+  options.compilerArgs << '-Xlint:unchecked'
+}

--- a/hoptimator-mcp-server/build.gradle
+++ b/hoptimator-mcp-server/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'java'
-  id 'application'
   id 'idea'
   id 'maven-publish'
 }
@@ -11,20 +10,12 @@ dependencies {
   implementation project(':hoptimator-util')
   implementation project(':hoptimator-k8s')
 
-  implementation project(':hoptimator-demodb')
-  implementation project(':hoptimator-kafka')
-  implementation project(':hoptimator-venice')
-
   implementation libs.slf4j.simple
   implementation libs.calcite.core
   implementation libs.gson
   implementation libs.jackson.databind
   implementation libs.jackson.dataformat.yaml
   implementation libs.mcp
-}
-
-application {
-  mainClassName  = 'com.linkedin.hoptimator.mcp.server.HoptimatorMcpServer'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ include 'hoptimator-k8s'
 include 'hoptimator-kafka-controller'
 include 'hoptimator-kafka'
 include 'hoptimator-mcp-server'
+include 'hoptimator-mcp-server-app'
 include 'hoptimator-models'           // <-- marked for deletion
 include 'hoptimator-operator'
 include 'hoptimator-operator-integration'

--- a/start-mcp-server
+++ b/start-mcp-server
@@ -2,8 +2,7 @@
 
 BASEDIR="$( cd "$( dirname "$0" )" && pwd )"
 
-$BASEDIR/build/install/hoptimator-mcp-server/bin/hoptimator-mcp-server \
+$BASEDIR/hoptimator-mcp-server-app/build/install/hoptimator-mcp-server-app/bin/hoptimator-mcp-server-app \
   -Dorg.slf4j.simpleLogger.showThreadName=false \
   -Dorg.slf4j.simpleLogger.showLogName=false \
   com.linkedin.hoptimator.mcp.server.HoptimatorMcpServer "jdbc:hoptimator://fun=mysql"
-


### PR DESCRIPTION
Split mcp package to remove oss drivers. Wasn't very extensible as written.

Tested no regressions in mcp server