### PR TITLE
Auto-Create Offline-Tier Backfill Triggers For Logical Tables

### DIFF
--- a/deploy/samples/logicaldb.yaml
+++ b/deploy/samples/logicaldb.yaml
@@ -10,3 +10,16 @@ spec:
   url: jdbc:logical://nearline=kafka-database;online=venice
   schema: LOGICAL
   dialect: Calcite
+
+---
+
+# This defines a logical table consisting of: nearline + offline (both are demo db).
+
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: Database
+metadata:
+  name: logical-offline
+spec:
+  url: jdbc:logical://nearline=ads-database;offline=profile-database
+  schema: LOGICAL_OFFLINE
+  dialect: Calcite

--- a/deploy/samples/retl-job-template.yaml
+++ b/deploy/samples/retl-job-template.yaml
@@ -4,6 +4,7 @@ metadata:
   name: retl-job-template
   namespace: default
 spec:
+  databases: ["profile-database"]
   yaml: |
     apiVersion: batch/v1
     kind: Job

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployer.java
@@ -15,14 +15,14 @@ import java.util.Map;
 import java.util.Properties;
 
 
-class K8sTriggerDeployer extends K8sDeployer<V1alpha1TableTrigger, V1alpha1TableTriggerList> {
+public class K8sTriggerDeployer extends K8sDeployer<V1alpha1TableTrigger, V1alpha1TableTriggerList> {
 
   private final K8sContext context;
   private final Trigger trigger;
   private final K8sApi<V1alpha1TableTrigger, V1alpha1TableTriggerList> triggerApi;
   private final K8sApi<V1alpha1JobTemplate, V1alpha1JobTemplateList> jobTemplateApi;
 
-  K8sTriggerDeployer(Trigger trigger, K8sContext context) {
+  public K8sTriggerDeployer(Trigger trigger, K8sContext context) {
     super(context, K8sApiEndpoints.TABLE_TRIGGERS);
     this.context = context;
     this.trigger = trigger;
@@ -40,21 +40,26 @@ class K8sTriggerDeployer extends K8sDeployer<V1alpha1TableTrigger, V1alpha1Table
 
   @Override
   public void update() throws SQLException {
-    if (trigger.options().containsKey(Trigger.PAUSED_OPTION)) {
-      String pauseValue = trigger.options().get(Trigger.PAUSED_OPTION);
-      String canonicalName = K8sUtils.canonicalizeName(trigger.name());
-      V1alpha1TableTrigger existingTrigger = triggerApi.get(canonicalName);
+    String canonicalName = K8sUtils.canonicalizeName(trigger.name());
+    V1alpha1TableTrigger existingTrigger = triggerApi.getIfExists(context.namespace(), canonicalName);
 
+    Boolean targetPaused = null;
+    if (trigger.options().containsKey(Trigger.PAUSED_OPTION)) {
+      targetPaused = Boolean.TRUE.toString().equals(trigger.options().get(Trigger.PAUSED_OPTION));
+    } else if (existingTrigger != null && existingTrigger.getSpec() != null) {
+      targetPaused = existingTrigger.getSpec().getPaused();
+    }
+
+    if (targetPaused != null) {
       if (existingTrigger == null) {
         throw new SQLException("Trigger " + trigger.name() + " not found.");
       }
-
       V1alpha1TableTriggerSpec spec = existingTrigger.getSpec();
       if (spec == null) {
         spec = new V1alpha1TableTriggerSpec();
         existingTrigger.spec(spec);
       }
-      spec.setPaused("true".equals(pauseValue));
+      spec.setPaused(targetPaused);
       triggerApi.update(existingTrigger);
       return;
     }
@@ -107,6 +112,9 @@ class K8sTriggerDeployer extends K8sDeployer<V1alpha1TableTrigger, V1alpha1Table
         .yaml(rendered);
     if (!jobProps.isEmpty()) {
       spec.jobProperties(jobProps);
+    }
+    if (trigger.options().containsKey(Trigger.PAUSED_OPTION)) {
+      spec.paused("true".equals(trigger.options().get(Trigger.PAUSED_OPTION)));
     }
     return new V1alpha1TableTrigger()
         .kind(K8sApiEndpoints.TABLE_TRIGGERS.kind())

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployerTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployerTest.java
@@ -101,7 +101,7 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("MY_TRIGGER", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", options);
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
 
     deployer.update();
 
@@ -120,7 +120,7 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("MY_TRIGGER", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", options);
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
 
     deployer.update();
 
@@ -139,7 +139,7 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("MY_TRIGGER", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", options);
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
 
     deployer.update();
 
@@ -154,7 +154,7 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("MY_TRIGGER", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", options);
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
 
     assertThrows(SQLException.class, deployer::update);
   }
@@ -169,7 +169,7 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("MY_TRIGGER", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", Collections.emptyMap());
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
 
     deployer.delete();
 
@@ -181,7 +181,7 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("MY_TRIGGER", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", Collections.emptyMap());
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
 
     assertThrows(SQLException.class, deployer::delete);
   }
@@ -308,7 +308,7 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("MY_TRIGGER", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", options);
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
     deployer.update();
 
     // FakeK8sApi.update() removes and re-adds. Verify the object is still present.
@@ -342,10 +342,138 @@ class K8sTriggerDeployerTest {
     Trigger trigger = new Trigger("NONEXISTENT", new UserJob(null, "myjob"),
         Arrays.asList("schema", "table"), "0 * * * *", Collections.emptyMap());
 
-    K8sTriggerDeployer deployer = makeDeployer(trigger, null);
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
 
     // FakeK8sApi.get() throws SQLException(404) for unknown names
     assertThrows(SQLException.class, deployer::delete,
         "delete() on a non-existing trigger must throw");
+  }
+
+  // ───────── update() paused-state-preservation tests ─────────
+
+  @Test
+  void updatePreservesPausedWhenOptionsHaveNoPausedOption() throws SQLException {
+    // Scenario: CREATE OR REPLACE TABLE with no explicit pause/resume — an existing paused
+    // CRD must remain paused even though the caller passes no PAUSED_OPTION.
+    V1alpha1TableTrigger existing = new V1alpha1TableTrigger()
+        .metadata(new V1ObjectMeta().name("mytrigger"))
+        .spec(new V1alpha1TableTriggerSpec().paused(true));
+    triggers.add(existing);
+
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "myjob"),
+        Arrays.asList("schema", "table"), "0 * * * *", Collections.emptyMap());
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    deployer.update();
+
+    assertTrue(triggers.get(0).getSpec().getPaused(),
+        "Existing paused=true must be preserved when options omit PAUSED_OPTION");
+  }
+
+  @Test
+  void updatePreservesUnpausedWhenOptionsHaveNoPausedOption() throws SQLException {
+    // Scenario: existing CRD is unpaused and the caller passes no PAUSED_OPTION — stays unpaused.
+    V1alpha1TableTrigger existing = new V1alpha1TableTrigger()
+        .metadata(new V1ObjectMeta().name("mytrigger"))
+        .spec(new V1alpha1TableTriggerSpec().paused(false));
+    triggers.add(existing);
+
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "myjob"),
+        Arrays.asList("schema", "table"), "0 * * * *", Collections.emptyMap());
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    deployer.update();
+
+    assertFalse(triggers.get(0).getSpec().getPaused(),
+        "Existing paused=false must be preserved (short-circuit path sets false)");
+  }
+
+  @Test
+  void updateWithPausedOptionFalseUnpausesAlreadyPausedTrigger() throws SQLException {
+    // Scenario: RESUME TRIGGER DDL — PAUSED_OPTION="false" must unpause the existing trigger
+    // even though it was paused. Regression check for a bug where currentlyPaused forced true.
+    V1alpha1TableTrigger existing = new V1alpha1TableTrigger()
+        .metadata(new V1ObjectMeta().name("mytrigger"))
+        .spec(new V1alpha1TableTriggerSpec().paused(true));
+    triggers.add(existing);
+
+    Map<String, String> options = new HashMap<>();
+    options.put(Trigger.PAUSED_OPTION, "false");
+    Trigger trigger = new Trigger("MY_TRIGGER", null, new ArrayList<>(), null, options);
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    deployer.update();
+
+    assertFalse(triggers.get(0).getSpec().getPaused(),
+        "Explicit PAUSED_OPTION=false must override a currently-paused CRD");
+  }
+
+  @Test
+  void updateFallsThroughToSuperUpdateWhenNoExistingAndNoPausedOption() throws SQLException {
+    // Scenario: first-time CREATE OR REPLACE TABLE — no existing trigger, no PAUSED_OPTION.
+    // Must go through super.update() so api.update() upserts (creates) instead of throwing
+    // "Trigger not found".
+    V1alpha1JobTemplate jobTemplate = new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("myjob").namespace("test-ns"))
+        .spec(new V1alpha1JobTemplateSpec().yaml("template: {{name}}"));
+    jobTemplates.add(jobTemplate);
+
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "MY_JOB"),
+        Arrays.asList("SCHEMA", "TABLE"), "0 * * * *", Collections.emptyMap());
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    deployer.update();
+
+    assertEquals(1, triggers.size(),
+        "super.update() must upsert the trigger when none exists");
+  }
+
+  @Test
+  void updateFallsThroughToSuperUpdateWhenExistingHasNullPaused() throws SQLException {
+    // Scenario: existing CRD has spec.paused=null — neither the explicit-option nor the
+    // preserve-existing path fires, so super.update() re-renders (which calls toK8sObject,
+    // which needs a JobTemplate).
+    V1alpha1TableTrigger existing = new V1alpha1TableTrigger()
+        .metadata(new V1ObjectMeta().name("mytrigger"))
+        .spec(new V1alpha1TableTriggerSpec()); // paused not set → null
+    triggers.add(existing);
+
+    V1alpha1JobTemplate jobTemplate = new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("myjob").namespace("test-ns"))
+        .spec(new V1alpha1JobTemplateSpec().yaml("template: {{name}}"));
+    jobTemplates.add(jobTemplate);
+
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "MY_JOB"),
+        Arrays.asList("SCHEMA", "TABLE"), "0 * * * *", Collections.emptyMap());
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    deployer.update();
+
+    // If super.update() ran, toK8sObject() populated spec.table on the re-rendered CRD.
+    // The short-circuit would instead leave spec.table untouched (null on the existing).
+    assertTrue(triggers.stream().anyMatch(t -> "TABLE".equals(t.getSpec().getTable())),
+        "super.update() must have run toK8sObject() — expected a CRD with spec.table='TABLE'");
+  }
+
+  // ───────── toK8sObject() paused rendering test ─────────
+
+  @Test
+  void toK8sObjectSetsSpecPausedWhenPausedOptionTrue() throws SQLException {
+    V1alpha1JobTemplate jobTemplate = new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("myjob").namespace("test-ns"))
+        .spec(new V1alpha1JobTemplateSpec().yaml("template: {{name}}"));
+    jobTemplates.add(jobTemplate);
+
+    Map<String, String> options = new HashMap<>();
+    options.put(Trigger.PAUSED_OPTION, "true");
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "MY_JOB"),
+        Arrays.asList("SCHEMA", "TABLE"), "0 * * * *", options);
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    List<String> specs = deployer.specify();
+
+    assertFalse(specs.isEmpty());
+    assertTrue(specs.get(0).contains("paused: true"),
+        "spec.paused=true must be present in rendered YAML when PAUSED_OPTION=true — got: " + specs.get(0));
   }
 }

