### PR TITLE
Add lastDeployedAt timestamp to SqlJob status

### DIFF
--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Database.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Database.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Database metadata.
  */
 @ApiModel(description = "Database metadata.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1Database implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * DatabaseList is a list of Database
  */
 @ApiModel(description = "DatabaseList is a list of Database")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1DatabaseList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1DatabaseSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Database spec.
  */
 @ApiModel(description = "Database spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1DatabaseSpec {
   public static final String SERIALIZED_NAME_CATALOG = "catalog";
   @SerializedName(SERIALIZED_NAME_CATALOG)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Engine.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Engine.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Engine metadata.
  */
 @ApiModel(description = "Engine metadata.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1Engine implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * EngineList is a list of Engine
  */
 @ApiModel(description = "EngineList is a list of Engine")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1EngineList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1EngineSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Engine spec.
  */
 @ApiModel(description = "Engine spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1EngineSpec {
   public static final String SERIALIZED_NAME_DATABASES = "databases";
   @SerializedName(SERIALIZED_NAME_DATABASES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplate.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplate.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Template to apply to matching jobs.
  */
 @ApiModel(description = "Template to apply to matching jobs.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1JobTemplate implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * JobTemplateList is a list of JobTemplate
  */
 @ApiModel(description = "JobTemplateList is a list of JobTemplate")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1JobTemplateList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1JobTemplateSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * JobTemplate spec.
  */
 @ApiModel(description = "JobTemplate spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1JobTemplateSpec {
   public static final String SERIALIZED_NAME_DATABASES = "databases";
   @SerializedName(SERIALIZED_NAME_DATABASES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTable.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTable.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Logical Table spanning multiple physical storage tiers.
  */
 @ApiModel(description = "Logical Table spanning multiple physical storage tiers.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1LogicalTable implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTableList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTableList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * LogicalTableList is a list of LogicalTable
  */
 @ApiModel(description = "LogicalTableList is a list of LogicalTable")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1LogicalTableList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTableSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTableSpec.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Desired logical table configuration.
  */
 @ApiModel(description = "Desired logical table configuration.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1LogicalTableSpec {
   public static final String SERIALIZED_NAME_TABLE_NAME = "tableName";
   @SerializedName(SERIALIZED_NAME_TABLE_NAME)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTableSpecTiers.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1LogicalTableSpecTiers.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * V1alpha1LogicalTableSpecTiers
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1LogicalTableSpecTiers {
   public static final String SERIALIZED_NAME_DATABASE = "database";
   @SerializedName(SERIALIZED_NAME_DATABASE)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Pipeline.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Pipeline.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * A set of objects that work together to deliver data.
  */
 @ApiModel(description = "A set of objects that work together to deliver data.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1Pipeline implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * PipelineList is a list of Pipeline
  */
 @ApiModel(description = "PipelineList is a list of Pipeline")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1PipelineList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Pipeline spec.
  */
 @ApiModel(description = "Pipeline spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1PipelineSpec {
   public static final String SERIALIZED_NAME_SQL = "sql";
   @SerializedName(SERIALIZED_NAME_SQL)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1PipelineStatus.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Pipeline status.
  */
 @ApiModel(description = "Pipeline status.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1PipelineStatus {
   public static final String SERIALIZED_NAME_FAILED = "failed";
   @SerializedName(SERIALIZED_NAME_FAILED)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJob.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJob.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator generic SQL job
  */
 @ApiModel(description = "Hoptimator generic SQL job")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1SqlJob implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SqlJobList is a list of SqlJob
  */
 @ApiModel(description = "SqlJobList is a list of SqlJob")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1SqlJobList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobSpec.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * SQL job spec
  */
 @ApiModel(description = "SQL job spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1SqlJobSpec {
   public static final String SERIALIZED_NAME_CONFIGS = "configs";
   @SerializedName(SERIALIZED_NAME_CONFIGS)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SqlJobStatus.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1SqlJobStatus {
   public static final String SERIALIZED_NAME_CONFIGS = "configs";
   @SerializedName(SERIALIZED_NAME_CONFIGS)
@@ -40,6 +40,10 @@ public class V1alpha1SqlJobStatus {
   public static final String SERIALIZED_NAME_FAILED = "failed";
   @SerializedName(SERIALIZED_NAME_FAILED)
   private Boolean failed;
+
+  public static final String SERIALIZED_NAME_LAST_DEPLOYED_AT = "lastDeployedAt";
+  @SerializedName(SERIALIZED_NAME_LAST_DEPLOYED_AT)
+  private Long lastDeployedAt;
 
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)
@@ -105,6 +109,29 @@ public class V1alpha1SqlJobStatus {
 
   public void setFailed(Boolean failed) {
     this.failed = failed;
+  }
+
+
+  public V1alpha1SqlJobStatus lastDeployedAt(Long lastDeployedAt) {
+    
+    this.lastDeployedAt = lastDeployedAt;
+    return this;
+  }
+
+   /**
+   * Epoch millis of the last deploy request the operator issued for this SqlJob.
+   * @return lastDeployedAt
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Epoch millis of the last deploy request the operator issued for this SqlJob.")
+
+  public Long getLastDeployedAt() {
+    return lastDeployedAt;
+  }
+
+
+  public void setLastDeployedAt(Long lastDeployedAt) {
+    this.lastDeployedAt = lastDeployedAt;
   }
 
 
@@ -188,6 +215,7 @@ public class V1alpha1SqlJobStatus {
     V1alpha1SqlJobStatus v1alpha1SqlJobStatus = (V1alpha1SqlJobStatus) o;
     return Objects.equals(this.configs, v1alpha1SqlJobStatus.configs) &&
         Objects.equals(this.failed, v1alpha1SqlJobStatus.failed) &&
+        Objects.equals(this.lastDeployedAt, v1alpha1SqlJobStatus.lastDeployedAt) &&
         Objects.equals(this.message, v1alpha1SqlJobStatus.message) &&
         Objects.equals(this.ready, v1alpha1SqlJobStatus.ready) &&
         Objects.equals(this.sql, v1alpha1SqlJobStatus.sql);
@@ -195,7 +223,7 @@ public class V1alpha1SqlJobStatus {
 
   @Override
   public int hashCode() {
-    return Objects.hash(configs, failed, message, ready, sql);
+    return Objects.hash(configs, failed, lastDeployedAt, message, ready, sql);
   }
 
 
@@ -205,6 +233,7 @@ public class V1alpha1SqlJobStatus {
     sb.append("class V1alpha1SqlJobStatus {\n");
     sb.append("    configs: ").append(toIndentedString(configs)).append("\n");
     sb.append("    failed: ").append(toIndentedString(failed)).append("\n");
+    sb.append("    lastDeployedAt: ").append(toIndentedString(lastDeployedAt)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    ready: ").append(toIndentedString(ready)).append("\n");
     sb.append("    sql: ").append(toIndentedString(sql)).append("\n");

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Subscription.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1Subscription.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Hoptimator Subscription
  */
 @ApiModel(description = "Hoptimator Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1Subscription implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * SubscriptionList is a list of Subscription
  */
 @ApiModel(description = "SubscriptionList is a list of Subscription")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1SubscriptionList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionSpec.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * Subscription spec
  */
 @ApiModel(description = "Subscription spec")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1SubscriptionSpec {
   public static final String SERIALIZED_NAME_DATABASE = "database";
   @SerializedName(SERIALIZED_NAME_DATABASE)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1SubscriptionStatus.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Filled in by the operator.
  */
 @ApiModel(description = "Filled in by the operator.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1SubscriptionStatus {
   public static final String SERIALIZED_NAME_ATTRIBUTES = "attributes";
   @SerializedName(SERIALIZED_NAME_ATTRIBUTES)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplate.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplate.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Template to apply to matching tables.
  */
 @ApiModel(description = "Template to apply to matching tables.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1TableTemplate implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * TableTemplateList is a list of TableTemplate
  */
 @ApiModel(description = "TableTemplateList is a list of TableTemplate")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1TableTemplateList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTemplateSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
  * TableTemplate spec.
  */
 @ApiModel(description = "TableTemplate spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1TableTemplateSpec {
   public static final String SERIALIZED_NAME_CONNECTOR = "connector";
   @SerializedName(SERIALIZED_NAME_CONNECTOR)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTrigger.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTrigger.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Trigger for a specific table.
  */
 @ApiModel(description = "Trigger for a specific table.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1TableTrigger implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * TableTriggerList is a list of TableTrigger
  */
 @ApiModel(description = "TableTriggerList is a list of TableTrigger")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1TableTriggerList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerSpec.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * TableTrigger spec.
  */
 @ApiModel(description = "TableTrigger spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1TableTriggerSpec {
   public static final String SERIALIZED_NAME_CATALOG = "catalog";
   @SerializedName(SERIALIZED_NAME_CATALOG)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1TableTriggerStatus.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * TableTrigger status.
  */
 @ApiModel(description = "TableTrigger status.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-14T22:46:35.638Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1TableTriggerStatus {
   public static final String SERIALIZED_NAME_JOBS = "jobs";
   @SerializedName(SERIALIZED_NAME_JOBS)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1View.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1View.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * A SQL view.
  */
 @ApiModel(description = "A SQL view.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1View implements io.kubernetes.client.common.KubernetesObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewList.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewList.java
@@ -32,7 +32,7 @@ import java.util.List;
  * ViewList is a list of View
  */
 @ApiModel(description = "ViewList is a list of View")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1ViewList implements io.kubernetes.client.common.KubernetesListObject {
   public static final String SERIALIZED_NAME_API_VERSION = "apiVersion";
   @SerializedName(SERIALIZED_NAME_API_VERSION)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewSpec.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewSpec.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * View spec.
  */
 @ApiModel(description = "View spec.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1ViewSpec {
   public static final String SERIALIZED_NAME_CATALOG = "catalog";
   @SerializedName(SERIALIZED_NAME_CATALOG)

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewStatus.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/models/V1alpha1ViewStatus.java
@@ -28,7 +28,7 @@ import java.time.OffsetDateTime;
 /**
  * V1alpha1ViewStatus
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-21T19:10:45.166Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-05-19T19:18:59.968Z[Etc/UTC]")
 public class V1alpha1ViewStatus {
   public static final String SERIALIZED_NAME_WATERMARK = "watermark";
   @SerializedName(SERIALIZED_NAME_WATERMARK)

--- a/hoptimator-k8s/src/main/resources/sqljobs.crd.yaml
+++ b/hoptimator-k8s/src/main/resources/sqljobs.crd.yaml
@@ -80,6 +80,10 @@ spec:
                   type: object
                   additionalProperties:
                     type: string
+                lastDeployedAt:
+                  description: Epoch millis of the last deploy request the operator issued for this SqlJob.
+                  type: integer
+                  format: int64
       subresources:
         status: {}
       additionalPrinterColumns:


### PR DESCRIPTION
## Summary

Adds an optional `status.lastDeployedAt` field (epoch millis, int64) to the `SqlJob` CRD. Operators that materialize SqlJobs can use this to track when they last issued a deploy for a given SqlJob — e.g., to drive a periodic re-deploy cycle.

The field is additive and optional; existing SqlJob objects and operators that don't read or write it are unaffected.

## Changes

- `hoptimator-k8s/src/main/resources/sqljobs.crd.yaml`: new `status.lastDeployedAt` property (`integer`, format `int64`).
- `V1alpha1SqlJobStatus.java` regenerated via `make generate-models`.

## Testing

- [x] `make generate-models` produces a clean diff with only `lastDeployedAt`
      additions on `V1alpha1SqlJobStatus`.
- [x] `make build && make install` succeeds.
- [x] `./gradlew publishToMavenLocal` succeeds; downstream consumer compiles
      and tests pass against the snapshot.