### PR TITLE
Add dry-run via `deploy=false` connection property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,9 @@ deploy-kafka: deploy deploy-flink
 	kubectl wait --for=condition=Established=True crds/kafkas.kafka.strimzi.io
 	kubectl apply -f ./deploy/samples/kafkadb.yaml
 	kubectl apply -f ./deploy/dev/kafka.yaml
-	kubectl wait kafka.kafka.strimzi.io/one --for=condition=Ready --timeout=10m -n kafka
-	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-1 --for=condition=Ready --timeout=10m
-	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-2 --for=condition=Ready --timeout=10m
+	kubectl wait kafka.kafka.strimzi.io/one --for=condition=Ready --timeout=15m -n kafka
+	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-1 --for=condition=Ready --timeout=15m
+	kubectl wait kafkatopic.kafka.strimzi.io/kafka-database-existing-topic-2 --for=condition=Ready --timeout=15m
 
 undeploy-kafka:
 	kubectl delete kafkatopic.kafka.strimzi.io --all || echo "skipping"

--- a/deploy/dev/kafka.yaml
+++ b/deploy/dev/kafka.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     strimzi.io/cluster: one
 spec:
-  replicas: 3
+  replicas: 1
   roles:
     - controller
   storage:
@@ -42,7 +42,7 @@ metadata:
   labels:
     strimzi.io/cluster: one
 spec:
-  replicas: 3
+  replicas: 1
   roles:
     - broker
   storage:

--- a/docs/user-guide/ddl-reference.md
+++ b/docs/user-guide/ddl-reference.md
@@ -73,7 +73,8 @@ and `DROP` removes its target from the in-memory schema so a follow-up
 `deploy=false` is orthogonal to `mode`: combining it with `mode=apply`
 dry-runs an apply-mode script.
 