--- a/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployer.java
+++ b/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployer.java
@@ -6,6 +6,7 @@ import java.sql.SQLNonTransientException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,10 @@ import java.util.Properties;
 
 import com.linkedin.hoptimator.SqlDialect;
 import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseSpec;
+import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplate;
+import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplateList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1TableTrigger;
+import com.linkedin.hoptimator.k8s.models.V1alpha1TableTriggerList;
 import com.linkedin.hoptimator.util.planner.PipelineRel;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
@@ -22,6 +27,8 @@ import org.slf4j.LoggerFactory;
 import io.kubernetes.client.openapi.models.V1OwnerReference;
 
 import com.linkedin.hoptimator.Deployer;
+import com.linkedin.hoptimator.Trigger;
+import com.linkedin.hoptimator.UserJob;
 import com.linkedin.hoptimator.Validated;
 import com.linkedin.hoptimator.Validator;
 import com.linkedin.hoptimator.Job;
@@ -31,6 +38,7 @@ import com.linkedin.hoptimator.k8s.K8sApi;
 import com.linkedin.hoptimator.k8s.K8sApiEndpoints;
 import com.linkedin.hoptimator.k8s.K8sContext;
 import com.linkedin.hoptimator.k8s.K8sPipelineBundle;
+import com.linkedin.hoptimator.k8s.K8sTriggerDeployer;
 import com.linkedin.hoptimator.k8s.K8sUtils;
 import com.linkedin.hoptimator.k8s.models.V1alpha1Database;
 import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseList;
