### PR TITLE
Add support for Flink Beam templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ deploy-flink: deploy
 	kubectl apply -f ./deploy/dev/flink-session-cluster.yaml
 	kubectl apply -f ./deploy/dev/flink-sql-gateway.yaml
 	kubectl apply -f ./deploy/samples/flink-template.yaml
+	kubectl apply -f ./deploy/samples/flink-beam-template.yaml
 
 undeploy-flink:
 	kubectl delete flinksessionjobs.flink.apache.org --all || echo "skipping"

--- a/deploy/config/hoptimator-configmap.yaml
+++ b/deploy/config/hoptimator-configmap.yaml
@@ -13,7 +13,12 @@ data:
   game.properties: |
     enemy.types=aliens,monsters
     player.maximum-lives=5
+
   user-interface.properties: |
     color.good=purple
     color.bad=yellow
     allow.textmode=true
+
+  flink.config: |
+    flink.app.name=hoptimator-flink-runner
+    flink.app.type=SQL

--- a/deploy/samples/flink-beam-template.yaml
+++ b/deploy/samples/flink-beam-template.yaml
@@ -1,0 +1,26 @@
+## This template adds Flink Beam support.
+
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: JobTemplate
+metadata:
+  name: flink-beam-sqljob-template
+spec:
+  yaml: |
+    apiVersion: hoptimator.linkedin.com/v1alpha1
+    kind: SqlJob
+    metadata:
+      name: {{name}}
+    spec:
+      dialect: FlinkBeam
+      executionMode: Streaming
+      sql:
+        - PLACEHOLDER
+      configs:
+        {{flink.app.type==BEAM}}
+        source.group.id: hoptimator-flink-beam-{{pipeline}}
+        source.schemas: {{sourceSchemas}}
+        source.tables: {{sourceTables}}
+        sink.schema: {{schema}}
+        sink.table: {{table}}
+        fields: {{fieldMap}}
+        {{flinkconfigs}}

--- a/deploy/samples/flink-template.yaml
+++ b/deploy/samples/flink-template.yaml
@@ -16,7 +16,8 @@ spec:
         entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
         args:
         - {{flinksql}}
-        jarURI: file:///opt/hoptimator-flink-runner.jar
+        jarURI: file:///opt/{{flink.app.name}}.jar
         parallelism: {{flink.parallelism:1}}
         upgradeMode: stateless
         state: running
+        {{flink.app.type==SQL}}

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
@@ -48,6 +48,18 @@ public class Job implements Deployable {
     return sink;
   }
 
+  public ThrowingFunction<SqlDialect, String> sql() {
+    return eval("sql");
+  }
+
+  public ThrowingFunction<SqlDialect, String> query() {
+    return eval("query");
+  }
+
+  public ThrowingFunction<SqlDialect, String> fieldMap() {
+    return eval("fieldMap");
+  }
+
   /**
    * Retrieves a lazy-evaluated template function by key.
    *
@@ -68,7 +80,7 @@ public class Job implements Deployable {
    * @see #lazyEvals
    * @see ThrowingFunction#apply(Object)
    */
