### PR TITLE
Spawn Trigger Jobs With Owner Reference

### DIFF
--- a/deploy/samples/retl-job-template.yaml
+++ b/deploy/samples/retl-job-template.yaml
@@ -17,7 +17,7 @@ spec:
             image: alpine/k8s:1.33.0
             env:
               - name: TABLE_TRIGGER_NAME
-                value: "{{name}}-trigger"
+                value: "{{trigger}}"
               - name: SOURCE_TABLE_NAME
                 value: "{{offline.table.name}}"
               - name: ONLINE_TABLE_NAME

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/trigger/TableTriggerReconciler.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/trigger/TableTriggerReconciler.java
@@ -4,6 +4,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +12,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
+import io.kubernetes.client.openapi.models.V1OwnerReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -221,7 +223,17 @@ public final class TableTriggerReconciler implements Reconciler {
     annotations.put(TRIGGER_TIMESTAMP_KEY, trigger.getStatus().getTimestamp().toString());
     Map<String, String> labels = new HashMap<>();
     labels.put(TRIGGER_KEY, trigger.getMetadata().getName());
-    yamlApi.createWithMetadata(yaml, annotations, labels, trigger.getMetadata().getOwnerReferences());
+    List<V1OwnerReference> ownerReference;
+    if (trigger.getMetadata().getOwnerReferences() != null && !trigger.getMetadata().getOwnerReferences().isEmpty()) {
+      ownerReference = trigger.getMetadata().getOwnerReferences();
+    } else {
+      ownerReference = Collections.singletonList(new V1OwnerReference()
+          .apiVersion(trigger.getApiVersion())
+          .kind(trigger.getKind())
+          .name(trigger.getMetadata().getName())
+          .uid(trigger.getMetadata().getUid()));
+    }
+    yamlApi.createWithMetadata(yaml, annotations, labels, ownerReference);
   }
 
   private ExecutionTime scheduledExecution(V1alpha1TableTrigger object) {


### PR DESCRIPTION
# Summary
* Spawn jobs initiated by TableTriggers with correct owner references to ensure clean cascading deletion when a TableTrigger is dropped. 

# Test
```
0: Hoptimator> CREATE TRIGGER dummy_retl_trigger ON ads.ad_clicks AS 'retl-job-template' IN 'default' WITH ('offline.table.name' 'my-namespace.my-table','job.properties.online.table.name' 'MyOnlineTable');
INFO Validating statement: CREATE TRIGGER `DUMMY_RETL_TRIGGER` ON `ADS`.`AD_CLICKS` AS 'retl-job-template' IN 'default' WITH ('offline.table.name', 'my-namespace.my-table', 'job.properties.online.table.name', 'MyOnlineTable')
INFO Validating trigger DUMMY_RETL_TRIGGER with deployers
INFO Validated trigger DUMMY_RETL_TRIGGER
INFO Creating trigger DUMMY_RETL_TRIGGER
INFO Successfully snapshot K8s obj: TableTrigger:dummyretltrigger
INFO Created K8s obj: TableTrigger:dummyretltrigger
INFO Deployed trigger DUMMY_RETL_TRIGGER
INFO CREATE TRIGGER DUMMY_RETL_TRIGGER completed
No rows affected (0.317 seconds)
```

```
➜  Hoptimator git:(sthakkar/apr01_26/addOwnerReference) ✗ k get jobs dummyretltrigger-retl-job-template-job -oyaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    trigger: dummyretltrigger
    triggerTimestamp: "2026-04-02T01:26:26Z"
  creationTimestamp: "2026-04-02T01:26:26Z"
  generation: 1
  labels:
    trigger: dummyretltrigger
  name: dummyretltrigger-retl-job-template-job
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: TableTrigger
    name: dummyretltrigger
    uid: 8526b8e2-fd43-409a-9716-7e61132c3583
  resourceVersion: "413127"
  uid: ad7b7352-2a4a-4a3b-84fc-bcf186c48dc8
spec:
...
```