@@ -53,6 +61,7 @@ import com.linkedin.hoptimator.jdbc.HoptimatorDdlUtils;
 public class LogicalTableDeployer implements Deployer, Validated {
 
   private static final Logger log = LoggerFactory.getLogger(LogicalTableDeployer.class);
+  private static final String LOGICAL_TRIGGER_NAME = "logical-%s-offline-trigger";
 
   private final Source source;
   private final Properties tierProps;
@@ -61,6 +70,7 @@ public class LogicalTableDeployer implements Deployer, Validated {
 
   private final List<Deployer> tierDeployers = new ArrayList<>();
   private final List<K8sPipelineBundle> pipelineDeployers = new ArrayList<>();
+  private final List<Deployer> triggerDeployers = new ArrayList<>();
   private final List<Runnable> schemaRollbacks = new ArrayList<>();
 
   // Created lazily in deployAll(). Null until then, so restore() is a no-op for the CRD if
@@ -186,6 +196,7 @@ public class LogicalTableDeployer implements Deployer, Validated {
           : logicalTableDeployer.createAndReference();
       K8sContext ownerContext = context.withOwner(ownerRef);
       deployImplicitPipelines(tierMap, tierDatabases, tierSources, ownerContext, update);
+      deployImplicitTrigger(tierMap, tierSources, ownerContext);
     } catch (Exception e) {
       if (e instanceof SQLException) {
         throw e;
@@ -208,7 +219,11 @@ public class LogicalTableDeployer implements Deployer, Validated {
 
   @Override
   public void restore() {
-    // Restore pipeline deployers first (they reference the LogicalTable CRD via ownerRef)
+    // Restore trigger deployers first (they reference the LogicalTable CRD via ownerRef)
+    for (int i = triggerDeployers.size() - 1; i >= 0; i--) {
+      triggerDeployers.get(i).restore();
+    }
+    // Restore pipeline deployers next (they also reference the LogicalTable CRD via ownerRef)
     for (int i = pipelineDeployers.size() - 1; i >= 0; i--) {
       pipelineDeployers.get(i).restore();
     }
@@ -442,6 +457,80 @@ public class LogicalTableDeployer implements Deployer, Validated {
   /** Returns the canonical pipeline name for an implicit inter-tier pipeline. */
   static String pipelineName(String tableName, String fromTier, String toTier) {
     return "logical-" + K8sUtils.canonicalizeName(tableName) + "-" + fromTier + "-to-" + toTier;
+  }
+
+  /**
+   * Creates or updates a {@link V1alpha1TableTrigger} for the offline tier, owned by the
+   * LogicalTable CRD.
+   */
+  private void deployImplicitTrigger(Map<String, String> tierMap, Map<String, Source> tierSources, K8sContext ownerContext)
+      throws SQLException {
+    if (!tierMap.containsKey(LogicalTier.OFFLINE.tierName())) {
+      return;
+    }
+    Source offlineSource = tierSources.get(LogicalTier.OFFLINE.tierName());
+    String offlineDatabase = offlineSource.database();
+
+    V1alpha1JobTemplate jobTemplate = findMatchingJobTemplate(ownerContext, offlineDatabase);
+    if (jobTemplate == null) {
+      return;
+    }
+
+    String triggerName = String.format(LOGICAL_TRIGGER_NAME, K8sUtils.canonicalizeName(source.table()));
+
+    V1alpha1TableTrigger existing = null;
+    try {
+      existing = createTableTriggerApi(ownerContext).getIfExists(ownerContext.namespace(), triggerName);
+    } catch (Exception e) {
+      log.warn("Existence check for implicit trigger {} failed; assuming first deployment: {}",
+          triggerName, e.toString());
+    }
+
+    Map<String, String> triggerOptions = new HashMap<>(source.options());
+    if (existing == null) {
+      triggerOptions.put(Trigger.PAUSED_OPTION, "true");
+    }
+    UserJob userJob = new UserJob(ownerContext.namespace(), jobTemplate.getMetadata().getName());
+    Trigger trigger = new Trigger(triggerName, userJob, offlineSource.path(), null, triggerOptions);
+
+    K8sTriggerDeployer triggerDeployer = createTriggerDeployer(trigger, ownerContext);
+    triggerDeployers.add(triggerDeployer);
+    if (existing == null) {
+      triggerDeployer.create();
+    } else {
+      triggerDeployer.update();
+    }
+    log.info("Deployed offline-tier trigger {} for logical table {} using JobTemplate {}",
+        triggerName, source.table(), jobTemplate.getMetadata().getName());
+  }
+
+  private V1alpha1JobTemplate findMatchingJobTemplate(K8sContext ownerContext, String offlineDatabase) {
+    Collection<V1alpha1JobTemplate> jobTemplates;
+    try {
+      jobTemplates = createJobTemplateApi(ownerContext).list();
+    } catch (Exception e) {
+      log.error("Error listing JobTemplates in namespace {}; skipping implicit trigger creation for offline database {}: {}",
+          ownerContext.namespace(), offlineDatabase, e.toString());
+      return null;
+    }
+
+    return jobTemplates.stream()
+        .filter(template -> template.getSpec() != null
+            && template.getSpec().getDatabases() != null
+            && template.getSpec().getDatabases().contains(offlineDatabase))
+        .findFirst().orElse(null);
+  }
+
+  K8sApi<V1alpha1JobTemplate, V1alpha1JobTemplateList> createJobTemplateApi(K8sContext ctx) {
+    return new K8sApi<>(ctx, K8sApiEndpoints.JOB_TEMPLATES);
+  }
+
+  K8sApi<V1alpha1TableTrigger, V1alpha1TableTriggerList> createTableTriggerApi(K8sContext ctx) {
+    return new K8sApi<>(ctx, K8sApiEndpoints.TABLE_TRIGGERS);
+  }
+
+  K8sTriggerDeployer createTriggerDeployer(Trigger trigger, K8sContext ctx) {
+    return new K8sTriggerDeployer(trigger, ctx);
   }
 
   /**

--- a/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/LogicalTableDeployerTest.java
+++ b/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/LogicalTableDeployerTest.java
@@ -24,18 +24,26 @@ import io.kubernetes.client.openapi.models.V1OwnerReference;
 
 import com.linkedin.hoptimator.Deployer;
 import com.linkedin.hoptimator.Source;
+import com.linkedin.hoptimator.Trigger;
 import com.linkedin.hoptimator.Validated;
 import com.linkedin.hoptimator.Validator;
 import com.linkedin.hoptimator.jdbc.DeployerUtils;
 import com.linkedin.hoptimator.jdbc.HoptimatorConnection;
 import com.linkedin.hoptimator.jdbc.HoptimatorDriver;
 import com.linkedin.hoptimator.k8s.FakeK8sApi;
+import com.linkedin.hoptimator.k8s.K8sApi;
 import com.linkedin.hoptimator.k8s.K8sContext;
+import com.linkedin.hoptimator.k8s.K8sTriggerDeployer;
 import com.linkedin.hoptimator.k8s.K8sUtils;
 import com.linkedin.hoptimator.k8s.models.V1alpha1Database;
 import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseList;
 import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseSpec;
+import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplate;
+import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplateList;
+import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplateSpec;
 import com.linkedin.hoptimator.k8s.models.V1alpha1LogicalTableSpecTiers;
+import com.linkedin.hoptimator.k8s.models.V1alpha1TableTrigger;
+import com.linkedin.hoptimator.k8s.models.V1alpha1TableTriggerList;
 import com.linkedin.hoptimator.util.DeploymentService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -666,5 +674,273 @@ class LogicalTableDeployerTest {
         "INSERT target should be the online sink: " + sql);
     assertTrue(sql.contains("SELECT * FROM \"KAFKA\".\"events\""),
         "SELECT source should be the nearline source: " + sql);
+  }
+
+  // ───────── deployImplicitTrigger() tests ─────────
+
+  /** Spy-deployer that captures the Trigger passed to createTriggerDeployer and whether
+   * create()/update() was called, while stubbing the actual K8sTriggerDeployer to avoid
+   * real K8s calls. */
+  private static final class TriggerCapture {
+    Trigger trigger;
+    boolean createCalled;
+    boolean updateCalled;
+  }
+
+  /**
+   * Builds a LogicalTableDeployer that mocks the CRD deployer, suppresses pipeline deployment,
+   * and captures the implicit trigger via overrides on the package-private factory methods.
+   *
+   * <p>Pass {@code preExistingTriggers} to seed the trigger API with CRDs that already exist —
+   * controls whether {@code deployImplicitTrigger} takes the first-deploy (create) or the
+   * re-deploy (update) path.
+   */
+  private LogicalTableDeployer deployerWithJobTemplates(
+      Source src, Properties props, K8sContext ctx,
+      FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi,
+      List<V1alpha1JobTemplate> jobTemplates,
+      List<V1alpha1TableTrigger> preExistingTriggers,
+      TriggerCapture capture) {
+    FakeK8sApi<V1alpha1JobTemplate, V1alpha1JobTemplateList> jobTemplateApi =
+        new FakeK8sApi<>(jobTemplates);
+    FakeK8sApi<V1alpha1TableTrigger, V1alpha1TableTriggerList> triggerApi =
+        new FakeK8sApi<>(preExistingTriggers);
+    return new LogicalTableDeployer(src, props, ctx, dbApi) {
+      @Override
+      K8sLogicalTableDeployer createLogicalTableDeployer(
+          String crdName, String databaseLabel, Map<String, String> tierMap) {
+        return mockCrdDeployer;
+      }
+
+      @Override
+      void deployPipelineBundle(String fromTier, String toTier,
+          Map<String, V1alpha1Database> tierDatabases,
+          Map<String, Source> tierSources,
+          K8sContext ownerContext, boolean update) {
+        // No-op in trigger-focused tests.
+      }
+
+      @Override
+      K8sApi<V1alpha1JobTemplate, V1alpha1JobTemplateList> createJobTemplateApi(K8sContext c) {
+        return jobTemplateApi;
+      }
+
+      @Override
+      K8sApi<V1alpha1TableTrigger, V1alpha1TableTriggerList> createTableTriggerApi(K8sContext c) {
+        return triggerApi;
+      }
+
+      @Override
+      K8sTriggerDeployer createTriggerDeployer(Trigger trigger, K8sContext c) {
+        capture.trigger = trigger;
+        return new K8sTriggerDeployer(trigger, c) {
+          @Override
+          public void create() {
+            capture.createCalled = true;
+          }
+
+          @Override
+          public void update() {
+            capture.updateCalled = true;
+          }
+        };
+      }
+    };
+  }
+
+  /** Convenience overload for tests that don't pre-seed any triggers. */
+  private LogicalTableDeployer deployerWithJobTemplates(
+      Source src, Properties props, K8sContext ctx,
+      FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi,
+      List<V1alpha1JobTemplate> jobTemplates,
+      TriggerCapture capture) {
+    return deployerWithJobTemplates(src, props, ctx, dbApi, jobTemplates,
+        new ArrayList<>(), capture);
+  }
+
+  private static V1alpha1JobTemplate makeJobTemplate(String name, String... databases) {
+    return new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name(name).namespace("default"))
+        .spec(new V1alpha1JobTemplateSpec().yaml("template: {{name}}")
+            .databases(Arrays.asList(databases)));
+  }
+
+  @Test
+  void implicitTriggerCreatedOnCreatePathWhenOfflineTierAndMatchingJobTemplateExist()
+      throws Exception {
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).createAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, capture).create();
+
+    assertNotNull(capture.trigger, "implicit trigger must be created");
+    assertTrue(capture.createCalled, "create() must be invoked on the trigger deployer");
+    assertFalse(capture.updateCalled, "update() must not be invoked on create path");
+  }
+
+  @Test
+  void implicitTriggerSkippedWhenNoOfflineTier() throws Exception {
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("online-db", "ONLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+    Properties props = new Properties();
+    props.setProperty(LogicalTier.NEARLINE.tierName(), "nearline-db");
+    props.setProperty(LogicalTier.ONLINE.tierName(), "online-db");
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).createAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), props, mockContext(), dbApi, jobTemplates, capture)
+        .create();
+
+    assertEquals(null, capture.trigger,
+        "No offline tier → implicit trigger must not be created");
+  }
+
+  @Test
+  void implicitTriggerSkippedWhenNoMatchingJobTemplate() throws Exception {
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    // JobTemplate exists but declares a different database.
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("other-template", "some-other-db")));
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).createAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, capture).create();
+
+    assertEquals(null, capture.trigger,
+        "No JobTemplate declares the offline DB → implicit trigger must be skipped");
+  }
+
+  @Test
+  void implicitTriggerPathUsesOfflineTierPhysicalPath() throws Exception {
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).createAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, capture).create();
+
+    // testSource() has path [logical, testevent]; offline tier's Database has schema=OFFLINE.
+    // Expect the trigger to target the offline physical schema, not the logical one.
+    assertEquals("OFFLINE", capture.trigger.schema(),
+        "Trigger schema must point at the offline tier's physical schema");
+    assertEquals("testevent", capture.trigger.table(),
+        "Trigger table must be the logical table name");
+  }
+
+  @Test
+  void implicitTriggerCreatePathHasPausedOptionSet() throws Exception {
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).createAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, capture).create();
+
+    assertEquals("true", capture.trigger.options().get(Trigger.PAUSED_OPTION),
+        "create path must set PAUSED_OPTION=true so the CRD is created paused");
+  }
+
+  @Test
+  void implicitTriggerUpdateOnExistingCrdOmitsPausedOptionAndCallsUpdate() throws Exception {
+    // Scenario: existing trigger CRD present — re-deploy must NOT set PAUSED_OPTION (paused
+    // state is preserved inside K8sTriggerDeployer.update()) and must call update(), not create().
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+
+    // Seed a pre-existing trigger CRD matching the canonical implicit trigger name.
+    List<V1alpha1TableTrigger> existing = new ArrayList<>(Arrays.asList(
+        new V1alpha1TableTrigger()
+            .metadata(new V1ObjectMeta().name("logical-testevent-offline-trigger"))));
+
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).updateAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, existing, capture).update();
+
+    assertFalse(capture.trigger.options().containsKey(Trigger.PAUSED_OPTION),
+        "re-deploy of existing trigger must not set PAUSED_OPTION — paused state is preserved "
+        + "inside K8sTriggerDeployer.update()");
+    assertTrue(capture.updateCalled, "update() must be invoked when the CRD already exists");
+    assertFalse(capture.createCalled, "create() must not be invoked when the CRD already exists");
+  }
+
+  @Test
+  void implicitTriggerFirstCreateOrReplaceStartsPausedAndCallsCreate() throws Exception {
+    // Scenario: CREATE OR REPLACE TABLE on a not-yet-deployed logical table (no existing trigger
+    // CRD). The implicit trigger must still be created PAUSED even though the DDL routes via
+    // LogicalTableDeployer.update(). Existence check gates the decision, not the DDL verb.
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).updateAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, capture).update();  // CREATE OR REPLACE → update()
+
+    assertEquals("true", capture.trigger.options().get(Trigger.PAUSED_OPTION),
+        "first CREATE OR REPLACE with no existing CRD must still set PAUSED_OPTION=true");
+    assertTrue(capture.createCalled,
+        "first-time deploy must call create() regardless of the DDL's update flag");
+    assertFalse(capture.updateCalled, "update() must not be invoked when no CRD exists yet");
+  }
+
+  @Test
+  void implicitTriggerForwardsSourceOptionsToTriggerOptions() throws Exception {
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).createAndReference();
+
+    // CREATE TABLE WITH ("ab.cd" "customValue", "job.properties.online.name" "testevent-online")
+    Map<String, String> sourceOptions = new java.util.HashMap<>();
+    sourceOptions.put("ab.cd", "customValue");
+    sourceOptions.put("job.properties.online.name", "testevent-online");
+    Source src = new Source("logical", Arrays.asList("logical", "testevent"), sourceOptions);
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(src, twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, capture).create();
+
+    assertEquals("customValue", capture.trigger.options().get("ab.cd"),
+        "Arbitrary WITH option must flow through to trigger options (as {{ab.cd}} in template)");
+    assertEquals("testevent-online", capture.trigger.options().get("job.properties.online.name"),
+        "job.properties.* WITH option must flow through for jobProperties + template rendering");
+  }
+
+  @Test
+  void implicitTriggerNameFollowsLogicalOfflineConvention() throws Exception {
+    FakeK8sApi<V1alpha1Database, V1alpha1DatabaseList> dbApi = new FakeK8sApi<>(
+        Arrays.asList(makeDb("nearline-db", "NEARLINE"), makeDb("offline-db", "OFFLINE")));
+    List<V1alpha1JobTemplate> jobTemplates = new ArrayList<>(
+        Arrays.asList(makeJobTemplate("retl-offline", "offline-db")));
+    doReturn(new V1OwnerReference()).when(mockCrdDeployer).createAndReference();
+
+    TriggerCapture capture = new TriggerCapture();
+    deployerWithJobTemplates(testSource(), twoTierProps("nearline-db", "offline-db"),
+        mockContext(), dbApi, jobTemplates, capture).create();
+
+    assertEquals("logical-testevent-offline-trigger", capture.trigger.name());
   }
 }