-  public ThrowingFunction<SqlDialect, String> eval(String key) {
+  private ThrowingFunction<SqlDialect, String> eval(String key) {
     if (!lazyEvals.containsKey(key)) {
       throw new IllegalArgumentException("Unknown eval key: " + key + ". Available keys: " + lazyEvals.keySet());
     }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
@@ -1,6 +1,7 @@
 package com.linkedin.hoptimator;
 
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -13,6 +14,7 @@ import java.util.Map;
 public class Job implements Deployable {
 
   private final String name;
+  private final Set<Source> sources;
   private final Sink sink;
 
   /**
@@ -27,14 +29,19 @@ public class Job implements Deployable {
    */
   private final Map<String, ThrowingFunction<SqlDialect, String>> lazyEvals;
 
-  public Job(String name, Sink sink, Map<String, ThrowingFunction<SqlDialect, String>> lazyEvals) {
+  public Job(String name, Set<Source> sources, Sink sink, Map<String, ThrowingFunction<SqlDialect, String>> lazyEvals) {
     this.name = name;
+    this.sources = sources;
     this.sink = sink;
     this.lazyEvals = lazyEvals;
   }
 
   public String name() {
     return name;
+  }
+
+  public Set<Source> sources() {
+    return sources;
   }
 
   public Sink sink() {

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Job.java
@@ -69,6 +69,9 @@ public class Job implements Deployable {
    * @see ThrowingFunction#apply(Object)
    */
   public ThrowingFunction<SqlDialect, String> eval(String key) {
+    if (!lazyEvals.containsKey(key)) {
+      throw new IllegalArgumentException("Unknown eval key: " + key + ". Available keys: " + lazyEvals.keySet());
+    }
     return lazyEvals.get(key);
   }
 

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/MaterializedView.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/MaterializedView.java
@@ -1,16 +1,15 @@
 package com.linkedin.hoptimator;
 
 import java.util.List;
-import java.util.function.Function;
 
 
 public class MaterializedView extends View implements Deployable {
 
   private final String database;
-  private final Function<SqlDialect, String> pipelineSql;
+  private final ThrowingFunction<SqlDialect, String> pipelineSql;
   private final Pipeline pipeline;
 
-  public MaterializedView(String database, List<String> path, String viewSql, Function<SqlDialect, String> pipelineSql,
+  public MaterializedView(String database, List<String> path, String viewSql, ThrowingFunction<SqlDialect, String> pipelineSql,
       Pipeline pipeline) {
     super(path, viewSql);
     this.database = database;
@@ -22,7 +21,7 @@ public class MaterializedView extends View implements Deployable {
     return pipeline;
   }
 
-  public Function<SqlDialect, String> pipelineSql() {
+  public ThrowingFunction<SqlDialect, String> pipelineSql() {
     return pipelineSql;
   }
 

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ThrowingFunction.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ThrowingFunction.java
@@ -1,0 +1,12 @@
+package com.linkedin.hoptimator;
+
+import java.sql.SQLException;
+
+
+/**
+ * Functional interface that allows functions to throw SQLException.
+ */
+@FunctionalInterface
+public interface ThrowingFunction<T, R> {
+  R apply(T t) throws SQLException;
+}

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ThrowingSupplier.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ThrowingSupplier.java
@@ -1,0 +1,12 @@
+package com.linkedin.hoptimator;
+
+import java.sql.SQLException;
+
+
+/**
+ * Functional interface that allows suppliers to throw SQLException.
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T> {
+  T get() throws SQLException;
+}

--- a/hoptimator-cli/src/main/java/sqlline/HoptimatorAppConfig.java
+++ b/hoptimator-cli/src/main/java/sqlline/HoptimatorAppConfig.java
@@ -127,6 +127,8 @@ public class HoptimatorAppConfig extends Application {
         RelOptTable table = root.rel.getTable();
         if (table != null) {
           connectionProperties.setProperty(DeploymentService.PIPELINE_OPTION, String.join(".", table.getQualifiedName()));
+        } else if (create != null) {
+          connectionProperties.setProperty(DeploymentService.PIPELINE_OPTION, create.name.toString());
         }
         PipelineRel.Implementor plan = DeploymentService.plan(root, conn.materializations(), connectionProperties);
         if (create != null) {
@@ -301,6 +303,8 @@ public class HoptimatorAppConfig extends Application {
         RelOptTable table = root.rel.getTable();
         if (table != null) {
           connectionProperties.setProperty(DeploymentService.PIPELINE_OPTION, String.join(".", table.getQualifiedName()));
+        } else if (create != null) {
+          connectionProperties.setProperty(DeploymentService.PIPELINE_OPTION, create.name.toString());
         }
         PipelineRel.Implementor plan = DeploymentService.plan(root, conn.materializations(), connectionProperties);
         if (create != null) {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -230,7 +230,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       schemaSnapshot = HoptimatorDdlUtils.snapshotAndSetSinkSchema(context, new HoptimatorDriver.Prepare(connection), plan, sql, pair);
       logger.info("Added view {} to schema {}", viewName, schemaPlus.getName());
       Pipeline pipeline = plan.pipeline(viewName, connection);
-      MaterializedView hook = new MaterializedView(database, viewPath, sql, pipeline.job().sql(), pipeline);
+      MaterializedView hook = new MaterializedView(database, viewPath, sql, pipeline.job().eval("sql"), pipeline);
       // TODO support CREATE ... WITH (options...)
       ValidationService.validateOrThrow(hook);
       deployers = DeploymentService.deployers(hook, connection);

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -230,7 +230,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       schemaSnapshot = HoptimatorDdlUtils.snapshotAndSetSinkSchema(context, new HoptimatorDriver.Prepare(connection), plan, sql, pair);
       logger.info("Added view {} to schema {}", viewName, schemaPlus.getName());
       Pipeline pipeline = plan.pipeline(viewName, connection);
-      MaterializedView hook = new MaterializedView(database, viewPath, sql, pipeline.job().eval("sql"), pipeline);
+      MaterializedView hook = new MaterializedView(database, viewPath, sql, pipeline.job().sql(), pipeline);
       // TODO support CREATE ... WITH (options...)
       ValidationService.validateOrThrow(hook);
       deployers = DeploymentService.deployers(hook, connection);

--- a/hoptimator-jdbc/src/testFixtures/java/com/linkedin/hoptimator/jdbc/QuidemTestBase.java
+++ b/hoptimator-jdbc/src/testFixtures/java/com/linkedin/hoptimator/jdbc/QuidemTestBase.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.apache.calcite.rel.RelRoot;
@@ -90,7 +91,10 @@ public abstract class QuidemTestBase {
                 RelRoot root = HoptimatorDriver.convert(conn, sql).root;
                 String[] parts = line.split(" ", 2);
                 String pipelineName = parts.length == 2 ? parts[1] : "test";
-                Pipeline pipeline = DeploymentService.plan(root, Collections.emptyList(), conn.connectionProperties())
+                Properties properties = new Properties();
+                properties.putAll(conn.connectionProperties());
+                properties.put(DeploymentService.PIPELINE_OPTION, pipelineName);
+                Pipeline pipeline = DeploymentService.plan(root, Collections.emptyList(), properties)
                     .pipeline(pipelineName, conn);
                 List<String> specs = new ArrayList<>();
                 for (Source source : pipeline.sources()) {

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator.k8s;
 
+import com.linkedin.hoptimator.Source;
 import com.linkedin.hoptimator.ThrowingFunction;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -45,6 +46,9 @@ class K8sJobDeployer extends K8sYamlDeployer {
         .with("database", job.sink().database())
         .with("schema", job.sink().schema())
         .with("table", job.sink().table())
+        .with("sourceDatabases", () -> job.sources().stream().map(Source::database).collect(Collectors.joining(",")))
+        .with("sourceSchemas", () -> job.sources().stream().map(Source::schema).collect(Collectors.joining(",")))
+        .with("sourceTables", () -> job.sources().stream().map(Source::table).collect(Collectors.joining(",")))
         .with("sql", () -> sql.apply(SqlDialect.ANSI))
         .with("flinksql", () -> sql.apply(SqlDialect.FLINK))
         .with("flinkconfigs", properties)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -38,8 +38,8 @@ class K8sJobDeployer extends K8sYamlDeployer {
   public List<String> specify() throws SQLException {
     Properties properties = ConfigService.config(context.connection(), false, FLINK_CONFIG);
     properties.putAll(job.sink().options());
-    ThrowingFunction<SqlDialect, String> sql = job.eval("sql");
-    ThrowingFunction<SqlDialect, String> fieldMap = job.eval("fieldMap");
+    ThrowingFunction<SqlDialect, String> sql = job.sql();
+    ThrowingFunction<SqlDialect, String> fieldMap = job.fieldMap();
     String name = K8sUtils.canonicalizeName(job.sink().database(), job.name());
     Template.Environment env = new Template.SimpleEnvironment()
         .with("name", name)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator.k8s;
 
+import com.linkedin.hoptimator.ThrowingFunction;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.linkedin.hoptimator.Job;
@@ -36,25 +37,34 @@ class K8sJobDeployer extends K8sYamlDeployer {
   public List<String> specify() throws SQLException {
     Properties properties = ConfigService.config(context.connection(), false, FLINK_CONFIG);
     properties.putAll(job.sink().options());
-    Function<SqlDialect, String> sql = job.sql();
+    ThrowingFunction<SqlDialect, String> sql = job.eval("sql");
+    ThrowingFunction<SqlDialect, String> fieldMap = job.eval("fieldMap");
     String name = K8sUtils.canonicalizeName(job.sink().database(), job.name());
     Template.Environment env = new Template.SimpleEnvironment()
         .with("name", name)
         .with("database", job.sink().database())
         .with("schema", job.sink().schema())
         .with("table", job.sink().table())
-        .with("sql", sql.apply(SqlDialect.ANSI))
-        .with("flinksql", sql.apply(SqlDialect.FLINK))
+        .with("sql", () -> sql.apply(SqlDialect.ANSI))
+        .with("flinksql", () -> sql.apply(SqlDialect.FLINK))
         .with("flinkconfigs", properties)
+        .with("fieldMap", () -> fieldMap.apply(SqlDialect.ANSI))
         .with(job.sink().options());
-    return jobTemplateApi.list()
+    List<String> templates = jobTemplateApi.list()
         .stream()
         .map(V1alpha1JobTemplate::getSpec)
         .filter(Objects::nonNull)
         .filter(x -> x.getDatabases() == null || x.getDatabases().contains(job.sink().database()))
         .map(V1alpha1JobTemplateSpec::getYaml)
         .filter(Objects::nonNull)
-        .map(x -> new Template.SimpleTemplate(x).render(env))
         .collect(Collectors.toList());
+    List<String> renderedTemplates = new ArrayList<>();
+    for (String template : templates) {
+      String renderedTemplate = new Template.SimpleTemplate(template).render(env);
+      if (renderedTemplate != null) {
+        renderedTemplates.add(renderedTemplate);
+      }
+    }
+    return renderedTemplates;
   }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -52,8 +52,8 @@ class K8sJobDeployer extends K8sYamlDeployer {
         .with("sql", () -> sql.apply(SqlDialect.ANSI))
         .with("flinksql", () -> sql.apply(SqlDialect.FLINK))
         .with("flinkconfigs", properties)
-        .with("fieldMap", () -> fieldMap.apply(SqlDialect.ANSI))
-        .with(job.sink().options());
+        .with("fieldMap", () -> "'" + fieldMap.apply(SqlDialect.ANSI) + "'")
+        .with(properties);
     List<String> templates = jobTemplateApi.list()
         .stream()
         .map(V1alpha1JobTemplate::getSpec)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
@@ -98,7 +98,7 @@ class K8sMaterializedViewDeployer implements Deployer {
     return K8sUtils.canonicalizeName(view.path());
   }
 
-  String sql() {
+  String sql() throws SQLException {
     return view.pipelineSql().apply(SqlDialect.ANSI);
   }
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Database.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Database.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Database metadata.
  */
 @ApiModel(description = "Database metadata.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1Database implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * DatabaseList is a list of Database
  */
 @ApiModel(description = "DatabaseList is a list of Database")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1DatabaseList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Database spec.
  */
 @ApiModel(description = "Database spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1DatabaseSpec {
   /**
    * SQL dialect the driver expects.

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Engine.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Engine.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Engine metadata.
  */
 @ApiModel(description = "Engine metadata.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1Engine implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * EngineList is a list of Engine
  */
 @ApiModel(description = "EngineList is a list of Engine")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1EngineList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Engine spec.
  */
 @ApiModel(description = "Engine spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1EngineSpec {
   public static final String SERIALIZED_NAME_DATABASES = "databases";
   @SerializedName(SERIALIZED_NAME_DATABASES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplate.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplate.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Template to apply to matching jobs.
  */
 @ApiModel(description = "Template to apply to matching jobs.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1JobTemplate implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * JobTemplateList is a list of JobTemplate
  */
 @ApiModel(description = "JobTemplateList is a list of JobTemplate")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1JobTemplateList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * JobTemplate spec.
  */
 @ApiModel(description = "JobTemplate spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1JobTemplateSpec {
   public static final String SERIALIZED_NAME_DATABASES = "databases";
   @SerializedName(SERIALIZED_NAME_DATABASES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJob.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJob.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator generic SQL job
  */
 @ApiModel(description = "Hoptimator generic SQL job")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1SqlJob implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SqlJobList is a list of SqlJob
  */
 @ApiModel(description = "SqlJobList is a list of SqlJob")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1SqlJobList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobSpec.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * SQL job spec
  */
 @ApiModel(description = "SQL job spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1SqlJobSpec {
   public static final String SERIALIZED_NAME_CONFIGS = "configs";
   @SerializedName(SERIALIZED_NAME_CONFIGS)
@@ -43,7 +43,9 @@ public class V1alpha1SqlJobSpec {
    */
   @JsonAdapter(DialectEnum.Adapter.class)
   public enum DialectEnum {
-    FLINK("Flink");
+    FLINK("Flink"),
+    
+    FLINKBEAM("FlinkBeam");
 
     private String value;
 

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobStatus.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1SqlJobStatus {
   public static final String SERIALIZED_NAME_CONFIGS = "configs";
   @SerializedName(SERIALIZED_NAME_CONFIGS)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Subscription.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Subscription.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator Subscription
  */
 @ApiModel(description = "Hoptimator Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1Subscription implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SubscriptionList is a list of Subscription
  */
 @ApiModel(description = "SubscriptionList is a list of Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1SubscriptionList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionSpec.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Subscription spec
  */
 @ApiModel(description = "Subscription spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1SubscriptionSpec {
   public static final String SERIALIZED_NAME_DATABASE = "database";
   @SerializedName(SERIALIZED_NAME_DATABASE)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionStatus.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1SubscriptionStatus {
   public static final String SERIALIZED_NAME_ATTRIBUTES = "attributes";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplate.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplate.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Template to apply to matching tables.
  */
 @ApiModel(description = "Template to apply to matching tables.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1TableTemplate implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * TableTemplateList is a list of TableTemplate
  */
 @ApiModel(description = "TableTemplateList is a list of TableTemplate")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1TableTemplateList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * TableTemplate spec.
  */
 @ApiModel(description = "TableTemplate spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1TableTemplateSpec {
   public static final String SERIALIZED_NAME_CONNECTOR = "connector";
   @SerializedName(SERIALIZED_NAME_CONNECTOR)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTrigger.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTrigger.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Trigger for a specific table.
  */
 @ApiModel(description = "Trigger for a specific table.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1TableTrigger implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * TableTriggerList is a list of TableTrigger
  */
 @ApiModel(description = "TableTriggerList is a list of TableTrigger")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1TableTriggerList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * TableTrigger spec.
  */
 @ApiModel(description = "TableTrigger spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1TableTriggerSpec {
   /**
    * Gets or Sets operations

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerStatus.java
@@ -29,7 +29,7 @@ import java.time.OffsetDateTime;
  * TableTrigger status.
  */
 @ApiModel(description = "TableTrigger status.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1TableTriggerStatus {
   public static final String SERIALIZED_NAME_TIMESTAMP = "timestamp";
   @SerializedName(SERIALIZED_NAME_TIMESTAMP)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1View.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1View.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * A SQL view.
  */
 @ApiModel(description = "A SQL view.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1View implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * ViewList is a list of View
  */
 @ApiModel(description = "ViewList is a list of View")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1ViewList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * View spec.
  */
 @ApiModel(description = "View spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-05-21T02:31:00.123Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-09-04T16:19:29.143Z[Etc/UTC]")
 public class V1alpha1ViewSpec {
   public static final String SERIALIZED_NAME_MATERIALIZED = "materialized";
   @SerializedName(SERIALIZED_NAME_MATERIALIZED)

--- a/hoptimator-k8s/src/main/resources/sqljobs.crd.yaml
+++ b/hoptimator-k8s/src/main/resources/sqljobs.crd.yaml
@@ -43,6 +43,7 @@ spec:
                   type: string
                   enum:
                   - Flink
+                  - FlinkBeam
                   default: Flink
                 executionMode:
                   description: Streaming or Batch.

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/TestSqlScripts.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/TestSqlScripts.java
@@ -31,4 +31,10 @@ public class TestSqlScripts extends QuidemTestBase {
   public void k8sMetadataTables() throws Exception {
     run("k8s-metadata.id", "hints=offline.table.name=ads_offline");
   }
+
+  @Test
+  @Tag("integration")
+  public void k8sConditionalJobTemplate() throws Exception {
+    run("k8s-metadata-beam.id", "hints=flink.app.type=BEAM");
+  }
 }

--- a/hoptimator-k8s/src/test/resources/k8s-metadata-beam.id
+++ b/hoptimator-k8s/src/test/resources/k8s-metadata-beam.id
@@ -1,0 +1,43 @@
+!set outputformat mysql
+!use k8s
+
+create or replace materialized view ads.pages as select page_urn from ads.page_views;
+(0 rows modified)
+
+!update
+
+select * from ads.pages;
++-------------------+
+| PAGE_URN          |
++-------------------+
+| urn:li:page:10000 |
+| urn:li:page:10001 |
++-------------------+
+(2 rows)
+
+!ok
+
+select name, failed from "k8s".pipeline_elements order by name;
++---------------------------+--------+
+| NAME                      | FAILED |
++---------------------------+--------+
+| SqlJob/ads-database-pages | false  |
++---------------------------+--------+
+(1 row)
+
+!ok
+
+select * from "k8s".pipeline_element_map order by element_name, pipeline_name;
++---------------------------+---------------+
+| ELEMENT_NAME              | PIPELINE_NAME |
++---------------------------+---------------+
+| SqlJob/ads-database-pages | ads-pages     |
++---------------------------+---------------+
+(1 row)
+
+!ok
+
+drop materialized view ads.pages;
+(0 rows modified)
+
+!update

--- a/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
+++ b/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/TestSqlScripts.java
@@ -13,4 +13,10 @@ public class TestSqlScripts extends QuidemTestBase {
   public void kafkaDdlScript() throws Exception {
     run("kafka-ddl.id", "hints=kafka.partitions=4,flink.parallelism=2,kafka.source.k1=v1,kafka.sink.k2=v2");
   }
+
+  @Test
+  @Tag("integration")
+  public void kafkaDdlScriptBeamJob() throws Exception {
+    run("kafka-ddl-beam.id", "hints=flink.app.type=BEAM");
+  }
 }

--- a/hoptimator-kafka/src/test/resources/kafka-ddl-beam.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl-beam.id
@@ -1,0 +1,52 @@
+!set outputformat mysql
+!use k8s
+
+insert into kafka."existing-topic-1" select * from kafka."existing-topic-2";
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: SqlJob
+metadata:
+  name: kafka-database-existing-topic-1
+spec:
+  dialect: FlinkBeam
+  executionMode: Streaming
+  sql:
+    - PLACEHOLDER
+  configs:
+    source.group.id: hoptimator-flink-beam-existing-topic-1
+    source.schemas: KAFKA
+    source.tables: existing-topic-2
+    sink.schema: KAFKA
+    sink.table: existing-topic-1
+    fields: '{"VALUE":"VALUE","KEY":"KEY"}'
+    pipeline: 'existing-topic-1'
+    flink.app.type: 'BEAM'
+    flink.app.name: 'hoptimator-flink-runner'
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: kafka-database-existing-topic-1
+  labels:
+    strimzi.io/cluster: one
+spec:
+  topicName: existing-topic-1
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: kafka-database-existing-topic-2
+  labels:
+    strimzi.io/cluster: one
+spec:
+  topicName: existing-topic-2
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+!specify existing-topic-1

--- a/hoptimator-operator/build.gradle
+++ b/hoptimator-operator/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+  implementation project(':hoptimator-api')
   implementation project(':hoptimator-avro') // <-- marked for deletion
   implementation project(':hoptimator-planner') // <-- marked for deletion
   implementation project(':hoptimator-catalog') // <-- marked for deletion

--- a/hoptimator-util/build.gradle
+++ b/hoptimator-util/build.gradle
@@ -12,6 +12,8 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testImplementation 'org.mockito:mockito-junit-jupiter:5.+'
+  testImplementation 'org.mockito:mockito-core:5.+'
 }
 
 test {

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/Template.java
@@ -210,8 +210,14 @@ public interface Template {
           if (value == null) {
             log.warn("Template variable '{}' resolved to null. Skipping template.", key);
             return null;
+          } else if (transform.contains("notPresent")) {
+            return null;
           }
         } catch (IllegalArgumentException e) {
+          if (transform.contains("notPresent")) {
+            m.appendReplacement(sb, "");
+            continue;
+          }
           log.warn("Missing template variable '{}' in environment: {}. Skipping template.", key, e.getMessage());
           return null;
         }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
@@ -106,7 +106,7 @@ public interface PipelineRel extends RelNode {
       templateEvals.put("query", query(connection));
       templateEvals.put("fieldMap", fieldMap());
 
-      Job job = new Job(name, sink, templateEvals);
+      Job job = new Job(name, sources.keySet(), sink, templateEvals);
       return new Pipeline(sources.keySet(), sink, job);
     }
 

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/TrivialQueryChecker.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/TrivialQueryChecker.java
@@ -1,0 +1,196 @@
+package com.linkedin.hoptimator.util.planner;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableFunctionScan;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalCalc;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalExchange;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalIntersect;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalMatch;
+import org.apache.calcite.rel.logical.LogicalMinus;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalTableModify;
+import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+
+
+/**
+ * RelShuttle implementation that checks if a query is trivial.
+ * A trivial query only contains TableScans and simple LogicalProjects.
+ */
+public class TrivialQueryChecker implements RelShuttle {
+  private boolean trivial = true;
+
+  /**
+   * Determines if a RelNode represents a trivial query that only contains:
+   * - Simple table scans
+   * - Simple projections (field references and aliasing)
+   * - No joins, aggregations, filters, functions, or other complex operations
+   */
+  public static boolean isTrivialQuery(RelNode node) {
+    TrivialQueryChecker checker = new TrivialQueryChecker();
+    try {
+      node.accept(checker);
+      return checker.isTrivial();
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public boolean isTrivial() {
+    return trivial;
+  }
+
+  @Override
+  public RelNode visit(TableScan scan) {
+    return visitScan(scan);
+  }
+
+  @Override
+  public RelNode visit(LogicalProject project) {
+    return visitProject(project);
+  }
+
+  @Override
+  public RelNode visit(TableFunctionScan scan) {
+    trivial = false; // Not allowed in trivial queries
+    return scan;
+  }
+
+  @Override
+  public RelNode visit(LogicalValues values) {
+    trivial = false; // Not allowed in trivial queries
+    return values;
+  }
+
+  @Override
+  public RelNode visit(LogicalFilter filter) {
+    trivial = false; // Not allowed in trivial queries
+    return filter;
+  }
+
+  @Override
+  public RelNode visit(LogicalCalc calc) {
+    trivial = false; // Not allowed in trivial queries
+    return calc;
+  }
+
+  @Override
+  public RelNode visit(LogicalJoin join) {
+    trivial = false; // Not allowed in trivial queries
+    return join;
+  }
+
+  @Override
+  public RelNode visit(LogicalCorrelate correlate) {
+    trivial = false; // Not allowed in trivial queries
+    return correlate;
+  }
+
+  @Override
+  public RelNode visit(LogicalUnion union) {
+    trivial = false; // Not allowed in trivial queries
+    return union;
+  }
+
+  @Override
+  public RelNode visit(LogicalIntersect intersect) {
+    trivial = false; // Not allowed in trivial queries
+    return intersect;
+  }
+
+  @Override
+  public RelNode visit(LogicalMinus minus) {
+    trivial = false; // Not allowed in trivial queries
+    return minus;
+  }
+
+  @Override
+  public RelNode visit(LogicalAggregate aggregate) {
+    trivial = false; // Not allowed in trivial queries
+    return aggregate;
+  }
+
+  @Override
+  public RelNode visit(LogicalMatch match) {
+    trivial = false; // Not allowed in trivial queries
+    return match;
+  }
+
+  @Override
+  public RelNode visit(LogicalSort sort) {
+    trivial = false; // Not allowed in trivial queries
+    return sort;
+  }
+
+  @Override
+  public RelNode visit(LogicalExchange exchange) {
+    trivial = false; // Not allowed in trivial queries
+    return exchange;
+  }
+
+  @Override
+  public RelNode visit(LogicalTableModify modify) {
+    trivial = false; // Not allowed in trivial queries
+    return modify;
+  }
+
+  @Override
+  public RelNode visit(RelNode other) {
+    if (other instanceof PipelineRules.PipelineProject) {
+      return visitProject((PipelineRules.PipelineProject) other);
+    } else if (other instanceof PipelineRules.PipelineTableScan) {
+      return visitScan((PipelineRules.PipelineTableScan) other);
+    }
+
+    // All other node types not specified above are considered non-trivial
+    trivial = false;
+    return other;
+  }
+
+  private RelNode visitScan(TableScan scan) {
+    // Table scans are allowed in trivial queries
+    return scan;
+  }
+
+  private RelNode visitProject(Project project) {
+    // Check if the project only contains simple field references
+    for (RexNode expr : project.getProjects()) {
+      if (!isSimpleFieldReference(expr)) {
+        trivial = false;
+        break;
+      }
+    }
+    // Continue visiting children
+    return visitChildren(project);
+  }
+
+  /**
+   * Checks if a RexNode represents a simple field reference (no functions, calculations, etc.)
+   */
+  private boolean isSimpleFieldReference(RexNode expr) {
+    return expr instanceof RexInputRef; // Simple field reference by index
+  }
+
+  /**
+   * Visits all children of a RelNode
+   */
+  private RelNode visitChildren(RelNode node) {
+    for (RelNode input : node.getInputs()) {
+      input.accept(this);
+      if (!trivial) {
+        break; // Short-circuit if we already found it's not trivial
+      }
+    }
+    return node;
+  }
+}

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
@@ -2,10 +2,11 @@ package com.linkedin.hoptimator.util;
 
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 
 public class TestTemplate {
 
@@ -26,6 +27,7 @@ public class TestTemplate {
         + "{{nameLower toLowerCase}}\n"
         + "{{multiline concat}}\n"
         + "{{multilineUpper concat toUpperCase}}\n"
+        + "{{missing notPresent}}\n"
         + "{{other unknown}}\n";
 
     String renderedTemplate = new Template.SimpleTemplate(template).render(env);
@@ -39,5 +41,23 @@ public class TestTemplate {
     assertEquals("123", renderedTemplates.get(5));
     assertEquals("ABC", renderedTemplates.get(6));
     assertEquals("test", renderedTemplates.get(7));
+  }
+
+  @Test
+  public void missingProperty() {
+    Template.Environment env = new Template.SimpleEnvironment();
+    String template = "{{field}}";
+    String renderedTemplate = new Template.SimpleTemplate(template).render(env);
+    assertNull(renderedTemplate);
+  }
+
+  @Test
+  public void ignoreTemplateProperty() {
+    Template.Environment env = new Template.SimpleEnvironment()
+        .with("field", "true");
+    String template = "{{field notPresent}}";
+
+    String renderedTemplate = new Template.SimpleTemplate(template).render(env);
+    assertNull(renderedTemplate);
   }
 }

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
@@ -30,7 +30,6 @@ public class TestTemplate {
         + "{{nameLower toLowerCase}}\n"
         + "{{multiline concat}}\n"
         + "{{multilineUpper concat toUpperCase}}\n"
-        + "{{missing notPresent}}\n"
         + "{{other unknown}}\n"
         + "{{supplier}}\n";
 
@@ -57,12 +56,32 @@ public class TestTemplate {
   }
 
   @Test
-  public void ignoreTemplateProperty() throws SQLException {
+  public void templateEquality() throws SQLException {
     Template.Environment env = new Template.SimpleEnvironment()
-        .with("field", "true");
-    String template = "{{field notPresent}}";
+        .with("field1", "true");
+    String template = "{{name:default}}\n"
+        + "{{field1==true}}\n"
+        + "{{field1!=false}}\n";
 
     String renderedTemplate = new Template.SimpleTemplate(template).render(env);
+    List<String> renderedTemplates = Arrays.asList(renderedTemplate.split("\n"));
+    assertEquals(1, renderedTemplates.size());
+    assertEquals("default", renderedTemplates.get(0));
+  }
+
+  @Test
+  public void templateEqualityFailure() throws SQLException {
+    Template.Environment env = new Template.SimpleEnvironment()
+        .with("field1", "true");
+    String template1 = "{{name:default}}\n"
+        + "{{field1==false}}\n";
+
+    String renderedTemplate = new Template.SimpleTemplate(template1).render(env);
+    assertNull(renderedTemplate);
+
+    String template2 = "{{name:default}}\n"
+        + "{{field1!=true}}\n";
+    renderedTemplate = new Template.SimpleTemplate(template2).render(env);
     assertNull(renderedTemplate);
   }
 

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/TestTemplate.java
@@ -1,24 +1,27 @@
 package com.linkedin.hoptimator.util;
 
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class TestTemplate {
 
   @Test
-  public void testRender() {
+  public void testRender() throws SQLException {
     Template.Environment env = new Template.SimpleEnvironment()
             .with("name", "name")
             .with("nameUpper", "name")
             .with("nameLower", "NAME")
             .with("multiline", "1\n2\n3\n")
             .with("multilineUpper", "a\nb\nc\n")
-            .with("other", "test");
+            .with("other", "test")
+            .with("supplier", () -> "value");
 
     String template = "{{keys:KEY}}\n"
         + "{{keyPrefix:}}\n"
@@ -28,11 +31,12 @@ public class TestTemplate {
         + "{{multiline concat}}\n"
         + "{{multilineUpper concat toUpperCase}}\n"
         + "{{missing notPresent}}\n"
-        + "{{other unknown}}\n";
+        + "{{other unknown}}\n"
+        + "{{supplier}}\n";
 
     String renderedTemplate = new Template.SimpleTemplate(template).render(env);
     List<String> renderedTemplates = Arrays.asList(renderedTemplate.split("\n"));
-    assertEquals(8, renderedTemplates.size());
+    assertEquals(9, renderedTemplates.size());
     assertEquals("KEY", renderedTemplates.get(0));
     assertEquals("", renderedTemplates.get(1));
     assertEquals("name", renderedTemplates.get(2));
@@ -41,10 +45,11 @@ public class TestTemplate {
     assertEquals("123", renderedTemplates.get(5));
     assertEquals("ABC", renderedTemplates.get(6));
     assertEquals("test", renderedTemplates.get(7));
+    assertEquals("value", renderedTemplates.get(8));
   }
 
   @Test
-  public void missingProperty() {
+  public void missingProperty() throws SQLException {
     Template.Environment env = new Template.SimpleEnvironment();
     String template = "{{field}}";
     String renderedTemplate = new Template.SimpleTemplate(template).render(env);
@@ -52,12 +57,25 @@ public class TestTemplate {
   }
 
   @Test
-  public void ignoreTemplateProperty() {
+  public void ignoreTemplateProperty() throws SQLException {
     Template.Environment env = new Template.SimpleEnvironment()
         .with("field", "true");
     String template = "{{field notPresent}}";
 
     String renderedTemplate = new Template.SimpleTemplate(template).render(env);
     assertNull(renderedTemplate);
+  }
+
+  @Test
+  public void supplierException() {
+    Template.Environment env = new Template.SimpleEnvironment()
+        .with("field", () -> {
+          throw new SQLException("test");
+        });
+    String template = "{{field}}";
+
+    assertThrows(SQLException.class, () -> {
+      new Template.SimpleTemplate(template).render(env);
+    });
   }
 }

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelTest.java
@@ -1,0 +1,267 @@
+package com.linkedin.hoptimator.util.planner;
+
+import com.linkedin.hoptimator.Job;
+import com.linkedin.hoptimator.Pipeline;
+import com.linkedin.hoptimator.SqlDialect;
+import com.linkedin.hoptimator.ThrowingFunction;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.runtime.ImmutablePairList;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class PipelineRelTest {
+
+    @Mock
+    private Connection mockConnection;
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+    private PipelineRel.Implementor implementor;
+
+    @BeforeEach
+    void setUp() {
+        typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+        rexBuilder = new RexBuilder(typeFactory);
+
+        // Create sample target fields mapping
+        List<Map.Entry<Integer, String>> entries = List.of(
+            new AbstractMap.SimpleEntry<>(0, "dest_field1"),
+            new AbstractMap.SimpleEntry<>(1, "dest_field2")
+        );
+        implementor = new PipelineRel.Implementor(ImmutablePairList.copyOf(entries), new HashMap<>());
+    }
+
+    @Test
+    void testFieldMapThrowsExceptionForNonTrivialQuery() {
+        RelDataType rowType = createSimpleRowType();
+        RelNode nonTrivialQuery = createNonTrivialQuery(rowType);
+        implementor.setQuery(nonTrivialQuery);
+
+        ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+        assertNotNull(fieldMapFunc, "Field map function should be created");
+
+        SQLNonTransientException exception = assertThrows(SQLNonTransientException.class,
+            () -> fieldMapFunc.apply(SqlDialect.ANSI),
+            "Non-trivial queries should throw SQLNonTransientException");
+
+        assertTrue(exception.getMessage().contains("Field mapping is only supported for trivial queries"));
+    }
+
+    @Test
+    void testFieldMapSuccessForTrivialQuery() {
+        RelDataType rowType = createSimpleRowType();
+        RelNode trivialQuery = createTrivialQuery(rowType);
+        implementor.setQuery(trivialQuery);
+
+        ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+        assertNotNull(fieldMapFunc, "Field map function should be created");
+
+        assertThrows(Exception.class, () -> fieldMapFunc.apply(SqlDialect.ANSI),
+            "Field map function should attempt execution but fail due to mock limitations");
+    }
+
+    @Test
+    void testValidateFieldMappingWithSinkRowType() {
+        RelDataType sinkRowType = createRowTypeWithFields("dest_field1", "dest_field2", "extra_field");
+
+        // Set up the sink with proper field mapping
+        assertDoesNotThrow(() -> implementor.setSink("test_db", List.of("schema", "test_table"),
+            sinkRowType, Collections.emptyMap()));
+
+        // Create a trivial query and test field mapping
+        RelNode trivialQuery = createTrivialQuery(createSimpleRowType());
+        implementor.setQuery(trivialQuery);
+
+        ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+        assertNotNull(fieldMapFunc, "Field map function should be created");
+
+        assertThrows(Exception.class, () -> fieldMapFunc.apply(SqlDialect.ANSI),
+            "Field mapping should attempt execution but fail due to mock limitations");
+    }
+
+    @Test
+    void testValidateFieldMappingFailsForMissingField() {
+        // Create sink type missing one of the target fields
+        RelDataType sinkRowType = createRowTypeWithFields("dest_field1"); // missing dest_field2
+
+        implementor.setSink("test_db", List.of("schema", "test_table"), sinkRowType, Collections.emptyMap());
+
+        RelNode trivialQuery = createTrivialQuery(createSimpleRowType());
+        implementor.setQuery(trivialQuery);
+
+        ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+        assertNotNull(fieldMapFunc, "Field map function should be created");
+
+        SQLNonTransientException exception = assertThrows(SQLNonTransientException.class,
+            () -> fieldMapFunc.apply(SqlDialect.ANSI), "Missing target field should cause validation failure");
+        assertTrue(exception.getMessage().contains("dest_field2"));
+    }
+
+    @Test
+    void testQueryGeneration() throws SQLException {
+        RelNode trivialQuery = createTrivialQuery(createSimpleRowType());
+        implementor.setQuery(trivialQuery);
+        implementor.addSource("test_db", List.of("source_table"), createSimpleRowType(), Collections.emptyMap());
+
+        ThrowingFunction<SqlDialect, String> queryFunc = implementor.query(mockConnection);
+        assertNotNull(queryFunc, "Query function should be created");
+
+        assertThrows(Exception.class, () -> queryFunc.apply(SqlDialect.ANSI),
+            "Query function should attempt SQL generation but fail due to mock limitations");
+    }
+
+    @Test
+    void testPipelineCreation() throws SQLException {
+        RelNode trivialQuery = createTrivialQuery(createSimpleRowType());
+        implementor.setQuery(trivialQuery);
+        implementor.addSource("test_db", List.of("source_table"), createSimpleRowType(), Collections.emptyMap());
+        implementor.setSink("test_db", List.of("sink_table"), createSimpleRowType(), Collections.emptyMap());
+
+        Pipeline pipeline = implementor.pipeline("test-pipeline", mockConnection);
+
+        assertNotNull(pipeline);
+
+        Job job = pipeline.job();
+        assertNotNull(job);
+        assertEquals("test-pipeline", job.name());
+
+        // Test that lazy evaluations are properly set up
+        ThrowingFunction<SqlDialect, String> sqlEval = job.eval("sql");
+        ThrowingFunction<SqlDialect, String> queryEval = job.eval("query");
+        ThrowingFunction<SqlDialect, String> fieldMapEval = job.eval("fieldMap");
+
+        assertNotNull(sqlEval);
+        assertNotNull(queryEval);
+        assertNotNull(fieldMapEval);
+    }
+
+    @Test
+    void testFieldMapJsonSerialization() {
+        RelNode trivialQuery = createTrivialQuery(createSimpleRowType());
+        implementor.setQuery(trivialQuery);
+
+        ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+        assertNotNull(fieldMapFunc, "Field map function should be created");
+
+        assertThrows(Exception.class, () -> fieldMapFunc.apply(SqlDialect.ANSI),
+            "Field map function should attempt execution but may fail due to RelToSqlConverter limitations with test mocks");
+    }
+
+    @Test
+    void testFunctionExceptionHandling() {
+        // Test with null query to trigger exception
+        implementor.setQuery(null);
+
+        ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+        assertNotNull(fieldMapFunc, "Function should be created even with null query");
+
+        assertThrows(SQLNonTransientException.class, () -> fieldMapFunc.apply(SqlDialect.ANSI),
+            "Function should propagate exceptions from null query");
+    }
+
+    @Test
+    void testLazyEvaluation() {
+        RelNode trivialQuery = createTrivialQuery(createSimpleRowType());
+        implementor.setQuery(trivialQuery);
+
+        // Function creation should not throw, even if query processing might fail
+        assertDoesNotThrow(() -> {
+            ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+            assertNotNull(fieldMapFunc, "Function should be created lazily");
+
+            ThrowingFunction<SqlDialect, String> queryFunc = implementor.query(mockConnection);
+            assertNotNull(queryFunc, "Query function should be created lazily");
+        }, "Function creation should be lazy and not execute immediately");
+    }
+
+    @Test
+    void testFunctionErrorScenarios() {
+        // Test with malformed query setup
+        RelNode trivialQuery = createTrivialQuery(createSimpleRowType());
+        implementor.setQuery(trivialQuery);
+
+        // Test fieldMap without sink (should still work)
+        ThrowingFunction<SqlDialect, String> fieldMapFunc = implementor.fieldMap();
+        assertNotNull(fieldMapFunc, "Field map function should be created without sink");
+
+        assertThrows(Exception.class, () -> fieldMapFunc.apply(SqlDialect.ANSI),
+            "Field map should attempt execution but fail due to RelToSqlConverter limitations");
+    }
+
+
+    // Helper methods for creating test data
+
+    private RelDataType createSimpleRowType() {
+        return createRowTypeWithFields("field1", "field2");
+    }
+
+    private RelDataType createRowTypeWithFields(String... fieldNames) {
+        RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(typeFactory);
+        for (String fieldName : fieldNames) {
+            builder.add(fieldName, SqlTypeName.VARCHAR);
+        }
+        return builder.build();
+    }
+
+    private RelNode createTrivialQuery(RelDataType rowType) {
+        // Create a mock trivial query that will pass TrivialQueryChecker
+        LogicalProject mockTrivialQuery = mock(LogicalProject.class);
+        when(mockTrivialQuery.getRowType()).thenReturn(rowType);
+        when(mockTrivialQuery.getInputs()).thenReturn(Collections.emptyList());
+        when(mockTrivialQuery.accept(any(RelShuttle.class))).thenCallRealMethod();
+        when(mockTrivialQuery.getCluster()).thenReturn(mock(RelOptCluster.class));
+
+        // Create simple projection expressions (field references)
+        List<RexNode> projects = List.of(
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1)
+        );
+        when(mockTrivialQuery.getProjects()).thenReturn(projects);
+        return mockTrivialQuery;
+    }
+
+    private RelNode createNonTrivialQuery(RelDataType rowType) {
+        // Create a mock non-trivial query that will fail TrivialQueryChecker
+        LogicalFilter mockNonTrivialQuery = mock(LogicalFilter.class);
+        when(mockNonTrivialQuery.getRowType()).thenReturn(rowType);
+        when(mockNonTrivialQuery.getInputs()).thenReturn(Collections.emptyList());
+        when(mockNonTrivialQuery.accept(any(RelShuttle.class))).thenCallRealMethod();
+        when(mockNonTrivialQuery.getCluster()).thenReturn(mock(RelOptCluster.class));
+        return mockNonTrivialQuery;
+    }
+}

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelTest.java
@@ -105,9 +105,9 @@ public class PipelineRelTest {
         assertEquals("test-pipeline", job.name());
 
         // Test that lazy evaluations are properly set up
-        ThrowingFunction<SqlDialect, String> sqlEval = job.eval("sql");
-        ThrowingFunction<SqlDialect, String> queryEval = job.eval("query");
-        ThrowingFunction<SqlDialect, String> fieldMapEval = job.eval("fieldMap");
+        ThrowingFunction<SqlDialect, String> sqlEval = job.sql();
+        ThrowingFunction<SqlDialect, String> queryEval = job.query();
+        ThrowingFunction<SqlDialect, String> fieldMapEval = job.fieldMap();
 
         assertNotNull(sqlEval);
         assertNotNull(queryEval);

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/TrivialQueryCheckerTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/TrivialQueryCheckerTest.java
@@ -1,0 +1,200 @@
+package com.linkedin.hoptimator.util.planner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test suite for TrivialQueryChecker to verify correct identification of trivial vs non-trivial queries.
+ *
+ * A trivial query should only contain:
+ * - Simple table scans
+ * - Simple projections (field references only, no functions or calculations)
+ *
+ * Non-trivial queries include:
+ * - Joins, aggregations, filters, sorts, unions
+ * - Complex expressions in projections
+ * - Any other relational operations
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class TrivialQueryCheckerTest {
+
+    @Mock
+    private PipelineRules.PipelineTableScan mockTableScan;
+
+    @Mock
+    private PipelineRules.PipelineProject mockProject;
+
+    @Mock
+    private LogicalFilter mockFilter;
+
+    @Mock
+    private LogicalJoin mockJoin;
+
+    private RelDataTypeFactory typeFactory;
+    private RexBuilder rexBuilder;
+
+    @BeforeEach
+    void setUp() {
+        typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+        rexBuilder = new RexBuilder(typeFactory);
+
+        // Set up accept() methods to properly dispatch to TrivialQueryChecker visit methods
+        when(mockTableScan.accept(any(RelShuttle.class))).thenCallRealMethod();
+        when(mockProject.accept(any(RelShuttle.class))).thenCallRealMethod();
+        when(mockFilter.accept(any(RelShuttle.class))).thenCallRealMethod();
+        when(mockJoin.accept(any(RelShuttle.class))).thenCallRealMethod();
+    }
+
+    @Test
+    void testTableScanIsTrivial() {
+        when(mockTableScan.getInputs()).thenReturn(Collections.emptyList());
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(mockTableScan);
+        assertTrue(result, "Simple table scan should be considered trivial");
+    }
+
+    @Test
+    void testSimpleProjectionIsTrivial() {
+        // Create simple field reference expressions
+        RelDataType rowType = createRowType("field1", "field2");
+        List<RexNode> simpleProjections = Arrays.asList(
+            new RexInputRef(0, rowType.getFieldList().get(0).getType()),
+            new RexInputRef(1, rowType.getFieldList().get(1).getType())
+        );
+
+        when(mockProject.getProjects()).thenReturn(simpleProjections);
+        when(mockProject.getInputs()).thenReturn(Arrays.asList(mockTableScan));
+        when(mockTableScan.getInputs()).thenReturn(Collections.emptyList());
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(mockProject);
+        assertTrue(result, "Simple projection with field references should be trivial");
+    }
+
+    @Test
+    void testComplexProjectionIsNotTrivial() {
+        // Create a complex expression (function call)
+        RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+
+        // Create a simple complex expression - a function call
+        RexNode complexExpression = rexBuilder.makeCall(
+            org.apache.calcite.sql.fun.SqlStdOperatorTable.PLUS,
+            rexBuilder.makeInputRef(intType, 0),
+            rexBuilder.makeExactLiteral(java.math.BigDecimal.ONE)
+        );
+
+        when(mockProject.getProjects()).thenReturn(Arrays.asList(complexExpression));
+        when(mockProject.getInputs()).thenReturn(Arrays.asList(mockTableScan));
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(mockProject);
+        assertFalse(result, "Projection with complex expressions should not be trivial");
+    }
+
+    @Test
+    void testOtherNodesNotTrivial() {
+        when(mockFilter.getInputs()).thenReturn(Arrays.asList(mockTableScan));
+        when(mockJoin.getInputs()).thenReturn(Arrays.asList(mockTableScan, mockTableScan));
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(mockFilter);
+        assertFalse(result, "Queries with filters should not be trivial");
+
+        result = TrivialQueryChecker.isTrivialQuery(mockJoin);
+        assertFalse(result, "Queries with joins should not be trivial");
+    }
+
+    @Test
+    void testComplexQueryIsNotTrivial() {
+        // Create a complex query: SELECT ... FROM table1 JOIN table2 WHERE ...
+        when(mockProject.getInputs()).thenReturn(Arrays.asList(mockFilter));
+        when(mockFilter.getInputs()).thenReturn(Arrays.asList(mockJoin));
+        when(mockJoin.getInputs()).thenReturn(Arrays.asList(mockTableScan, mockTableScan));
+        when(mockTableScan.getInputs()).thenReturn(Collections.emptyList());
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(mockProject);
+        assertFalse(result, "Complex queries with multiple operations should not be trivial");
+    }
+
+    @Test
+    void testExceptionHandling() {
+        RelNode faultyNode = mock(RelNode.class);
+        when(faultyNode.accept(any(RelShuttle.class))).thenThrow(new RuntimeException("Test exception"));
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(faultyNode);
+        assertFalse(result, "Queries that throw exceptions should be considered non-trivial");
+    }
+
+    /**
+     * Test nested trivial operations (table scan -> simple project -> simple project)
+     */
+    @Test
+    void testNestedTrivialOperationsAreTrivial() {
+        RelDataType rowType = createRowType("field1", "field2");
+        List<RexNode> simpleProjections = Arrays.asList(
+            new RexInputRef(0, rowType.getFieldList().get(0).getType()),
+            new RexInputRef(1, rowType.getFieldList().get(1).getType())
+        );
+
+        LogicalProject innerProject = mock(LogicalProject.class);
+        when(innerProject.getProjects()).thenReturn(simpleProjections);
+        when(innerProject.getInputs()).thenReturn(Arrays.asList(mockTableScan));
+
+        when(mockProject.getProjects()).thenReturn(simpleProjections);
+        when(mockProject.getInputs()).thenReturn(Arrays.asList(innerProject));
+        when(mockTableScan.getInputs()).thenReturn(Collections.emptyList());
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(mockProject);
+        assertTrue(result, "Nested trivial operations should remain trivial");
+    }
+
+    @Test
+    void testUnknownNodeTypeIsNotTrivial() {
+        // Create a mock RelNode that doesn't match any of the known trivial types
+        RelNode unknownNode = mock(RelNode.class);
+        when(unknownNode.getInputs()).thenReturn(Collections.emptyList());
+        when(unknownNode.getRowType()).thenReturn(createRowType("field1"));
+
+        // Mock the accept method to call visit(RelNode other) which returns false
+        when(unknownNode.accept(any(RelShuttle.class))).thenAnswer(invocation -> {
+            org.apache.calcite.rel.RelShuttle shuttle = invocation.getArgument(0);
+            return shuttle.visit(unknownNode);
+        });
+
+        boolean result = TrivialQueryChecker.isTrivialQuery(unknownNode);
+        assertFalse(result, "Unknown RelNode types should be considered non-trivial");
+    }
+
+    private RelDataType createRowType(String... fieldNames) {
+        RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(typeFactory);
+        for (String fieldName : fieldNames) {
+            builder.add(fieldName, SqlTypeName.VARCHAR);
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
Several changes wrapped under this:
1. Add new `FlinkBeam` enum type to SqlJobs crd & regenerate model files
2. Pass source information (database/schema/table) through Job type to allow to pop out in job templates
3. Add template equality checks to only match a given template if a specified condition is met
{{field==value}} or {{field!=value}}
4. Add new fieldMap logic to generate a mapping of fields from source to destination.
Logic only applies when the query is "trivial", meaning Projects & Table Scans only. If there is a use case this can be extended to joins in the future but would require prefixing fields in the field map with the relevant source
5. Add lazy evaluation of sql & fieldmap functions & allow them to throw SqlExceptions
6. Lots of testing - found some quoting and newline issues when applying yaml and fixed

Field map testing and examples:
1. Standard select query
```
create or replace materialized view ads.pages as select page_urn from ads.page_views;
"PAGE_URN" -> "PAGE_URN"
```

2. Select * query
```
create or replace materialized view ads.pages as select * from ads.page_views;
"MEMBER_URN" -> "MEMBER_URN"
"PAGE_URN" -> "PAGE_URN"
```

3. Select query with alias
```
create or replace materialized view ads.pages as select page_urn as new_page_urn from ads.page_views;
"PAGE_URN" -> "NEW_PAGE_URN"
```

4. Mulitple fields and aliases
```
create or replace materialized view ads."PAGE_VIEWS$filter" as select first_name as page_urn, last_name as member_urn from profile.members;
"LAST_NAME" -> "MEMBER_URN"
"FIRST_NAME" -> "PAGE_URN"
```

5. Implicit aliasing
```
create or replace materialized view "VENICE"."test-store$insert-partial" ("KEY_id", "intField") as select "KEY", "intField" from "VENICE"."test-store-primitive";
"intField" -> "intField"
"KEY" -> "KEY_id"
```

6. Nested fields
```
create or replace materialized view "VENICE"."test-store$insert-nested" ("KEY_id", "intField") as select "KEY", "nestedField"['nestedIntField'] from "VENICE"."test-store-primitive";
"nestedField.nestedIntField" -> "intField",
"KEY" -> "KEY_id"
```

Error cases:
1. Aliasing a literal
```
create or replace materialized view ads.pages as select page_urn, '1' as new_field from ads.page_views;
Field mapping is only supported for trivial queries with simple projections and aliasing.
```

2. Unknown source field
```
create or replace materialized view ads."PAGE_VIEWS$myview" as select "unknown" from profile.members;
Column 'unknown' not found in any table
```

3. Unknown sink field
```
create or replace materialized view ads."PAGE_VIEWS$myview" as select first_name from profile.members;
ERROR Field FIRST_NAME not found in sink schema
```

4. Non-trivial query (join)
```
create or replace materialized view ads.audience as select first_name, last_name from ads.page_views natural join profile.members;
Field mapping is only supported for trivial queries with simple projections and aliasing.
```

Added more tests for deeply nested fields, aliasing nested fields, etc.