-> Dry-run is distinct from `!specify` (and the underlying `SPECIFY` mode),
+> Dry-run is distinct from `!specify` (and the underlying `SPECIFY` mode;
+> see [CLI reference](sql-cli.md#specify-sql)),
 > which is the strict zero-side-effect preview used to render deployment
 > artifacts for a single statement. `!specify` always invokes
 > `deployer.specify()` and unwinds the in-memory schema afterward. Dry-run

--- a/docs/user-guide/ddl-reference.md
+++ b/docs/user-guide/ddl-reference.md
@@ -50,6 +50,36 @@ remains imperative and explicit. Detection of *incompatible* metadata changes
 `CREATE` and `CREATE OR REPLACE` apply the new definition regardless. Use
 caution when changing schemas of in-flight pipelines.
 
+## Dry-run: validating a script without deploying
+
+The `deploy` connection property toggles whether DDL actually touches the
+underlying deployers.
+
+| `deploy` value     | Behavior                                                                    |
+|--------------------|-----------------------------------------------------------------------------|
+| `true` (default)   | Normal operation. Each DDL invokes the deployers (create/update/delete).    |
+| `false`            | Dry-run. Each DDL is parsed, validated, and applied to the in-memory schema, but no deployer is invoked. |
+
+```
+jdbc:hoptimator://...;deploy=false
+```
+
+In dry-run mode, a session can execute a multi-statement script end-to-end —
+later statements see the in-memory effects of earlier ones (a `CREATE TABLE
+FOO` followed by `CREATE VIEW BAR AS SELECT * FROM FOO` validates correctly),
+and `DROP` removes its target from the in-memory schema so a follow-up
+`CREATE` of the same name doesn't collide. Nothing reaches the deployers.
+
+`deploy=false` is orthogonal to `mode`: combining it with `mode=apply`
+dry-runs an apply-mode script.
+
+> Dry-run is distinct from `!specify` (and the underlying `SPECIFY` mode),
+> which is the strict zero-side-effect preview used to render deployment
+> artifacts for a single statement. `!specify` always invokes
+> `deployer.specify()` and unwinds the in-memory schema afterward. Dry-run
+> preserves the in-memory mutation across statements and invokes no deployer
+> method at all.
+
 ## CREATE VIEW
 
 ```

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -154,11 +154,10 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       logger.info("Validated view {}", viewName);
       if (mode == HoptimatorDdlUtils.DdlMode.UPDATE) {
         logger.info("Deploying update view {}", viewName);
-        DeploymentService.update(deployers);
       } else {
         logger.info("Deploying create view {}", viewName);
-        DeploymentService.create(deployers);
       }
+      mode.executeDeployers(deployers, connection);
       logger.info("Deployed view {}", viewName);
       schemaPlus.add(viewName, viewTable);
       logger.info("Added view {} to schema {}", viewName, schemaPlus.getName());
@@ -243,11 +242,10 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       HoptimatorDdlUtils.DdlMode mode = HoptimatorDdlUtils.effectiveMode(create.getReplace(), connection);
       if (mode == HoptimatorDdlUtils.DdlMode.UPDATE) {
         logger.info("Updating trigger {}", name);
-        DeploymentService.update(deployers);
       } else {
         logger.info("Creating trigger {}", name);
-        DeploymentService.create(deployers);
       }
+      mode.executeDeployers(deployers, connection);
       logger.info("Deployed trigger {}", name);
       logger.info("CREATE TRIGGER {} completed", name);
     } catch (Exception e) {
@@ -336,7 +334,9 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
     try {
       logger.info("Firing trigger {} with {} option(s)", name, options.size() - 1);
       deployers = DeploymentService.deployers(trigger, connection);
-      DeploymentService.update(deployers);
+      if (!HoptimatorDdlUtils.isDryRun(connection)) {
+        DeploymentService.update(deployers);
+      }
       logger.info("FIRE TRIGGER {} completed", name);
     } catch (Exception e) {
       if (deployers != null) {
@@ -366,7 +366,9 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
     try {
       logger.info("Deleting trigger {}", name);
       deployers = DeploymentService.deployers(trigger, connection);
-      DeploymentService.delete(deployers);
+      if (!HoptimatorDdlUtils.isDryRun(connection)) {
+        DeploymentService.delete(deployers);
+      }
       logger.info("Deleted trigger {}", name);
       logger.info("DROP TRIGGER {} completed", name);
     } catch (Exception e) {
@@ -403,7 +405,9 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
     try {
       logger.info("Updating trigger {} with paused state: {}", name, paused);
       deployers = DeploymentService.deployers(trigger, connection);
-      DeploymentService.update(deployers);
+      if (!HoptimatorDdlUtils.isDryRun(connection)) {
+        DeploymentService.update(deployers);
+      }
       logger.info("Successfully updated trigger {} with paused state: {}", name, paused);
     } catch (Exception e) {
       if (deployers != null) {
@@ -460,7 +464,9 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         View view = new View(tablePath, materializedViewTable.viewSql());
         deployers = DeploymentService.deployers(view, connection);
         logger.info("Deleting materialized view {}", tableName);
-        DeploymentService.delete(deployers);
+        if (!HoptimatorDdlUtils.isDryRun(connection)) {
+          DeploymentService.delete(deployers);
+        }
         schemaPlus.removeTable(tableName);
         logger.info("Removed materialized table {} from schema {}", tableName, schemaPlus.getName());
       } else if (table instanceof ViewTable) {
@@ -472,7 +478,9 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         View view = new View(tablePath, viewTable.getViewSql());
         deployers = DeploymentService.deployers(view, connection);
         logger.info("Deleting view {}", tableName);
-        DeploymentService.delete(deployers);
+        if (!HoptimatorDdlUtils.isDryRun(connection)) {
+          DeploymentService.delete(deployers);
+        }
         schemaPlus.removeTable(tableName);
         logger.info("Removed view {} from schema {}", tableName, schemaPlus.getName());
       } else if (table instanceof HoptimatorJdbcTable || table instanceof TemporaryTable) {
@@ -495,7 +503,9 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         ValidationService.validateOrThrow(new PendingDelete<>(source), connection);
         deployers = DeploymentService.deployers(source, connection);
         logger.info("Deleting table {}", tableName);
-        DeploymentService.delete(deployers);
+        if (!HoptimatorDdlUtils.isDryRun(connection)) {
+          DeploymentService.delete(deployers);
+        }
         schemaPlus.removeTable(tableName);
         logger.info("Removed table {} from schema {}", tableName, schemaPlus.getName());
       } else {

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -152,13 +152,18 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       deployers = DeploymentService.deployers(view, connection);
       ValidationService.validateOrThrow(deployers, connection);
       logger.info("Validated view {}", viewName);
-      if (mode == HoptimatorDdlUtils.DdlMode.UPDATE) {
+      boolean dryRun = HoptimatorDdlUtils.isDryRun(connection);
+      if (dryRun) {
+        logger.info("Dry-run (deploy=false): skipping {} of view {}", mode, viewName);
+      } else if (mode == HoptimatorDdlUtils.DdlMode.UPDATE) {
         logger.info("Deploying update view {}", viewName);
       } else {
         logger.info("Deploying create view {}", viewName);
       }
       mode.executeDeployers(deployers, connection);
-      logger.info("Deployed view {}", viewName);
+      if (!dryRun) {
+        logger.info("Deployed view {}", viewName);
+      }
       schemaPlus.add(viewName, viewTable);
       logger.info("Added view {} to schema {}", viewName, schemaPlus.getName());
     } catch (SQLException | RuntimeException e) {
@@ -240,13 +245,18 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       ValidationService.validateOrThrow(deployers, connection);
       logger.info("Validated trigger {}", name);
       HoptimatorDdlUtils.DdlMode mode = HoptimatorDdlUtils.effectiveMode(create.getReplace(), connection);
-      if (mode == HoptimatorDdlUtils.DdlMode.UPDATE) {
+      boolean dryRun = HoptimatorDdlUtils.isDryRun(connection);
+      if (dryRun) {
+        logger.info("Dry-run (deploy=false): skipping {} of trigger {}", mode, name);
+      } else if (mode == HoptimatorDdlUtils.DdlMode.UPDATE) {
         logger.info("Updating trigger {}", name);
       } else {
         logger.info("Creating trigger {}", name);
       }
       mode.executeDeployers(deployers, connection);
-      logger.info("Deployed trigger {}", name);
+      if (!dryRun) {
+        logger.info("Deployed trigger {}", name);
+      }
       logger.info("CREATE TRIGGER {} completed", name);
     } catch (Exception e) {
       if (deployers != null) {
@@ -334,7 +344,9 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
     try {
       logger.info("Firing trigger {} with {} option(s)", name, options.size() - 1);
       deployers = DeploymentService.deployers(trigger, connection);
-      if (!HoptimatorDdlUtils.isDryRun(connection)) {
+      if (HoptimatorDdlUtils.isDryRun(connection)) {
+        logger.info("Dry-run (deploy=false): skipping fire of trigger {}", name);
+      } else {
         DeploymentService.update(deployers);
       }
       logger.info("FIRE TRIGGER {} completed", name);
@@ -364,12 +376,14 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
 
     Collection<Deployer> deployers = null;
     try {
-      logger.info("Deleting trigger {}", name);
       deployers = DeploymentService.deployers(trigger, connection);
-      if (!HoptimatorDdlUtils.isDryRun(connection)) {
+      if (HoptimatorDdlUtils.isDryRun(connection)) {
+        logger.info("Dry-run (deploy=false): skipping delete of trigger {}", name);
+      } else {
+        logger.info("Deleting trigger {}", name);
         DeploymentService.delete(deployers);
+        logger.info("Deleted trigger {}", name);
       }
-      logger.info("Deleted trigger {}", name);
       logger.info("DROP TRIGGER {} completed", name);
     } catch (Exception e) {
       if (deployers != null) {
@@ -403,12 +417,14 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
 
     Collection<Deployer> deployers = null;
     try {
-      logger.info("Updating trigger {} with paused state: {}", name, paused);
       deployers = DeploymentService.deployers(trigger, connection);
-      if (!HoptimatorDdlUtils.isDryRun(connection)) {
+      if (HoptimatorDdlUtils.isDryRun(connection)) {
+        logger.info("Dry-run (deploy=false): skipping update of trigger {} (paused state: {})", name, paused);
+      } else {
+        logger.info("Updating trigger {} with paused state: {}", name, paused);
         DeploymentService.update(deployers);
+        logger.info("Successfully updated trigger {} with paused state: {}", name, paused);
       }
-      logger.info("Successfully updated trigger {} with paused state: {}", name, paused);
     } catch (Exception e) {
       if (deployers != null) {
         DeploymentService.restore(deployers);
@@ -463,8 +479,10 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         MaterializedViewTable materializedViewTable = (MaterializedViewTable) table;
         View view = new View(tablePath, materializedViewTable.viewSql());
         deployers = DeploymentService.deployers(view, connection);
-        logger.info("Deleting materialized view {}", tableName);
-        if (!HoptimatorDdlUtils.isDryRun(connection)) {
+        if (HoptimatorDdlUtils.isDryRun(connection)) {
+          logger.info("Dry-run (deploy=false): skipping delete of materialized view {}", tableName);
+        } else {
+          logger.info("Deleting materialized view {}", tableName);
           DeploymentService.delete(deployers);
         }
         schemaPlus.removeTable(tableName);
@@ -477,8 +495,10 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         ViewTable viewTable = (ViewTable) table;
         View view = new View(tablePath, viewTable.getViewSql());
         deployers = DeploymentService.deployers(view, connection);
-        logger.info("Deleting view {}", tableName);
-        if (!HoptimatorDdlUtils.isDryRun(connection)) {
+        if (HoptimatorDdlUtils.isDryRun(connection)) {
+          logger.info("Dry-run (deploy=false): skipping delete of view {}", tableName);
+        } else {
+          logger.info("Deleting view {}", tableName);
           DeploymentService.delete(deployers);
         }
         schemaPlus.removeTable(tableName);
@@ -502,8 +522,10 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         // before any deployer-level state change.
         ValidationService.validateOrThrow(new PendingDelete<>(source), connection);
         deployers = DeploymentService.deployers(source, connection);
-        logger.info("Deleting table {}", tableName);
-        if (!HoptimatorDdlUtils.isDryRun(connection)) {
+        if (HoptimatorDdlUtils.isDryRun(connection)) {
+          logger.info("Dry-run (deploy=false): skipping delete of table {}", tableName);
+        } else {
+          logger.info("Deleting table {}", tableName);
           DeploymentService.delete(deployers);
         }
         schemaPlus.removeTable(tableName);

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
@@ -495,7 +495,10 @@ public final class HoptimatorDdlUtils {
       logger.info("Validated materialized view {}", viewName);
 
       // Execute (create/update) or collect specs (specify).
-      if (mode == DdlMode.UPDATE) {
+      boolean dryRun = mode.mutable() && isDryRun(conn);
+      if (dryRun) {
+        logger.info("Dry-run (deploy=false): skipping {} of materialized view {}", mode, viewName);
+      } else if (mode == DdlMode.UPDATE) {
         logger.info("Deploying update materialized view {}", viewName);
       } else if (mode == DdlMode.CREATE) {
         logger.info("Deploying create materialized view {}", viewName);
@@ -503,10 +506,12 @@ public final class HoptimatorDdlUtils {
         logger.info("Specifying materialized view {}", viewName);
       }
       List<String> specs = mode.executeDeployers(deployers, conn);
-      if (mode.mutable()) {
+      if (mode.mutable() && !dryRun) {
         logger.info("Deployed materialized view {}", viewName);
-      } else {
-        // SPECIFY (dry-run): roll back any side effects made by deployers during specify().
+      } else if (!mode.mutable()) {
+        // SPECIFY (single-statement preview): roll back any side effects made by deployers
+        // during specify(). Note: deploy=false dry-run does not touch deployers at all and
+        // therefore has nothing to restore.
         DeploymentService.restore(deployers);
       }
       success = true;
@@ -702,7 +707,10 @@ public final class HoptimatorDdlUtils {
       logger.info("Validating deployable resources for table {}", tableName);
       ValidationService.validateOrThrow(deployers, conn);
 
-      if (mode == DdlMode.UPDATE) {
+      boolean dryRun = mode.mutable() && isDryRun(conn);
+      if (dryRun) {
+        logger.info("Dry-run (deploy=false): skipping {} of table {}", mode, source);
+      } else if (mode == DdlMode.UPDATE) {
         logger.info("Deploying update table {}", source);
       } else if (mode == DdlMode.CREATE) {
         logger.info("Deploying create table {}", source);
@@ -710,10 +718,12 @@ public final class HoptimatorDdlUtils {
         logger.info("Specifying table {}", source);
       }
       List<String> specs = mode.executeDeployers(deployers, conn);
-      if (mode.mutable()) {
+      if (mode.mutable() && !dryRun) {
         logger.info("Deployed table {}", source);
-      } else {
-        // SPECIFY (dry-run): roll back any side effects made by deployers during specify()
+      } else if (!mode.mutable()) {
+        // SPECIFY (single-statement preview): roll back any side effects made by deployers
+        // during specify(). Note: deploy=false dry-run does not touch deployers at all and
+        // therefore has nothing to restore.
         DeploymentService.restore(deployers);
       }
       success = true;
@@ -779,10 +789,17 @@ public final class HoptimatorDdlUtils {
       deployers = DeploymentService.deployers(database, conn);
       ValidationService.validateOrThrow(deployers, conn);
 
+      boolean dryRun = mode.mutable() && isDryRun(conn);
+      if (dryRun) {
+        logger.info("Dry-run (deploy=false): skipping {} of database {}", mode, name);
+      }
       List<String> specs = mode.executeDeployers(deployers, conn);
-      if (mode.mutable()) {
+      if (mode.mutable() && !dryRun) {
         logger.info("Deployed database {}", name);
-      } else {
+      } else if (!mode.mutable()) {
+        // SPECIFY (single-statement preview): roll back any side effects made by deployers
+        // during specify(). Note: deploy=false dry-run does not touch deployers at all and
+        // therefore has nothing to restore.
         DeploymentService.restore(deployers);
       }
       return new SpecifyResult(specs, null, Collections.singletonList(name));

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
@@ -112,12 +112,41 @@ public final class HoptimatorDdlUtils {
   public static final String MODE_APPLY = "apply";
 
   /**
+   * Connection property that controls whether DDL statements actually deploy resources.
+   *
+   * <ul>
+   *   <li>{@code true} (default) — normal operation. Each DDL invokes the underlying
+   *       deployers (create/update/delete) to mutate external systems.</li>
+   *   <li>{@code false} — dry-run. Each DDL is parsed, validated, and applied to the
+   *       in-memory Calcite schema so subsequent statements in the same session can
+   *       reference it; the underlying deployers are <em>not</em> touched. Useful for
+   *       validating a multi-statement script end-to-end without producing side effects.</li>
+   * </ul>
+   *
+   * <p>Orthogonal to {@link #MODE_PROPERTY}: {@code mode=apply} + {@code deploy=false}
+   * dry-runs an apply-mode script.
+   *
+   * <p>Distinct from {@code SPECIFY} (the strict zero-side-effect path used by
+   * {@code !specify} and friends), which unwinds the in-memory schema and still invokes
+   * {@code deployer.specify()}. Dry-run preserves the in-memory mutation and does not
+   * invoke any deployer method.
+   *
+   * <p>Set per connection on the JDBC URL, e.g. {@code jdbc:hoptimator://...;deploy=false}
+   * — see {@code docs/user-guide/ddl-reference.md}.
+   */
+  public static final String DEPLOY_PROPERTY = "deploy";
+
+  /**
    * Resolves the effective {@link DdlMode} for a {@code CREATE} statement, combining the
    * statement's {@code OR REPLACE} flag with the connection's {@link #MODE_PROPERTY}.
    *
    * <p>In {@code create} mode (the default): {@code CREATE} → {@link DdlMode#CREATE} and
    * {@code CREATE OR REPLACE} → {@link DdlMode#UPDATE}. In {@code apply} mode: both forms
    * resolve to {@link DdlMode#UPDATE}, making CREATE idempotent.
+   *
+   * <p>Independent of {@link #DEPLOY_PROPERTY}: the returned mode is the same in dry-run
+   * and live runs, since dry-run is decided inside {@link DdlMode#executeDeployers} by
+   * consulting {@link #isDryRun}.
    */
   static DdlMode effectiveMode(boolean orReplace, HoptimatorConnection conn) {
     if (isApplyMode(conn)) {
@@ -134,6 +163,18 @@ public final class HoptimatorDdlUtils {
     }
     String mode = props.getProperty(MODE_PROPERTY, MODE_CREATE);
     return MODE_APPLY.equalsIgnoreCase(mode);
+  }
+
+  /** Whether the connection is configured for dry-run DDL (see {@link #DEPLOY_PROPERTY}). */
+  static boolean isDryRun(Connection conn) {
+    if (!(conn instanceof HoptimatorConnection)) {
+      return false;
+    }
+    Properties props = ((HoptimatorConnection) conn).connectionProperties();
+    if (props == null) {
+      return false;
+    }
+    return "false".equalsIgnoreCase(props.getProperty(DEPLOY_PROPERTY, "true"));
   }
 
   /**
@@ -160,14 +201,23 @@ public final class HoptimatorDdlUtils {
   }
 
   /**
-   * Controls whether a DDL operation performs a real deployment (CREATE or UPDATE)
-   * or a dry-run (SPECIFY).
+   * Controls how a {@code CREATE} statement is resolved against the connection's
+   * {@link #MODE_PROPERTY}.
+   *
+   * <p>{@code CREATE} maps to either {@link #CREATE} (strict) or {@link #UPDATE} (apply-mode
+   * convergence or explicit {@code CREATE OR REPLACE}). {@link #SPECIFY} is the strict
+   * zero-side-effect preview used by {@code !specify} and friends.
+   *
+   * <p>Dry-run (see {@link #DEPLOY_PROPERTY}) is orthogonal and resolved inline at each
+   * deployer call site by checking {@link #isDryRun}.
    */
   enum DdlMode {
     CREATE {
       @Override
       List<String> executeDeployers(Collection<Deployer> deployers, Connection conn) throws SQLException {
-        DeploymentService.create(deployers);
+        if (!isDryRun(conn)) {
+          DeploymentService.create(deployers);
+        }
         return Collections.emptyList();
       }
 
@@ -179,7 +229,9 @@ public final class HoptimatorDdlUtils {
     UPDATE {
       @Override
       List<String> executeDeployers(Collection<Deployer> deployers, Connection conn) throws SQLException {
-        DeploymentService.update(deployers);
+        if (!isDryRun(conn)) {
+          DeploymentService.update(deployers);
+        }
         return Collections.emptyList();
       }
 

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
@@ -178,6 +178,16 @@ public final class HoptimatorDdlUtils {
   }
 
   /**
+   * Whether deployment should be skipped for this mode + connection combination.
+   * Returns {@code true} only for mutable modes (CREATE/UPDATE) when the connection
+   * has {@code deploy=false}.  SPECIFY is never skipped — it renders specs as its
+   * primary purpose.
+   */
+  static boolean shouldSkipDeployment(DdlMode mode, Connection conn) {
+    return mode.mutable() && isDryRun(conn);
+  }
+
+  /**
    * The result of a {@link #specifyFromSql} call: the YAML artifact specs, the sink row type,
    * and the fully-qualified path of the sink (viewPath).
    *
@@ -495,7 +505,7 @@ public final class HoptimatorDdlUtils {
       logger.info("Validated materialized view {}", viewName);
 
       // Execute (create/update) or collect specs (specify).
-      boolean dryRun = mode.mutable() && isDryRun(conn);
+      boolean dryRun = shouldSkipDeployment(mode, conn);
       if (dryRun) {
         logger.info("Dry-run (deploy=false): skipping {} of materialized view {}", mode, viewName);
       } else if (mode == DdlMode.UPDATE) {
@@ -707,7 +717,7 @@ public final class HoptimatorDdlUtils {
       logger.info("Validating deployable resources for table {}", tableName);
       ValidationService.validateOrThrow(deployers, conn);
 
-      boolean dryRun = mode.mutable() && isDryRun(conn);
+      boolean dryRun = shouldSkipDeployment(mode, conn);
       if (dryRun) {
         logger.info("Dry-run (deploy=false): skipping {} of table {}", mode, source);
       } else if (mode == DdlMode.UPDATE) {
@@ -789,7 +799,7 @@ public final class HoptimatorDdlUtils {
       deployers = DeploymentService.deployers(database, conn);
       ValidationService.validateOrThrow(deployers, conn);
 
-      boolean dryRun = mode.mutable() && isDryRun(conn);
+      boolean dryRun = shouldSkipDeployment(mode, conn);
       if (dryRun) {
         logger.info("Dry-run (deploy=false): skipping {} of database {}", mode, name);
       }

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtilsTest.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtilsTest.java
@@ -59,7 +59,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 
@@ -1784,4 +1786,128 @@ class HoptimatorDdlUtilsTest {
 
     assertFalse(HoptimatorDdlUtils.isApplyMode(connectionWith(new Properties())));
   }
+
+  @Test
+  void testIsDryRunDefaultsToFalse() {
+    assertFalse(HoptimatorDdlUtils.isDryRun(connectionWith(new Properties())));
+  }
+
+  @Test
+  void testIsDryRunExplicitTrueDeploys() {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "true");
+    assertFalse(HoptimatorDdlUtils.isDryRun(connectionWith(props)));
+  }
+
+  @Test
+  void testIsDryRunFalseEnablesDryRun() {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "false");
+    assertTrue(HoptimatorDdlUtils.isDryRun(connectionWith(props)));
+  }
+
+  @Test
+  void testIsDryRunCaseInsensitive() {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "FALSE");
+    assertTrue(HoptimatorDdlUtils.isDryRun(connectionWith(props)));
+  }
+
+  @Test
+  void testIsDryRunUnknownValueIsLive() {
+    Properties props = new Properties();
+    // Anything that isn't "false" (case-insensitive) means deploy — typos shouldn't silently skip
+    // deployment.
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "nope");
+    assertFalse(HoptimatorDdlUtils.isDryRun(connectionWith(props)));
+  }
+
+  @Test
+  void testIsDryRunTolerantOfNullProperties() {
+    HoptimatorConnection conn = mock(HoptimatorConnection.class);
+    lenient().when(conn.connectionProperties()).thenReturn(null);
+    assertFalse(HoptimatorDdlUtils.isDryRun(conn));
+  }
+
+  @Test
+  void testIsDryRunFalseForNonHoptimatorConnection() {
+    // Plain java.sql.Connection — no HoptimatorConnection cast available — must be treated as
+    // live so non-Hoptimator code paths never accidentally suppress deployment.
+    assertFalse(HoptimatorDdlUtils.isDryRun(mock(java.sql.Connection.class)));
+  }
+
+  @Test
+  void testIsDryRunComposesWithApplyMode() {
+    // The two properties are orthogonal: mode=apply + deploy=false is "dry-run an apply script".
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.MODE_PROPERTY, HoptimatorDdlUtils.MODE_APPLY);
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "false");
+    HoptimatorConnection conn = connectionWith(props);
+    assertTrue(HoptimatorDdlUtils.isApplyMode(conn));
+    assertTrue(HoptimatorDdlUtils.isDryRun(conn));
+  }
+
+  @Test
+  void testDdlModeCreateInvokesDeployerWhenLive() throws SQLException {
+    HoptimatorConnection conn = connectionWith(new Properties());
+    List<Deployer> deployers = Collections.singletonList(mock(Deployer.class));
+
+    List<String> specs = HoptimatorDdlUtils.DdlMode.CREATE.executeDeployers(deployers, conn);
+
+    assertTrue(specs.isEmpty());
+    mockDeploymentService.verify(() -> DeploymentService.create(deployers), times(1));
+  }
+
+  @Test
+  void testDdlModeCreateSkipsDeployerWhenDryRun() throws SQLException {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "false");
+    HoptimatorConnection conn = connectionWith(props);
+    List<Deployer> deployers = Collections.singletonList(mock(Deployer.class));
+
+    List<String> specs = HoptimatorDdlUtils.DdlMode.CREATE.executeDeployers(deployers, conn);
+
+    assertTrue(specs.isEmpty());
+    mockDeploymentService.verify(() -> DeploymentService.create(deployers), never());
+  }
+
+  @Test
+  void testDdlModeUpdateInvokesDeployerWhenLive() throws SQLException {
+    HoptimatorConnection conn = connectionWith(new Properties());
+    List<Deployer> deployers = Collections.singletonList(mock(Deployer.class));
+
+    HoptimatorDdlUtils.DdlMode.UPDATE.executeDeployers(deployers, conn);
+
+    mockDeploymentService.verify(() -> DeploymentService.update(deployers), times(1));
+  }
+
+  @Test
+  void testDdlModeUpdateSkipsDeployerWhenDryRun() throws SQLException {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "false");
+    HoptimatorConnection conn = connectionWith(props);
+    List<Deployer> deployers = Collections.singletonList(mock(Deployer.class));
+
+    HoptimatorDdlUtils.DdlMode.UPDATE.executeDeployers(deployers, conn);
+
+    mockDeploymentService.verify(() -> DeploymentService.update(deployers), never());
+  }
+
+  @Test
+  void testDdlModeSpecifyAlwaysCallsSpecifyEvenInDryRun() throws SQLException {
+    // SPECIFY's contract is "render the specs with zero external side-effects", so it must
+    // call deployer.specify() regardless of the deploy property. Restore is handled by callers
+    // (see processCreateMaterializedView / Table / Database), keyed off !mode.mutable().
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "false");
+    HoptimatorConnection conn = connectionWith(props);
+    Deployer deployer = mock(Deployer.class);
+    doReturn(Arrays.asList("rendered: yes")).when(deployer).specify();
+
+    List<String> specs = HoptimatorDdlUtils.DdlMode.SPECIFY.executeDeployers(
+        Collections.singletonList(deployer), conn);
+
+    assertEquals(Arrays.asList("rendered: yes"), specs);
+  }
+
 }

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtilsTest.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtilsTest.java
@@ -1793,7 +1793,7 @@ class HoptimatorDdlUtilsTest {
   }
 
   @Test
-  void testIsDryRunExplicitTrueReturnsFalse() {
+  void testIsDryRunReturnsFalseWhenDeployIsTrue() {
     Properties props = new Properties();
     props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "true");
     assertFalse(HoptimatorDdlUtils.isDryRun(connectionWith(props)));

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtilsTest.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtilsTest.java
@@ -1793,7 +1793,7 @@ class HoptimatorDdlUtilsTest {
   }
 
   @Test
-  void testIsDryRunExplicitTrueDeploys() {
+  void testIsDryRunExplicitTrueReturnsFalse() {
     Properties props = new Properties();
     props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "true");
     assertFalse(HoptimatorDdlUtils.isDryRun(connectionWith(props)));
@@ -1834,6 +1834,31 @@ class HoptimatorDdlUtilsTest {
     // Plain java.sql.Connection — no HoptimatorConnection cast available — must be treated as
     // live so non-Hoptimator code paths never accidentally suppress deployment.
     assertFalse(HoptimatorDdlUtils.isDryRun(mock(java.sql.Connection.class)));
+  }
+
+  @Test
+  void testShouldSkipDeploymentTrueForMutableModeWithDryRun() {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "false");
+    HoptimatorConnection conn = connectionWith(props);
+    assertTrue(HoptimatorDdlUtils.shouldSkipDeployment(HoptimatorDdlUtils.DdlMode.CREATE, conn));
+    assertTrue(HoptimatorDdlUtils.shouldSkipDeployment(HoptimatorDdlUtils.DdlMode.UPDATE, conn));
+  }
+
+  @Test
+  void testShouldSkipDeploymentFalseForSpecifyMode() {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "false");
+    HoptimatorConnection conn = connectionWith(props);
+    assertFalse(HoptimatorDdlUtils.shouldSkipDeployment(HoptimatorDdlUtils.DdlMode.SPECIFY, conn));
+  }
+
+  @Test
+  void testShouldSkipDeploymentFalseWhenDeployTrue() {
+    Properties props = new Properties();
+    props.setProperty(HoptimatorDdlUtils.DEPLOY_PROPERTY, "true");
+    HoptimatorConnection conn = connectionWith(props);
+    assertFalse(HoptimatorDdlUtils.shouldSkipDeployment(HoptimatorDdlUtils.DdlMode.CREATE, conn));
   }
 
   @Test
@@ -1894,7 +1919,7 @@ class HoptimatorDdlUtilsTest {
   }
 
   @Test
-  void testDdlModeSpecifyAlwaysCallsSpecifyEvenInDryRun() throws SQLException {
+  void testDdlModeSpecifyIgnoresDryRunProperty() throws SQLException {
     // SPECIFY's contract is "render the specs with zero external side-effects", so it must
     // call deployer.specify() regardless of the deploy property. Restore is handled by callers
     // (see processCreateMaterializedView / Table / Database), keyed off !mode.mutable().


### PR DESCRIPTION
## Summary

 - New `deploy` connection property: when `deploy=false`, each DDL statement is parsed, validated, and
  applied to the in-memory Calcite schema, but the underlying deployers are **not** invoked. Lets a session
   validate a multi-statement script end-to-end (later statements see earlier ones' in-memory effects)
  without external side-effects.
 - Orthogonal to `mode`: combine `deploy=false` with `mode=apply` to dry-run an apply-mode script.
 - Distinct from `SPECIFY` (`!specify`), which remains the strict zero-side-effect single-statement
  preview that still invokes `deployer.specify()` and unwinds the in-memory schema afterward. Dry-run
  preserves the in-memory mutation across statements and invokes no deployer method at all.

## Details

 - `HoptimatorDdlUtils.isDryRun(Connection)` reads the `deploy` property (defaults to `true`/live).
 - `DdlMode.CREATE` and `DdlMode.UPDATE` branches gate the `DeploymentService.create/update` call on
  `isDryRun`; `SPECIFY` is unchanged.  - Imperative non-CREATE DDL paths (`DROP {TABLE, VIEW, MATERIALIZED VIEW, TRIGGER}`, `FIRE/PAUSE/RESUME
  TRIGGER`) use inline `if (!isDryRun(connection))` guards. These don't fit the `DdlMode` enum, which is
  about CREATE-statement semantics (strict vs. apply vs. preview).
 - `CREATE VIEW` and `CREATE TRIGGER` previously bypassed `DdlMode.executeDeployers` and called
  `DeploymentService.create/update` directly; routed through `mode.executeDeployers` to inherit the gating.

## Testing Done

```
0: Hoptimator> create view bar as select * from foo;
INFO Validating statement: CREATE VIEW `BAR` AS
SELECT *
FROM `FOO`
INFO Validated sql statement. The view is named BAR and has path [DEFAULT, BAR]
INFO Validating deployable resources for view BAR
INFO Validated view BAR
INFO Dry-run (deploy=false): skipping UPDATE of view BAR
INFO Added view BAR to schema DEFAULT
INFO CREATE VIEW BAR completed
No rows affected (0.212 seconds)
```

Notice the "dry run ... skipping" message in the logs.