--- a/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/TestSqlScripts.java
+++ b/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/TestSqlScripts.java
@@ -12,4 +12,9 @@ public class TestSqlScripts extends QuidemTestBase {
   public void logicalTableDdlScript() throws Exception {
     run("logical-ddl.id");
   }
+
+  @Test
+  public void logicalTableOfflineDdlScript() throws Exception {
+    run("logical-offline-ddl.id");
+  }
 }

--- a/hoptimator-logical/src/test/resources/logical-offline-ddl.id
+++ b/hoptimator-logical/src/test/resources/logical-offline-ddl.id
@@ -1,0 +1,79 @@
+!set outputformat mysql
+!use k8s
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1: CREATE TABLE on a logical table with an offline tier auto-creates
+# a paused TableTrigger via LogicalTableDeployer.deployImplicitTrigger().
+# ─────────────────────────────────────────────────────────────────────────────
+create or replace table "LOGICAL_OFFLINE"."MEMBERS" ("ID" bigint, "NAME" varchar);
+(0 rows modified)
+
+!update
+
+# The trigger CRD must exist with the canonical "logical-<table>-offline-trigger" name,
+# pointing at the offline tier's physical schema (PROFILE), and must start paused=true.
+select name, schema, "TABLE", paused from "k8s".table_triggers where name = 'logical-members-offline-trigger';
++---------------------------------+---------+---------+--------+
+| NAME                            | SCHEMA  | TABLE   | PAUSED |
++---------------------------------+---------+---------+--------+
+| logical-members-offline-trigger | PROFILE | MEMBERS | true   |
++---------------------------------+---------+---------+--------+
+(1 row)
+
+!ok
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2: RESUME TRIGGER unpauses the implicit trigger.
+# ─────────────────────────────────────────────────────────────────────────────
+resume trigger "logical-members-offline-trigger";
+(0 rows modified)
+
+!update
+
+select paused from "k8s".table_triggers where name = 'logical-members-offline-trigger';
++--------+
+| PAUSED |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3: Subsequent CREATE OR REPLACE TABLE preserves the user's unpaused state.
+# (K8sTriggerDeployer.update() resolves paused from the existing CRD when the
+# caller doesn't set PAUSED_OPTION.)
+# ─────────────────────────────────────────────────────────────────────────────
+create or replace table "LOGICAL_OFFLINE"."MEMBERS" ("ID" bigint, "NAME" varchar, "EXTRA" varchar);
+(0 rows modified)
+
+!update
+
+select paused from "k8s".table_triggers where name = 'logical-members-offline-trigger';
++--------+
+| PAUSED |
++--------+
+| false  |
++--------+
+(1 row)
+
+!ok
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 4: PAUSE TRIGGER re-pauses it.
+# ─────────────────────────────────────────────────────────────────────────────
+pause trigger "logical-members-offline-trigger";
+(0 rows modified)
+
+!update
+
+select paused from "k8s".table_triggers where name = 'logical-members-offline-trigger';
++--------+
+| PAUSED |
++--------+
+| true   |
++--------+
+(1 row)
+
+!ok

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,6 @@ include 'hoptimator-logical'
 
 dependencyResolutionManagement {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven {
       url  "https://linkedin.jfrog.io/artifactory/open-source"


### PR DESCRIPTION
## Summary
- When a logical table is declared with an `offline` tier, a `TableTrigger` CRD is now auto-generated for backfill / rETL. The trigger starts paused, and picks up its job spec from a `JobTemplate` in the same namespace that declares the offline tier's Database in its `spec.databases`. 
- All `WITH (...)` options on `CREATE TABLE "LOGICAL"."t"` flow verbatim into the generated trigger's options, so JobTemplate authors can reference both `{{job.properties.<k>}}` (also forwarded to `spec.jobProperties`) and arbitrary template variables like `{{offline.table.name}}`. 

### Note
- Haven't added schedule based trigger's support yet with logical tables. 

## Testing

```
The following SQL matches the `retl-job-template` and would have the following trigger generated.
```

  ```sql
  CREATE OR REPLACE TABLE "LOGICAL"."testevent2" (
    "KEY_id" varchar, "memberId" bigint, "pageKey" varchar
  ) WITH (
    'job.properties.online.table.name' 'testevent-online',
    'offline.table.name' 'demotable'
  );
  ```

  ```yaml
➜  ~ k get tabletriggers logical-testevent2-offline-trigger -oyaml

apiVersion: hoptimator.linkedin.com/v1alpha1
kind: TableTrigger
metadata:
  creationTimestamp: "2026-04-23T18:55:10Z"
  generation: 1
  labels:
    view: profile-testevent2
  name: logical-testevent2-offline-trigger
  namespace: default
  ownerReferences:
  - apiVersion: hoptimator.linkedin.com/v1alpha1
    kind: LogicalTable
    name: logical-testevent2
    uid: fefa0ba6-6d0d-4455-ac01-282764199e00
  resourceVersion: "1312129"
  uid: 6cdbd997-7ff9-401b-96af-8572e978e568
spec:
  jobProperties:
    online.table.name: testevent-online
  paused: true
  schema: PROFILE
  table: testevent2
  yaml: |
    apiVersion: batch/v1
    kind: Job
    metadata:
      name: logical-testevent2-offline-trigger-retl-job-template-job
    spec:
      template:
        spec:
          containers:
          - name: hello
            image: alpine/k8s:1.33.0
            env:
              - name: TABLE_TRIGGER_NAME
                value: "logical-testevent2-offline-trigger"
              - name: SOURCE_TABLE_NAME
                value: "demotable"
              - name: ONLINE_TABLE_NAME
                value: "testevent-online"
            command: ["bash",  "-c", "echo logical-testevent2-offline-trigger-retl-job-template-trigger fired at `date`"]
          restartPolicy: Never
      backoffLimit: 4
  ```

### Scenarios

| Scenario                              | Deploy path |  `PAUSED_OPTION` set? |
|---------------------------------------|-------------|----------------------|
| `CREATE TABLE ...`                  | `create()`  | yes                  |
| `CREATE OR REPLACE TABLE ...` when TABLE doesn't exist       | `update()`  | yes                  |
| `CREATE OR REPLACE TABLE ...` when TABLE exists      | `update()`  | preserves existing trigger's pause value                   |
| Logical table without an offline tier | any         | N/A                    |
| Offline tier but no matching `JobTemplate` | any    | N/A                    |