### PR TITLE
Expose non-blocking start()/stop() on PipelineOperatorApp + fail-fast failure reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,6 @@ ext.jacocoAggregateExcludes = [
   // ── hoptimator-models / hoptimator-k8s ──────────────────────────────────────
   '**/models/**',           // auto-generated K8s CRD model classes
 
-  // ── hoptimator-operator ──────────────────────────────────────────────────────
-  '**/PipelineOperatorApp.class',                  // operator main entry point
-
   // ── hoptimator-flink-runner ──────────────────────────────────────────────────
   '**/FlinkRunner.class',                          // CLI entry point; requires Flink runtime
 

--- a/deploy/dev/kafka.yaml
+++ b/deploy/dev/kafka.yaml
@@ -15,7 +15,7 @@
 # Based on examples at:
 # https://github.com/strimzi/strimzi-kafka-operator/blob/main/examples/kafka
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -34,7 +34,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -53,7 +53,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: one
@@ -65,7 +65,6 @@ spec:
   kafka:
     version: 4.2.0
     metadataVersion: "4.0"
-    replicas: 1
     listeners:
       - name: plain
         port: 9094

--- a/deploy/samples/kafkadb.yaml
+++ b/deploy/samples/kafkadb.yaml
@@ -17,7 +17,7 @@ spec:
   databases:
   - kafka-database
   yaml: |
-    apiVersion: kafka.strimzi.io/v1beta2
+    apiVersion: kafka.strimzi.io/v1
     kind: KafkaTopic
     metadata:
       name: {{name}}
@@ -42,7 +42,7 @@ spec:
 
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-1
@@ -58,7 +58,7 @@ spec:
 
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-2

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -175,7 +175,7 @@ spec:
   databases:
     - kafka-database
   yaml: |
-    apiVersion: kafka.strimzi.io/v1beta2
+    apiVersion: kafka.strimzi.io/v1
     kind: KafkaTopic
     metadata:
       name: {{name}}

--- a/docs/kubernetes/crd-reference.md
+++ b/docs/kubernetes/crd-reference.md
@@ -168,7 +168,7 @@ spec:
   methods:
     - Scan
   yaml: |
-    apiVersion: kafka.strimzi.io/v1beta2
+    apiVersion: kafka.strimzi.io/v1
     kind: KafkaTopic
     metadata:
       name: {{name}}

--- a/docs/kubernetes/templates.md
+++ b/docs/kubernetes/templates.md
@@ -50,7 +50,7 @@ spec:
   databases: [ kafka-database ]
   methods: [ Scan, Modify ]
   yaml: |
-    apiVersion: kafka.strimzi.io/v1beta2
+    apiVersion: kafka.strimzi.io/v1
     kind: KafkaTopic
     metadata:
       name: {{name}}

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatusEstimatorTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/status/K8sPipelineElementStatusEstimatorTest.java
@@ -65,7 +65,7 @@ public class K8sPipelineElementStatusEstimatorTest {
       "apiVersion: foo.org/v1beta1\n" + "kind: FakeJob\n" + "metadata:\n" + "  name: fake-job-name\n" + "spec:\n"
           + "  deploymentName: fake-deployment\n" + "  job:\n" + "    entryClass: com.runner.FakeRunner";
   private static final String FAKE_KAFKA_TOPIC_SPEC =
-      "apiVersion: kafka.strimzi.io/v1beta2\n" + "kind: KafkaTopic\n" + "metadata:\n" + "      name: fake-kafka-topic\n"
+      "apiVersion: kafka.strimzi.io/v1\n" + "kind: KafkaTopic\n" + "metadata:\n" + "      name: fake-kafka-topic\n"
           + "      labels:\n" + "        strimzi.io/cluster: one\n" + "spec:\n" + "      topicName: existing-topic-1\n"
           + "      partitions: 1";
 

--- a/hoptimator-kafka/src/test/resources/kafka-ddl-beam.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl-beam.id
@@ -22,7 +22,7 @@ spec:
     flink.app.type: 'BEAM'
     flink.app.name: 'hoptimator-flink-runner'
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-1
@@ -36,7 +36,7 @@ spec:
     retention.ms: 7200000
     segment.bytes: 1073741824
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-2

--- a/hoptimator-kafka/src/test/resources/kafka-ddl-create-table.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl-create-table.id
@@ -3,7 +3,7 @@
 
 # Verify create table plan — !specify previews the KafkaTopic YAML without executing
 create or replace table "KAFKA"."create-table-test" ("KEY" VARCHAR, "VALUE" BINARY) WITH ("kafka.partitions" '5');
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-create-table-test
@@ -55,7 +55,7 @@ spec:
     upgradeMode: stateless
     state: running
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-create-table-test
@@ -69,7 +69,7 @@ spec:
     retention.ms: 7200000
     segment.bytes: 1073741824
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-2

--- a/hoptimator-kafka/src/test/resources/kafka-ddl.id
+++ b/hoptimator-kafka/src/test/resources/kafka-ddl.id
@@ -41,7 +41,7 @@ spec:
     upgradeMode: stateless
     state: running
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-1
@@ -55,7 +55,7 @@ spec:
     retention.ms: 7200000
     segment.bytes: 1073741824
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-existing-topic-2

--- a/hoptimator-logical/src/test/resources/logical-ddl.id
+++ b/hoptimator-logical/src/test/resources/logical-ddl.id
@@ -204,7 +204,7 @@ spec:
     upgradeMode: stateless
     state: running
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: kafka-database-create-table-test

--- a/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/PipelineOperatorApp.java
+++ b/hoptimator-operator/src/main/java/com/linkedin/hoptimator/operator/PipelineOperatorApp.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator.operator;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.hoptimator.jdbc.HoptimatorConnection;
 import com.linkedin.hoptimator.k8s.K8sApiEndpoints;
 import com.linkedin.hoptimator.k8s.K8sContext;
@@ -8,6 +9,7 @@ import com.linkedin.hoptimator.operator.trigger.TableTriggerReconciler;
 import com.linkedin.hoptimator.operator.trigger.ViewReconciler;
 import io.kubernetes.client.extended.controller.Controller;
 import io.kubernetes.client.extended.controller.ControllerManager;
+import io.kubernetes.client.informer.SharedInformerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -22,16 +24,49 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 
+/**
+ * Hosts the pipeline operator's {@link ControllerManager}. Provides a non-blocking
+ * {@link #start(List)} / {@link #stop} pair so callers driven by an external lifecycle
+ * (Spring, Guava, etc.) are not blocked by {@code ControllerManager.run()}'s
+ * indefinite {@code CountDownLatch.await()}.
+ *
+ * <p>Failure handling: the caller supplies a {@link Consumer} that's invoked once if any
+ * controller exits unexpectedly or the runner thread dies with an uncaught exception.
+ * The handler should propagate the failure however the caller wants but a controller will
+ * not auto recover. The handler fires at most once per service instance and is suppressed
+ * during an intentional {@link #stop} sequence.
+ */
 public class PipelineOperatorApp {
   private static final Logger log = LoggerFactory.getLogger(PipelineOperatorApp.class);
 
   private final K8sContext context;
+  private final Consumer<Throwable> failureHandler;
+  private final AtomicBoolean stopRequested = new AtomicBoolean(false);
+  private final AtomicBoolean failureReported = new AtomicBoolean(false);
+  private ControllerManager controllerManager;
+  private Thread runnerThread;
+  private boolean shutdownHookInstalled;
 
+  /** Constructor for callers that don't care about runtime failures (e.g. {@link #main(String[])}). */
   public PipelineOperatorApp(K8sContext context) {
+    this(context, t -> { /* no-op */ });
+  }
+
+  /**
+   * @param failureHandler invoked once if a controller exits unexpectedly or the runner
+   *     thread dies with an uncaught exception. The throwable argument is the captured cause,
+   *     or {@code null} if the controller's {@code run()} returned cleanly without
+   *     a stop signal (no exception to capture).
+   */
+  public PipelineOperatorApp(K8sContext context, Consumer<Throwable> failureHandler) {
     this.context = context;
+    this.failureHandler = Objects.requireNonNull(failureHandler);
   }
 
   public static void main(String[] args) throws Exception {
@@ -60,29 +95,184 @@ public class PipelineOperatorApp {
     Properties connectionProperties = new Properties();
     connectionProperties.put("k8s.watch.namespace", watchNamespaceInput);
     K8sContext context = K8sContext.create(new HoptimatorConnection(null, connectionProperties));
-    new PipelineOperatorApp(context).run();
+    PipelineOperatorApp app = new PipelineOperatorApp(context);
+    app.installShutdownHook(Duration.ofMinutes(1));
+    app.start(Collections.emptyList());
+    app.awaitTermination();
   }
 
-  public void run() {
-    run(Collections.emptyList());
-  }
+  /**
+   * Registers informers and controllers, then starts the {@link ControllerManager} on a
+   * daemon thread named {@code hoptimator-controller-manager}. Returns promptly.
+   *
+   * <p>If a controller's {@code run()} method exits unexpectedly (without a corresponding
+   * {@link #stop} call), the configured {@link Consumer} failure handler is invoked once.
+   * Subsequent failures (e.g. other controllers also exiting) are dropped.
+   */
+  public synchronized void start(List<Controller> initialControllers) {
+    if (controllerManager != null) {
+      log.info("PipelineOperatorApp.start() ignored — already started");
+      return;
+    }
 
-  public void run(List<Controller> initialControllers) {
-    // register informers
     context.registerInformer(K8sApiEndpoints.PIPELINES, Duration.ofMinutes(5));
     context.registerInformer(K8sApiEndpoints.TABLE_TRIGGERS, Duration.ofMinutes(5));
     context.registerInformer(K8sApiEndpoints.VIEWS, Duration.ofMinutes(5));
 
+    List<Controller> rawControllers = buildControllers(initialControllers);
+    if (rawControllers.isEmpty()) {
+      log.warn("PipelineOperatorApp.start() called with no controllers; staying idle.");
+      return;
+    }
+
+    controllerManager = newControllerManager(
+        context.informerFactory(), rawControllers.stream()
+            .map(this::wrapForFailFast).toArray(Controller[]::new));
+
+    log.info("Starting operator with {} controllers.", rawControllers.size());
+    runnerThread = new Thread(controllerManager::run, "hoptimator-controller-manager");
+    runnerThread.setDaemon(true);
+    runnerThread.setUncaughtExceptionHandler((t, ex) -> {
+      log.error("Controller-manager runner thread died unexpectedly", ex);
+      reportFailure(ex);
+    });
+    runnerThread.start();
+  }
+
+  /**
+   * Builds the full controller list by appending the standard reconcilers to the caller-provided
+   * initial set. Extracted so tests can substitute a stub list without invoking the real
+   * reconciler factories.
+   */
+  @VisibleForTesting
+  List<Controller> buildControllers(List<Controller> initialControllers) {
     List<Controller> controllers = new ArrayList<>(initialControllers);
     controllers.addAll(ControllerService.controllers(context));
     controllers.add(PipelineReconciler.controller(context));
     controllers.add(TableTriggerReconciler.controller(context));
     controllers.add(ViewReconciler.controller(context));
+    return controllers;
+  }
 
-    ControllerManager controllerManager =
-        new ControllerManager(context.informerFactory(), controllers.toArray(new Controller[0]));
+  /**
+   * Constructs the {@link ControllerManager}. Extracted so tests can substitute a mock without
+   * invoking the real upstream constructor.
+   */
+  @VisibleForTesting
+  ControllerManager newControllerManager(SharedInformerFactory factory, Controller[] controllers) {
+    return new ControllerManager(factory, controllers);
+  }
 
-    log.info("Starting operator with {} controllers.", controllers.size());
-    controllerManager.run();
+  /**
+   * Wraps a {@link Controller} so an unexpected exit from its {@code run()} method
+   * (without {@link #stop} having been called) invokes the configured failure handler.
+   * Captures the thrown cause if the exit was via exception, otherwise reports {@code null}.
+   */
+  private Controller wrapForFailFast(Controller inner) {
+    String name = inner.getClass().getName();
+    return new Controller() {
+      @Override
+      public void run() {
+        Throwable cause = null;
+        try {
+          inner.run();
+        } catch (Throwable t) {
+          cause = t;
+          throw t;
+        } finally {
+          if (!stopRequested.get()) {
+            if (cause != null) {
+              log.error("Controller {} exited unexpectedly with throwable", name, cause);
+            } else {
+              log.error("Controller {} exited unexpectedly", name);
+            }
+            reportFailure(cause);
+          }
+        }
+      }
+
+      @Override
+      public void shutdown() {
+        inner.shutdown();
+      }
+    };
+  }
+
+  /**
+   * Invokes the failure handler at most once. Suppressed during intentional stop. Catches any
+   * throwable from the handler itself so a misbehaving handler can't corrupt our shutdown path.
+   */
+  private void reportFailure(Throwable cause) {
+    if (stopRequested.get()) {
+      return;
+    }
+    if (failureReported.compareAndSet(false, true)) {
+      try {
+        failureHandler.accept(cause);
+      } catch (Throwable t) {
+        log.error("Failure handler itself threw", t);
+      }
+    }
+  }
+
+  /**
+   * Signals the {@link ControllerManager} to stop and waits up to {@code timeout} for the
+   * runner thread to exit. No-op if {@link #start(List)} was never called.
+   */
+  public synchronized void stop(Duration timeout) {
+    if (controllerManager == null) {
+      // Either start() was never called, or start() short-circuited because controllers list
+      // was empty. Either way nothing to stop.
+      return;
+    }
+    // Mark intentional-stop FIRST so wrappers don't fire failureHandler on their way out.
+    stopRequested.set(true);
+    log.info("Stopping operator.");
+    controllerManager.shutdown();
+    if (runnerThread != null) {
+      try {
+        runnerThread.join(timeout.toMillis());
+        if (runnerThread.isAlive()) {
+          log.warn("Controller-manager runner thread did not terminate within {}", timeout);
+          runnerThread.interrupt();
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Registers a JVM shutdown hook that calls {@link #stop(Duration)} with the given timeout.
+   * Idempotent — a second call is a no-op. Useful when running from {@link #main(String[])} or
+   * any other entry point that doesn't have an external lifecycle manager driving shutdown.
+   */
+  public synchronized void installShutdownHook(Duration gracefulShutdownTimeout) {
+    if (shutdownHookInstalled) {
+      return;
+    }
+    Runtime.getRuntime().addShutdownHook(
+        new Thread(() -> stop(gracefulShutdownTimeout), "hoptimator-shutdown-hook"));
+    shutdownHookInstalled = true;
+  }
+
+  /**
+   * Blocks until the controller-manager runner thread exits, which happens on
+   * {@link #stop} or when all controllers terminate naturally. Returns immediately if
+   * {@link #start(List)} was called with an empty controller list (idle mode) — there's no
+   * runner to wait on and {@link #main(String[])} should be allowed to exit cleanly.
+   */
+  public void awaitTermination() throws InterruptedException {
+    Thread thread;
+    synchronized (this) {
+      thread = runnerThread;
+    }
+    if (thread == null) {
+      // Either never started or idle mode (no controllers). Either way, nothing to await.
+      // Idle mode lets main() exit cleanly; calling awaitTermination without start is a
+      // caller bug, but throwing here would punish the expected idle-mode path.
+      return;
+    }
+    thread.join();
   }
 }

--- a/hoptimator-operator/src/test/java/com/linkedin/hoptimator/operator/PipelineOperatorAppTest.java
+++ b/hoptimator-operator/src/test/java/com/linkedin/hoptimator/operator/PipelineOperatorAppTest.java
@@ -1,0 +1,414 @@
+package com.linkedin.hoptimator.operator;
+
+import com.linkedin.hoptimator.k8s.K8sContext;
+import io.kubernetes.client.extended.controller.Controller;
+import io.kubernetes.client.extended.controller.ControllerManager;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for {@link PipelineOperatorApp}.
+ *
+ * <p>Uses {@link TestablePipelineOperatorApp} which substitutes the {@link ControllerManager}
+ * construction and the controller list with mocks, letting us drive {@code start()} →
+ * {@code stop()} → {@code awaitTermination()} transitions without needing a real Kubernetes
+ * API server.
+ *
+ * <p>Failure-mode tests use an "interactive" fake {@link ControllerManager} that actually
+ * invokes each wrapped controller's {@code run()} method, exercising the fail-fast wrapper
+ * and verifying the failure handler is invoked exactly once with the right cause.
+ */
+@ExtendWith(MockitoExtension.class)
+class PipelineOperatorAppTest {
+
+  @Mock
+  private K8sContext context;
+
+  // --- State guards ---
+
+  @Test
+  void stopIsNoOpWhenNeverStarted() {
+    PipelineOperatorApp app = new PipelineOperatorApp(context);
+
+    assertDoesNotThrow(() -> app.stop(Duration.ofSeconds(1)));
+  }
+
+  @Test
+  void awaitTerminationReturnsWhenNeverStarted() {
+    // Idle mode (empty controllers) and never-started both result in a null runnerThread;
+    // awaitTermination treats both as "nothing to wait for" and returns. This is the right
+    // call for the empty-controllers path because main() expects to exit cleanly there.
+    PipelineOperatorApp app = new PipelineOperatorApp(context);
+
+    assertDoesNotThrow(app::awaitTermination);
+  }
+
+  @Test
+  void installShutdownHookIsIdempotent() {
+    PipelineOperatorApp app = new PipelineOperatorApp(context);
+
+    app.installShutdownHook(Duration.ofSeconds(1));
+    assertDoesNotThrow(() -> app.installShutdownHook(Duration.ofSeconds(1)));
+  }
+
+  // --- Lifecycle (start/stop with a fake manager) ---
+
+  @Test
+  void startSpawnsRunnerThreadThatBlocksOnControllerManagerRun() throws Exception {
+    CountDownLatch runEntered = new CountDownLatch(1);
+    CountDownLatch shutdownSignal = new CountDownLatch(1);
+    ControllerManager fakeManager = newFakeManager(runEntered, shutdownSignal);
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, fakeManager, t -> { });
+    app.start(List.of(mock(Controller.class)));
+
+    assertTrue(runEntered.await(2, TimeUnit.SECONDS),
+        "ControllerManager.run() should have been invoked on the runner thread");
+
+    shutdownSignal.countDown();
+  }
+
+  @Test
+  void startIsIdempotentSecondCallDoesNotConstructAnotherManager() {
+    AtomicInteger constructionCount = new AtomicInteger(0);
+    CountDownLatch shutdownSignal = new CountDownLatch(1);
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, null, t -> { }) {
+      @Override
+      ControllerManager newControllerManager(SharedInformerFactory factory, Controller[] controllers) {
+        constructionCount.incrementAndGet();
+        return newFakeManager(new CountDownLatch(1), shutdownSignal);
+      }
+    };
+
+    Controller dummy = mock(Controller.class);
+    app.start(List.of(dummy));
+    app.start(List.of(dummy)); // should be a no-op
+
+    assertEquals(1, constructionCount.get(),
+        "second start() must not construct another ControllerManager");
+
+    shutdownSignal.countDown();
+  }
+
+  @Test
+  void stopShutsDownControllerManagerAndUnblocksAwaitTermination() throws Exception {
+    CountDownLatch runEntered = new CountDownLatch(1);
+    CountDownLatch shutdownSignal = new CountDownLatch(1);
+    ControllerManager fakeManager = newFakeManager(runEntered, shutdownSignal);
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, fakeManager, t -> { });
+    app.start(List.of(mock(Controller.class)));
+    assertTrue(runEntered.await(2, TimeUnit.SECONDS));
+
+    Thread waiter = new Thread(() -> {
+      try {
+        app.awaitTermination();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }, "test-await-waiter");
+    waiter.start();
+    Thread.sleep(50);
+    assertTrue(waiter.isAlive(), "awaitTermination() should still be blocking");
+
+    app.stop(Duration.ofSeconds(2));
+
+    verify(fakeManager).shutdown();
+    waiter.join(2_000);
+    assertFalse(waiter.isAlive(), "awaitTermination() should have unblocked after stop()");
+  }
+
+  @Test
+  void stopInterruptsRunnerThreadIfShutdownDoesNotWakeItWithinTimeout() throws Exception {
+    CountDownLatch runEntered = new CountDownLatch(1);
+    CountDownLatch unreachable = new CountDownLatch(1);
+    ControllerManager fakeManager = mock(ControllerManager.class);
+    doAnswer(inv -> {
+      runEntered.countDown();
+      try {
+        unreachable.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    }).when(fakeManager).run();
+    doAnswer(inv -> null).when(fakeManager).shutdown();
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, fakeManager, t -> { });
+    app.start(List.of(mock(Controller.class)));
+    assertTrue(runEntered.await(2, TimeUnit.SECONDS));
+
+    app.stop(Duration.ofMillis(100));
+
+    app.assertRunnerThreadTerminated(2_000);
+  }
+
+  @Test
+  void emptyControllerListPutsServiceInIdleMode() throws Exception {
+    // No controllers → no manager, no runner. stop() is a no-op; awaitTermination returns.
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, null, t -> { });
+
+    app.start(Collections.emptyList());
+    app.stop(Duration.ofSeconds(1));
+
+    long start = System.currentTimeMillis();
+    app.awaitTermination();
+    assertTrue(System.currentTimeMillis() - start < 500,
+        "awaitTermination() in idle mode should return immediately");
+  }
+
+  // --- Failure handling via callback ---
+
+  @Test
+  void runnerThreadCrashInvokesFailureHandler() throws Exception {
+    CountDownLatch handlerInvoked = new CountDownLatch(1);
+    AtomicReference<Throwable> received = new AtomicReference<>();
+    Consumer<Throwable> handler = cause -> {
+      received.set(cause);
+      handlerInvoked.countDown();
+    };
+
+    RuntimeException boom = new RuntimeException("boom");
+    ControllerManager fakeManager = mock(ControllerManager.class);
+    doThrow(boom).when(fakeManager).run();
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, fakeManager, handler);
+    app.start(List.of(mock(Controller.class)));
+
+    assertTrue(handlerInvoked.await(2, TimeUnit.SECONDS),
+        "failure handler should fire when the runner thread dies");
+    assertSame(boom, received.get());
+  }
+
+  @Test
+  void controllerCleanExitInvokesFailureHandlerWithNullCause() throws Exception {
+    // A controller's run() returns cleanly without anyone calling stop(). The
+    // wrapper observes the unexpected exit and reports failure with no captured throwable.
+    CountDownLatch handlerInvoked = new CountDownLatch(1);
+    AtomicReference<Throwable> received = new AtomicReference<>();
+    Consumer<Throwable> handler = cause -> {
+      received.set(cause);
+      handlerInvoked.countDown();
+    };
+
+    Controller quickExit = mock(Controller.class);
+    doNothing().when(quickExit).run();
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, null, handler) {
+      @Override
+      ControllerManager newControllerManager(SharedInformerFactory factory, Controller[] controllers) {
+        return interactiveFakeManager(controllers);
+      }
+    };
+
+    app.start(List.of(quickExit));
+
+    assertTrue(handlerInvoked.await(2, TimeUnit.SECONDS));
+    assertNull(received.get(), "clean exit should report null cause");
+  }
+
+  @Test
+  void controllerThrowingInvokesFailureHandlerWithCause() throws Exception {
+    CountDownLatch handlerInvoked = new CountDownLatch(1);
+    AtomicReference<Throwable> received = new AtomicReference<>();
+    Consumer<Throwable> handler = cause -> {
+      received.set(cause);
+      handlerInvoked.countDown();
+    };
+
+    Controller throwing = mock(Controller.class);
+    RuntimeException boom = new RuntimeException("controller boom");
+    doThrow(boom).when(throwing).run();
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, null, handler) {
+      @Override
+      ControllerManager newControllerManager(SharedInformerFactory factory, Controller[] controllers) {
+        return interactiveFakeManager(controllers);
+      }
+    };
+
+    app.start(List.of(throwing));
+
+    assertTrue(handlerInvoked.await(2, TimeUnit.SECONDS));
+    assertSame(boom, received.get(), "throwing controller should report the captured throwable");
+  }
+
+  @Test
+  void multipleControllerExitsFireHandlerOnlyOnce() throws Exception {
+    AtomicInteger handlerCalls = new AtomicInteger(0);
+    Consumer<Throwable> handler = cause -> handlerCalls.incrementAndGet();
+
+    Controller exit1 = mock(Controller.class);
+    Controller exit2 = mock(Controller.class);
+    doNothing().when(exit1).run();
+    doNothing().when(exit2).run();
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, null, handler) {
+      @Override
+      ControllerManager newControllerManager(SharedInformerFactory factory, Controller[] controllers) {
+        return interactiveFakeManager(controllers);
+      }
+    };
+
+    app.start(List.of(exit1, exit2));
+    app.awaitTermination();
+    Thread.sleep(50); // let any straggling wrappers finish
+
+    assertEquals(1, handlerCalls.get(),
+        "failure handler should fire at most once even when multiple controllers exit");
+  }
+
+  @Test
+  void stopSuppressesFailureHandler() throws Exception {
+    // When stop() is called, controller wrappers fire on the way out — but the handler must
+    // not be invoked because the exit was intentional.
+    AtomicInteger handlerCalls = new AtomicInteger(0);
+    Consumer<Throwable> handler = cause -> handlerCalls.incrementAndGet();
+
+    Controller longRunning = mock(Controller.class);
+    CountDownLatch holdLongRunning = new CountDownLatch(1);
+    doAnswer(inv -> {
+      holdLongRunning.await();
+      return null;
+    }).when(longRunning).run();
+
+    TestablePipelineOperatorApp app = new TestablePipelineOperatorApp(context, null, handler) {
+      @Override
+      ControllerManager newControllerManager(SharedInformerFactory factory, Controller[] controllers) {
+        return interactiveFakeManager(controllers);
+      }
+    };
+
+    app.start(List.of(longRunning));
+    Thread.sleep(50); // let the controller enter run()
+
+    // Release the long-running controller from a separate thread so it can exit cleanly
+    // after stop() flips stopRequested.
+    new Thread(holdLongRunning::countDown).start();
+    app.stop(Duration.ofSeconds(2));
+    Thread.sleep(50); // let the wrapper's finally block observe stopRequested
+
+    assertEquals(0, handlerCalls.get(),
+        "failure handler must not fire during intentional stop");
+  }
+
+  // --- Helpers ---
+
+  /**
+   * Builds a fake {@link ControllerManager} whose {@code run()} signals it entered, then blocks on
+   * {@code shutdownSignal} until released. {@code shutdown()} releases the signal so {@code run()}
+   * returns and the runner thread can exit naturally.
+   */
+  private static ControllerManager newFakeManager(CountDownLatch runEntered, CountDownLatch shutdownSignal) {
+    ControllerManager fake = mock(ControllerManager.class);
+    lenient().doAnswer(inv -> {
+      runEntered.countDown();
+      shutdownSignal.await();
+      return null;
+    }).when(fake).run();
+    lenient().doAnswer(inv -> {
+      shutdownSignal.countDown();
+      return null;
+    }).when(fake).shutdown();
+    return fake;
+  }
+
+  /**
+   * Builds a fake {@link ControllerManager} that actually invokes each controller's {@code run()}
+   * on a worker thread, mimicking the real upstream behavior. Returns from {@code run()} only
+   * once every controller has returned.
+   */
+  private static ControllerManager interactiveFakeManager(Controller[] controllers) {
+    ControllerManager fake = mock(ControllerManager.class);
+    lenient().doAnswer(inv -> {
+      ExecutorService pool = Executors.newCachedThreadPool();
+      try {
+        CountDownLatch latch = new CountDownLatch(controllers.length);
+        for (Controller c : controllers) {
+          pool.submit(() -> {
+            try {
+              c.run();
+            } catch (Throwable ignored) {
+              // upstream ControllerManager catches and logs; mirror that behavior so the latch
+              // still counts down and run() can return.
+            } finally {
+              latch.countDown();
+            }
+          });
+        }
+        latch.await();
+      } finally {
+        pool.shutdown();
+      }
+      return null;
+    }).when(fake).run();
+    lenient().doAnswer(inv -> null).when(fake).shutdown();
+    return fake;
+  }
+
+  /**
+   * Subclass that substitutes the seams so tests don't need a real K8s context. If
+   * {@code presetManager} is non-null, every {@link #newControllerManager} call returns it.
+   */
+  private static class TestablePipelineOperatorApp extends PipelineOperatorApp {
+    private final ControllerManager presetManager;
+
+    TestablePipelineOperatorApp(K8sContext context, ControllerManager presetManager,
+        Consumer<Throwable> failureHandler) {
+      super(context, failureHandler);
+      this.presetManager = presetManager;
+    }
+
+    @Override
+    List<Controller> buildControllers(List<Controller> initialControllers) {
+      return initialControllers;
+    }
+
+    @Override
+    ControllerManager newControllerManager(SharedInformerFactory factory, Controller[] controllers) {
+      return presetManager;
+    }
+
+    void assertRunnerThreadTerminated(long timeoutMillis) throws InterruptedException {
+      Thread waiter = new Thread(() -> {
+        try {
+          awaitTermination();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      });
+      waiter.setDaemon(true);
+      waiter.start();
+      waiter.join(timeoutMillis);
+      assertFalse(waiter.isAlive(), "runner thread should have terminated within " + timeoutMillis + "ms");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
                                                                                                                                                                                               
Restructures `PipelineOperatorApp` to support hosting under an external lifecycle (Spring,
Guava, etc.) without the caller having to spin up its own thread
to escape `ControllerManager.run()`'s indefinite `CountDownLatch.await()`. Adds explicit
detection for unexpected controller termination so callers can wire it to a liveness probe
and let the orchestrator handle restart/                                                                                                                                                     
                                                                                                                                                                                               
## Motivation                                                                                                                                                                                  
                                                                
The previous `run()` / `run(List<Controller>)` API blocks until shutdown because                                                                                                               
`ControllerManager.run()` parks on a `CountDownLatch`. That works fine for `main()` but
breaks any caller that owns the calling thread for lifecycle purposes. Concretely, hosting                                                                                                     
this in a Spring Boot `CommandLineRunner` either wedges the lifecycle thread or requires
the caller to manually offload the call.                                                                                                
                                                                                                                                                                                               
A second, related gap: when a controller's `run()` returns unexpectedly ("all" or "some"
controllers exiting silently), the manager catches the exit, logs, and                                                                                                      
keeps blocking. Nothing surfaces the failure to the caller. Frameworks like fabric8's                                                                                                          
java-operator-sdk and controller-runtime expose this so the orchestrator can restart the                                                                                                       
process; this PR adds the same hook here.
(Though maybe we should just migrate to fabric8 at some point?)
                                                                                                                                                                                               
## Backward compatibility                                                                                                                                                                         
 
This is a breaking change — run() and run(List<Controller>) are removed. The                                                                                                                   
in-tree main() was the only caller within this repo and is updated.                                                                                                                                
                                                                                                                                                                                               
## Testing
- Unit tests pass
- Stood up hoptimator-operator pod via `make deploy` and tested early termination cleanly shuts down the pod.