### PR TITLE
Support 3-part "CATALOG.SCHEMA.TABLE" identifier in CREATE TRIGGER

### DIFF
--- a/deploy/samples/demodb.yaml
+++ b/deploy/samples/demodb.yaml
@@ -12,6 +12,17 @@ spec:
 apiVersion: hoptimator.linkedin.com/v1alpha1
 kind: Database
 metadata:
+  name: ads-catalog-database
+spec:
+  catalog: ADS_CATALOG
+  url: jdbc:demodb://names=ads
+  dialect: Calcite
+
+---
+
+apiVersion: hoptimator.linkedin.com/v1alpha1
+kind: Database
+metadata:
   name: profile-database
 spec:
   schema: PROFILE

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTableTriggerTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTableTriggerTable.java
@@ -13,14 +13,16 @@ public class K8sTableTriggerTable extends K8sTable<V1alpha1TableTrigger, V1alpha
   // CHECKSTYLE:OFF
   public static class Row {
     public String NAME;
+    public String CATALOG;
     public String SCHEMA;
     public String TABLE;
     public Boolean PAUSED;
     public String TIMESTAMP;
     public String WATERMARK;
 
-    public Row(String name, String schema, String table, Boolean paused, String timestamp, String watermark) {
+    public Row(String name, String catalog, String schema, String table, Boolean paused, String timestamp, String watermark) {
       this.NAME = name;
+      this.CATALOG = catalog;
       this.SCHEMA = schema;
       this.TABLE = table;
       this.PAUSED = paused;
@@ -36,7 +38,7 @@ public class K8sTableTriggerTable extends K8sTable<V1alpha1TableTrigger, V1alpha
 
   @Override
   public Row toRow(V1alpha1TableTrigger obj) {
-    return new Row(obj.getMetadata().getName(), obj.getSpec().getSchema(), obj.getSpec().getTable(),
+    return new Row(obj.getMetadata().getName(), obj.getSpec().getCatalog(), obj.getSpec().getSchema(), obj.getSpec().getTable(),
         obj.getSpec().getPaused(),
         Optional.ofNullable(obj.getStatus())
             .flatMap(x -> Optional.ofNullable(x.getTimestamp()))

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployer.java
@@ -112,6 +112,7 @@ public class K8sTriggerDeployer extends K8sDeployer<V1alpha1TableTrigger, V1alph
         .with("schedule", trigger.cronSchedule())
         .with("table", source != null ? source.table() : null)
         .with("schema", source != null ? source.schema() : null)
+        .with("catalog", source != null ? source.catalog() : null)
         .with(properties);
     V1alpha1JobTemplate jobTemplate = jobTemplateApi.get(jobNamespace, jobName);
     V1ObjectMeta meta = new V1ObjectMeta().name(triggerName);
@@ -133,6 +134,7 @@ public class K8sTriggerDeployer extends K8sDeployer<V1alpha1TableTrigger, V1alph
       }
     });
     V1alpha1TableTriggerSpec spec = new V1alpha1TableTriggerSpec()
+        .catalog(source != null ? source.catalog() : null)
         .schema(source != null ? source.schema() : null)
         .table(source != null ? source.table() : null)
         .schedule(trigger.cronSchedule())

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTrigger.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTrigger.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Trigger for a specific table.
  */
 @ApiModel(description = "Trigger for a specific table.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
 public class V1alpha1TableTrigger implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * TableTriggerList is a list of TableTrigger
  */
 @ApiModel(description = "TableTriggerList is a list of TableTrigger")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
 public class V1alpha1TableTriggerList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerSpec.java
@@ -31,8 +31,12 @@ import java.util.Map;
  * TableTrigger spec.
  */
 @ApiModel(description = "TableTrigger spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
 public class V1alpha1TableTriggerSpec {
+  public static final String SERIALIZED_NAME_CATALOG = "catalog";
+  @SerializedName(SERIALIZED_NAME_CATALOG)
+  private String catalog;
+
   public static final String SERIALIZED_NAME_JOB_PROPERTIES = "jobProperties";
   @SerializedName(SERIALIZED_NAME_JOB_PROPERTIES)
   private Map<String, String> jobProperties = null;
@@ -56,6 +60,29 @@ public class V1alpha1TableTriggerSpec {
   public static final String SERIALIZED_NAME_YAML = "yaml";
   @SerializedName(SERIALIZED_NAME_YAML)
   private String yaml;
+
+
+  public V1alpha1TableTriggerSpec catalog(String catalog) {
+    
+    this.catalog = catalog;
+    return this;
+  }
+
+   /**
+   * The catalog the table belongs to, e.g. OPENHOUSE. Optional; present only for 3-part identifiers.
+   * @return catalog
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The catalog the table belongs to, e.g. OPENHOUSE. Optional; present only for 3-part identifiers.")
+
+  public String getCatalog() {
+    return catalog;
+  }
+
+
+  public void setCatalog(String catalog) {
+    this.catalog = catalog;
+  }
 
 
   public V1alpha1TableTriggerSpec jobProperties(Map<String, String> jobProperties) {
@@ -211,7 +238,8 @@ public class V1alpha1TableTriggerSpec {
       return false;
     }
     V1alpha1TableTriggerSpec v1alpha1TableTriggerSpec = (V1alpha1TableTriggerSpec) o;
-    return Objects.equals(this.jobProperties, v1alpha1TableTriggerSpec.jobProperties) &&
+    return Objects.equals(this.catalog, v1alpha1TableTriggerSpec.catalog) &&
+        Objects.equals(this.jobProperties, v1alpha1TableTriggerSpec.jobProperties) &&
         Objects.equals(this.paused, v1alpha1TableTriggerSpec.paused) &&
         Objects.equals(this.schedule, v1alpha1TableTriggerSpec.schedule) &&
         Objects.equals(this.schema, v1alpha1TableTriggerSpec.schema) &&
@@ -221,7 +249,7 @@ public class V1alpha1TableTriggerSpec {
 
   @Override
   public int hashCode() {
-    return Objects.hash(jobProperties, paused, schedule, schema, table, yaml);
+    return Objects.hash(catalog, jobProperties, paused, schedule, schema, table, yaml);
   }
 
 
@@ -229,6 +257,7 @@ public class V1alpha1TableTriggerSpec {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class V1alpha1TableTriggerSpec {\n");
+    sb.append("    catalog: ").append(toIndentedString(catalog)).append("\n");
     sb.append("    jobProperties: ").append(toIndentedString(jobProperties)).append("\n");
     sb.append("    paused: ").append(toIndentedString(paused)).append("\n");
     sb.append("    schedule: ").append(toIndentedString(schedule)).append("\n");

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerStatus.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * TableTrigger status.
  */
 @ApiModel(description = "TableTrigger status.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
 public class V1alpha1TableTriggerStatus {
   public static final String SERIALIZED_NAME_JOBS = "jobs";
   @SerializedName(SERIALIZED_NAME_JOBS)

--- a/hoptimator-k8s/src/main/resources/tabletriggers.crd.yaml
+++ b/hoptimator-k8s/src/main/resources/tabletriggers.crd.yaml
@@ -30,6 +30,9 @@ spec:
               description: TableTrigger spec.
               type: object
               properties:
+                catalog:
+                  description: The catalog the table belongs to, e.g. OPENHOUSE. Optional; present only for 3-part identifiers.
+                  type: string
                 schema:
                   description: The schema the table belongs to, e.g. KAFKA.
                   type: string
@@ -80,6 +83,10 @@ spec:
         type: boolean
         description: Whether trigger is paused.
         jsonPath: .spec.paused
+      - name: CATALOG
+        type: string
+        description: Catalog name.
+        jsonPath: .spec.catalog
       - name: SCHEMA
         type: string
         description: Schema name.

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployerTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sTriggerDeployerTest.java
@@ -523,6 +523,78 @@ class K8sTriggerDeployerTest {
         "super.update() must have run toK8sObject() — expected a CRD with spec.table='TABLE'");
   }
 
+  // ───────── toK8sObject() catalog rendering tests ─────────
+
+  @Test
+  void toK8sObjectSetsSpecCatalogForThreePartPath() throws SQLException {
+    // Scenario: CREATE TRIGGER ... ON openhouse.mydb.mytable — the source path has 3 elements,
+    // so source.catalog() returns "OPENHOUSE" and spec.catalog must be set.
+    V1alpha1JobTemplate jobTemplate = new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("myjob").namespace("test-ns"))
+        .spec(new V1alpha1JobTemplateSpec().yaml("template: {{name}}"));
+    jobTemplates.add(jobTemplate);
+
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "MY_JOB"), "0 * * * *",
+        Collections.emptyMap(),
+        new Source(null, Arrays.asList("OPENHOUSE", "MYDB", "MYTABLE"), Collections.emptyMap()),
+        null);
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    List<String> specs = deployer.specify();
+
+    assertFalse(specs.isEmpty());
+    assertTrue(specs.get(0).contains("catalog: OPENHOUSE"),
+        "spec.catalog=OPENHOUSE must be present in rendered YAML — got: " + specs.get(0));
+    assertTrue(specs.get(0).contains("schema: MYDB"),
+        "spec.schema=MYDB must be present — got: " + specs.get(0));
+    assertTrue(specs.get(0).contains("table: MYTABLE"),
+        "spec.table=MYTABLE must be present — got: " + specs.get(0));
+  }
+
+  @Test
+  void toK8sObjectOmitsSpecCatalogForTwoPartPath() throws SQLException {
+    // Scenario: CREATE TRIGGER ... ON ads.ad_clicks — the source path has 2 elements,
+    // so source.catalog() is null and spec.catalog must not appear in the rendered YAML.
+    V1alpha1JobTemplate jobTemplate = new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("myjob").namespace("test-ns"))
+        .spec(new V1alpha1JobTemplateSpec().yaml("template: {{name}}"));
+    jobTemplates.add(jobTemplate);
+
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "MY_JOB"), "0 * * * *",
+        Collections.emptyMap(),
+        new Source(null, Arrays.asList("ADS", "AD_CLICKS"), Collections.emptyMap()),
+        null);
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    List<String> specs = deployer.specify();
+
+    assertFalse(specs.isEmpty());
+    assertFalse(specs.get(0).contains("catalog:"),
+        "spec.catalog must not appear for a 2-part path — got: " + specs.get(0));
+  }
+
+  @Test
+  void toK8sObjectBindsCatalogAsTemplateVariable() throws SQLException {
+    // Verify {{catalog}} is bound in the template environment for 3-part paths.
+    V1alpha1JobTemplate jobTemplate = new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("myjob").namespace("test-ns"))
+        .spec(new V1alpha1JobTemplateSpec().yaml(
+            "fqn: {{catalog}}.{{schema}}.{{table}}"));
+    jobTemplates.add(jobTemplate);
+
+    Trigger trigger = new Trigger("MY_TRIGGER", new UserJob("test-ns", "MY_JOB"), "0 * * * *",
+        Collections.emptyMap(),
+        new Source(null, Arrays.asList("OPENHOUSE", "MYDB", "MYTABLE"), Collections.emptyMap()),
+        null);
+
+    K8sTriggerDeployer deployer = makeDeployer(trigger, mockContext);
+    List<String> specs = deployer.specify();
+
+    assertFalse(specs.isEmpty());
+    assertTrue(specs.get(0).contains("fqn: OPENHOUSE.MYDB.MYTABLE"),
+        "{{catalog}}.{{schema}}.{{table}} must render to OPENHOUSE.MYDB.MYTABLE — got: " + specs.get(0));
+  }
+
   // ───────── toK8sObject() paused rendering test ─────────
 
   @Test


### PR DESCRIPTION
## Summary
- `CREATE TRIGGER ... ON catalog.schema.table` now stores the catalog on the resulting `TableTrigger` CRD (new optional `spec.catalog` field).
- The catalog is also bound as `{{catalog}}` for JobTemplate rendering, alongside the existing `{{schema}}` and `{{table}}`.
- 2-part `ON schema.table` is unchanged — `spec.catalog` simply stays unset.

## Example

```sql
CREATE TRIGGER dummy_retl_trigger ON ads_catalog.ads.ad_clicks 
AS 'retl-job-template' IN 'default' 
WITH (
'offline.table.name' 'my-namespace.my-table',
'job.properties.online.table.name' 'MyOnlineTable'
);
```

```yaml
➜  ~ k get tabletriggers dummyretltrigger -oyaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: TableTrigger
metadata:
  ...
  name: dummyretltrigger
  namespace: default
  resourceVersion: "1851126"
  uid: 6394d2d2-8c7d-4cbc-998e-a43530ba2df4
spec:
  catalog: ADS_CATALOG
  jobProperties:
    online.table.name: MyOnlineTable
  schema: ADS
  table: AD_CLICKS
  yaml: |
    apiVersion: batch/v1
    kind: Job
    metadata:
      name: dummyretltrigger-retl-job-template-job
    spec:
      ...
```
----------------
```sql
CREATE TRIGGER dummy_retl_trigger ON ads.ad_clicks 
AS 'retl-job-template' IN 'default' 
WITH (
'offline.table.name' 'my-namespace.my-table',
'job.properties.online.table.name' 'MyOnlineTable'
);
```
```yaml
➜  ~ k get tabletriggers dummyretltrigger -oyaml
apiVersion: hoptimator.linkedin.com/v1alpha1
kind: TableTrigger
metadata:
  creationTimestamp: "2026-05-14T22:36:27Z"
  generation: 1
  labels:
    view: ads-adclicks
  name: dummyretltrigger
  namespace: default
  resourceVersion: "1851103"
  uid: a97b3b4d-8718-4fb0-8283-9827777a7151
spec:
  jobProperties:
    online.table.name: MyOnlineTable
  schema: ADS
  table: AD_CLICKS
  yaml: |
    apiVersion: batch/v1
    kind: Job
    metadata:
      name: dummyretltrigger-retl-job-template-job
    spec:
      ...
```