### PR TITLE
Added Date and Timestamp Support in Avro's To/From Converter

### DIFF
--- a/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
+++ b/hoptimator-avro/src/main/java/com/linkedin/hoptimator/avro/AvroConverter.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator.avro;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -70,6 +71,12 @@ public final class AvroConverter {
           }
         case DOUBLE:
           return createAvroTypeWithNullability(Schema.Type.DOUBLE, dataType.isNullable());
+        case DATE:
+          return createAvroSchemaWithNullability(
+              LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT)), dataType.isNullable());
+        case TIMESTAMP:
+          return createAvroSchemaWithNullability(
+              LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG)), dataType.isNullable());
         case BOOLEAN:
           return createAvroTypeWithNullability(Schema.Type.BOOLEAN, dataType.isNullable());
         case ARRAY:
@@ -177,8 +184,20 @@ public final class AvroConverter {
             .filter(x -> x.getValue().getSqlTypeName() != unknown.getSqlTypeName())
             .collect(Collectors.toList())), nullable);
       case INT:
+        if (schema.getLogicalType() != null) {
+          String logicalName = schema.getLogicalType().getName();
+          if ("date".equals(logicalName)) {
+            return createRelType(typeFactory, SqlTypeName.DATE, nullable);
+          }
+        }
         return createRelType(typeFactory, SqlTypeName.INTEGER, nullable);
       case LONG:
+        if (schema.getLogicalType() != null) {
+          String logicalName = schema.getLogicalType().getName();
+          if ("timestamp-millis".equals(logicalName) || "timestamp-micros".equals(logicalName)) {
+            return createRelType(typeFactory, SqlTypeName.TIMESTAMP, nullable);
+          }
+        }
         return createRelType(typeFactory, SqlTypeName.BIGINT, nullable);
       case ENUM:
       case STRING:

--- a/hoptimator-avro/src/test/java/com/linkedin/hoptimator/avro/AvroConverterTest.java
+++ b/hoptimator-avro/src/test/java/com/linkedin/hoptimator/avro/AvroConverterTest.java
@@ -589,8 +589,8 @@ public class AvroConverterTest {
 
   @Test
   void testAvroFromUnsupportedTypeThrows() {
-    RelDataType dateType = typeFactory.createSqlType(SqlTypeName.DATE);
-    assertThrows(UnsupportedOperationException.class, () -> AvroConverter.avro("ns", "n", dateType));
+    RelDataType anyType = typeFactory.createSqlType(SqlTypeName.ANY);
+    assertThrows(UnsupportedOperationException.class, () -> AvroConverter.avro("ns", "n", anyType));
   }
 
   static Stream<Arguments> avroToRelPrimitiveCases() {
@@ -674,5 +674,51 @@ public class AvroConverterTest {
     Schema result = AvroConverter.avro("ns", "test", AvroConverter.proto(avroSchema));
 
     assertEquals(Schema.Type.STRING, result.getType());
+  }
+
+  @Test
+  void testAvroFromDateUsesLogicalType() {
+    RelDataType dateType = typeFactory.createTypeWithNullability(
+        typeFactory.createSqlType(SqlTypeName.DATE), true);
+    RelDataType rel = typeFactory.createStructType(
+        List.of(dateType), List.of("dateField"));
+
+    Schema avroSchema = AvroConverter.avro("NS", "R", rel);
+    assertNotNull(avroSchema);
+    assertEquals(1, avroSchema.getFields().size());
+
+    Schema fieldSchema = avroSchema.getFields().get(0).schema();
+    assertTrue(fieldSchema.isUnion());
+    Schema innerSchema = fieldSchema.getTypes().get(1);
+    assertEquals(Schema.Type.INT, innerSchema.getType());
+    assertNotNull(innerSchema.getLogicalType());
+    assertEquals("date", innerSchema.getLogicalType().getName());
+
+    RelDataType relDataTypeAgain = AvroConverter.rel(avroSchema);
+    assertEquals(SqlTypeName.DATE,
+        Objects.requireNonNull(relDataTypeAgain.getField("dateField", false, false)).getType().getSqlTypeName());
+  }
+
+  @Test
+  void testAvroFromTimestampUsesLogicalType() {
+    RelDataType timestampType = typeFactory.createTypeWithNullability(
+        typeFactory.createSqlType(SqlTypeName.TIMESTAMP), true);
+    RelDataType rel = typeFactory.createStructType(
+        List.of(timestampType), List.of("timestampField"));
+
+    Schema avroSchema = AvroConverter.avro("NS", "R", rel);
+    assertNotNull(avroSchema);
+    assertEquals(1, avroSchema.getFields().size());
+
+    Schema fieldSchema = avroSchema.getFields().get(0).schema();
+    assertTrue(fieldSchema.isUnion());
+    Schema innerSchema = fieldSchema.getTypes().get(1);
+    assertEquals(Schema.Type.LONG, innerSchema.getType());
+    assertNotNull(innerSchema.getLogicalType());
+    assertEquals("timestamp-millis", innerSchema.getLogicalType().getName());
+
+    RelDataType relDataTypeAgain = AvroConverter.rel(avroSchema);
+    assertEquals(SqlTypeName.TIMESTAMP,
+        Objects.requireNonNull(relDataTypeAgain.getField("timestampField", false, false)).getType().getSqlTypeName());
   }
 }


### PR DESCRIPTION
  ## Summary
  - Add Calcite `DATE` and `TIMESTAMP` type support to `AvroConverter` using Avro logical types.
  - Added support for both directions, `avro()` (Calcite → Avro) and `rel()` (Avro → Calcite).

  ## Testing
  - Added tests for both DATE and Timestamp to validate the conversion of Calcite type → Avro type → Calcite type.