### PR TITLE
Hardening: typed transient failures + required Deployer.exists()

### DIFF
--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ConnectorProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ConnectorProvider.java
@@ -1,10 +1,11 @@
 package com.linkedin.hoptimator;
 
+import java.sql.SQLException;
 import java.util.Collection;
 
 
 public interface ConnectorProvider {
 
   /** Find connectors capable of configuring data plane connectors for the obj. */
-  <T> Collection<Connector> connectors(T obj, DeploymentContext context);
+  <T> Collection<Connector> connectors(T obj, DeploymentContext context) throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployer.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/Deployer.java
@@ -17,12 +17,9 @@ public interface Deployer {
    * Whether the backing resource this deployer manages already exists. Used by the connection-free
    * direct path to enforce {@code CREATE} (not {@code OR REPLACE}) semantics — the SQL/DDL path
    * enforces the same thing via the Calcite catalog before deployers run, so this is not consulted
-   * there. Defaults to {@code false} (unknown/assume-absent) so deployers that do not implement it
-   * keep their existing behavior.
+   * there.
    */
-  default boolean exists() throws SQLException {
-    return false;
-  }
+  boolean exists() throws SQLException;
 
   /** Render a list of specs, usually YAML. */
   List<String> specify() throws SQLException;

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeployerProvider.java
@@ -1,12 +1,13 @@
 package com.linkedin.hoptimator;
 
+import java.sql.SQLException;
 import java.util.Collection;
 
 
 public interface DeployerProvider {
 
   /** Find deployers capable of deploying the obj. */
-  <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context);
+  <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) throws SQLException;
 
   /** A DeployerProvider with lower priority will execute first */
   int priority();

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeploymentContext.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/DeploymentContext.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator;
 
+import java.sql.SQLException;
 import java.util.Properties;
 
 import javax.annotation.Nullable;
@@ -44,5 +45,5 @@ public interface DeploymentContext {
    * @param connectionPrefix the expected URL scheme prefix (e.g. {@code "jdbc:kafka://"})
    */
   @Nullable Properties databaseProperties(@Nullable String catalog, @Nullable String schema,
-      String connectionPrefix);
+      String connectionPrefix) throws SQLException;
 }

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/ValidatorProvider.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/ValidatorProvider.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator;
 
+import java.sql.SQLException;
 import java.util.Collection;
 
 
@@ -8,5 +9,5 @@ public interface ValidatorProvider {
   /**
    * Returns validators that should be applied to {@code obj}.
    */
-  <T> Collection<Validator> validators(T obj, DeploymentContext context);
+  <T> Collection<Validator> validators(T obj, DeploymentContext context) throws SQLException;
 }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CalciteDeploymentContext.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/CalciteDeploymentContext.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.sql.SQLException;
 import java.util.Properties;
 
 import com.linkedin.hoptimator.DeploymentContext;
@@ -37,7 +38,7 @@ public final class CalciteDeploymentContext implements DeploymentContext {
 
   @Override
   public @Nullable Properties databaseProperties(@Nullable String catalog, @Nullable String schema,
-      String connectionPrefix) {
+      String connectionPrefix) throws SQLException {
     return DeployerUtils.extractPropertiesFromJdbcSchema(catalog, schema, connection, connectionPrefix);
   }
 }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DatabaseConfigResolver.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DatabaseConfigResolver.java
@@ -37,7 +37,7 @@ public interface DatabaseConfigResolver {
    * @param connectionPrefix the expected URL scheme prefix (e.g. {@code "jdbc:kafka://"})
    */
   @Nullable Properties databaseProperties(@Nullable String catalog, @Nullable String schema,
-      String connectionPrefix);
+      String connectionPrefix) throws SQLException;
 
   /**
    * Resolves the {@code database} identifier for a table at {@code tablePath} — the value exposed as

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DirectDeploymentContext.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DirectDeploymentContext.java
@@ -8,6 +8,7 @@ import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 
 import javax.annotation.Nullable;
+import java.sql.SQLException;
 import java.util.Properties;
 
 
@@ -79,7 +80,7 @@ public final class DirectDeploymentContext implements DeploymentContext {
 
   @Override
   public @Nullable Properties databaseProperties(@Nullable String catalog, @Nullable String schema,
-      String connectionPrefix) {
+      String connectionPrefix) throws SQLException {
     return databaseConfigResolver.databaseProperties(catalog, schema, connectionPrefix);
   }
 }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
@@ -72,6 +72,7 @@ import org.apache.calcite.util.Util;
 
 import javax.annotation.Nullable;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.util.ArrayList;
 import java.util.function.Consumer;
 import java.util.Arrays;
@@ -745,7 +746,7 @@ public final class HoptimatorDdlUtils {
       if (!manageCalciteSchema && mode == DdlMode.CREATE) {
         for (Deployer deployer : deployers) {
           if (deployer.exists()) {
-            throw new SQLException("Table " + tableName
+            throw new SQLNonTransientException("Table " + tableName
                 + " already exists. Set updateIfExists=true to update it.");
           }
         }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ValidationService.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/ValidationService.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 
 
 public final class ValidationService {
@@ -18,7 +17,7 @@ public final class ValidationService {
   private ValidationService() {
   }
 
-  public static <T> void validate(T obj, Validator.Issues issues, DeploymentContext context) {
+  public static <T> void validate(T obj, Validator.Issues issues, DeploymentContext context) throws SQLException {
     validators(obj, context).forEach(x -> x.validate(issues, context));
   }
 
@@ -47,7 +46,12 @@ public final class ValidationService {
     return providers;
   }
 
-  public static <T> Collection<Validator> validators(T obj, DeploymentContext context) {
-    return providers().stream().flatMap(x -> x.validators(obj, context).stream()).collect(Collectors.toList());
+  public static <T> Collection<Validator> validators(T obj, DeploymentContext context) throws SQLException {
+    // A loop (not a stream) so provider.validators() can propagate a checked SQLException.
+    List<Validator> validators = new ArrayList<>();
+    for (ValidatorProvider provider : providers()) {
+      validators.addAll(provider.validators(obj, context));
+    }
+    return validators;
   }
 }

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/DirectDeploymentContextTest.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/DirectDeploymentContextTest.java
@@ -4,6 +4,7 @@ import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
 
@@ -64,7 +65,7 @@ class DirectDeploymentContextTest {
   }
 
   @Test
-  void databasePropertiesDelegatesToResolver() {
+  void databasePropertiesDelegatesToResolver() throws SQLException {
     Properties dbProps = new Properties();
     dbProps.setProperty("bootstrap.servers", "localhost:9092");
     DirectDeploymentContext context =

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TableServiceTest.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/TableServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -148,7 +149,7 @@ class TableServiceTest {
 
     assertThatThrownBy(() -> TableService.create(new Properties(), Collections.emptyList(), path,
         recordSchema(), Collections.emptyMap(), false, false))
-        .isInstanceOf(SQLException.class)
+        .isInstanceOf(SQLNonTransientException.class)
         .hasMessageContaining("already exists");
 
     deployment.verify(() -> DeploymentService.create(any()), never());

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/ValidationServiceTest.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/ValidationServiceTest.java
@@ -42,7 +42,7 @@ class ValidationServiceTest {
    * record an error into issues. If the forEach call is removed, issues stays valid.
    */
   @Test
-  void testValidateObjIssuesInvokesValidators() {
+  void testValidateObjIssuesInvokesValidators() throws SQLException {
     ValidatorProviderTest.enableErrors();
     Validator.Issues issues = new Validator.Issues("test");
     ValidationService.validate("any-object", issues, null);
@@ -101,7 +101,7 @@ class ValidationServiceTest {
 
   // ValidatorProviderTest is registered and, when in error mode, returns a non-empty list.
   @Test
-  void testValidatorsReturnsValidatorsFromRegisteredProvider() {
+  void testValidatorsReturnsValidatorsFromRegisteredProvider() throws SQLException {
     ValidatorProviderTest.enableErrors();
     Collection<Validator> validators = ValidationService.validators("any-object", null);
     assertNotNull(validators);
@@ -116,13 +116,13 @@ class ValidationServiceTest {
   }
 
   @Test
-  void testValidatorsReturnsCollection() {
+  void testValidatorsReturnsCollection() throws SQLException {
     Collection<Validator> validators = ValidationService.validators("test-object", null);
     assertNotNull(validators);
   }
 
   @Test
-  void testValidatePopulatesIssues() {
+  void testValidatePopulatesIssues() throws SQLException {
     Validator.Issues issues = new Validator.Issues("test");
     ValidationService.validate("test-object", issues, null);
     assertNotNull(issues);

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sApi.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 
 public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> implements Api<T> {
@@ -36,6 +37,10 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     return endpoint;
   }
 
+  private <R> R call(String action, Supplier<R> request) throws SQLException {
+    return K8sUtils.normalizingCall(action, request);
+  }
+
   @Override
   public Collection<T> list() throws SQLException {
     return select(null);
@@ -44,22 +49,25 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
   public T get(String name) throws SQLException {
     final KubernetesApiResponse<T> resp;
     if (endpoint.clusterScoped()) {
-      resp = context.generic(endpoint).get(name);
+      resp = call("get " + endpoint().kind() + " " + name, () -> context.generic(endpoint).get(name));
     } else {
-      resp = context.generic(endpoint).get(context.namespace(), name);
+      resp = call("get " + endpoint().kind() + " " + name,
+          () -> context.generic(endpoint).get(context.namespace(), name));
     }
     K8sUtils.checkResponse("Error getting " + endpoint().kind() + " " + name, resp);
     return resp.getObject();
   }
 
   public T get(String namespace, String name) throws SQLException {
-    KubernetesApiResponse<T> resp = context.generic(endpoint).get(namespace, name);
+    KubernetesApiResponse<T> resp = call("get " + endpoint().kind() + " " + name,
+        () -> context.generic(endpoint).get(namespace, name));
     K8sUtils.checkResponse("Error getting " + endpoint().kind() + " " + name, resp);
     return resp.getObject();
   }
 
   public T getIfExists(String namespace, String name) throws SQLException {
-    KubernetesApiResponse<T> resp = context.generic(endpoint).get(namespace, name);
+    KubernetesApiResponse<T> resp = call("get " + endpoint().kind() + " " + name,
+        () -> context.generic(endpoint).get(namespace, name));
     if (resp.getHttpStatusCode() == 404) {
       return null;
     }
@@ -70,9 +78,10 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
   public T getIfExists(String name) throws SQLException {
     final KubernetesApiResponse<T> resp;
     if (endpoint.clusterScoped()) {
-      resp = context.generic(endpoint).get(name);
+      resp = call("get " + endpoint().kind() + " " + name, () -> context.generic(endpoint).get(name));
     } else {
-      resp = context.generic(endpoint).get(context.namespace(), name);
+      resp = call("get " + endpoint().kind() + " " + name,
+          () -> context.generic(endpoint).get(context.namespace(), name));
     }
     if (resp.getHttpStatusCode() == 404) {
       return null;
@@ -86,10 +95,12 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
       obj.getMetadata().namespace(context.namespace());
     }
     final KubernetesApiResponse<T> resp;
+    String name = obj.getMetadata().getName();
     if (endpoint.clusterScoped()) {
-      resp = context.generic(endpoint).get(obj.getMetadata().getName());
+      resp = call("get " + name, () -> context.generic(endpoint).get(name));
     } else {
-      resp  = context.generic(endpoint).get(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
+      resp = call("get " + name,
+          () -> context.generic(endpoint).get(obj.getMetadata().getNamespace(), name));
     }
     K8sUtils.checkResponse("Error getting " + obj.getMetadata().getName(), resp);
     return resp.getObject();
@@ -111,9 +122,9 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     options.setLabelSelector(labelSelector);
     final KubernetesApiResponse<U> resp;
     if (endpoint.clusterScoped()) {
-      resp = generic.list(options);
+      resp = call("list " + endpoint().kind(), () -> generic.list(options));
     } else {
-      resp = generic.list(context.namespace(), options);
+      resp = call("list " + endpoint().kind(), () -> generic.list(context.namespace(), options));
     }
     if (resp.getHttpStatusCode() == 404) {
       return Collections.emptyList();
@@ -128,7 +139,8 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
       obj.getMetadata().namespace(context.namespace());
     }
     context.own(obj);
-    KubernetesApiResponse<T> resp = context.generic(endpoint).create(obj);
+    KubernetesApiResponse<T> resp =
+        call("create " + obj.getMetadata().getName(), () -> context.generic(endpoint).create(obj));
     K8sUtils.checkResponse("Error creating " + obj.getMetadata().getName(), resp);
     log.info("Created K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
@@ -145,7 +157,7 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     DeleteOptions options = new DeleteOptions();
     options.setPropagationPolicy("Background");   // ensure deletes cascade
     KubernetesApiResponse<T> resp =
-        context.generic(endpoint).delete(namespace, name, options);
+        call("delete " + name, () -> context.generic(endpoint).delete(namespace, name, options));
     K8sUtils.checkResponse("Error deleting " + name, resp);
     log.info("Deleted K8s obj: {}:{}", endpoint.kind(), name);
   }
@@ -161,9 +173,11 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     }
     final KubernetesApiResponse<T> existing;
     if (endpoint.clusterScoped()) {
-      existing = context.generic(endpoint).get(obj.getMetadata().getName());
+      existing = call("get " + obj.getMetadata().getName(),
+          () -> context.generic(endpoint).get(obj.getMetadata().getName()));
     } else {
-      existing = context.generic(endpoint).get(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
+      existing = call("get " + obj.getMetadata().getName(),
+          () -> context.generic(endpoint).get(obj.getMetadata().getNamespace(), obj.getMetadata().getName()));
     }
     final KubernetesApiResponse<T> resp;
     if (existing.isSuccess()) {
@@ -198,10 +212,10 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
 
       obj.getMetadata().resourceVersion(existing.getObject().getMetadata().getResourceVersion());
       context.own(obj);
-      resp = context.generic(endpoint).update(obj);
+      resp = call("update " + obj.getMetadata().getName(), () -> context.generic(endpoint).update(obj));
     } else {
       context.own(obj);
-      resp = context.generic(endpoint).create(obj);
+      resp = call("create " + obj.getMetadata().getName(), () -> context.generic(endpoint).create(obj));
     }
     K8sUtils.checkResponse("Error updating " + obj.getMetadata().getName(), resp);
     log.info("Updated K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
@@ -211,7 +225,9 @@ public class K8sApi<T extends KubernetesObject, U extends KubernetesListObject> 
     if (obj.getMetadata().getNamespace() == null && !endpoint.clusterScoped()) {
       obj.getMetadata().namespace(context.namespace());
     }
-    KubernetesApiResponse<T> resp = context.generic(endpoint).updateStatus(obj, x -> status);
+    KubernetesApiResponse<T> resp =
+        call("update status of " + obj.getMetadata().getName(),
+            () -> context.generic(endpoint).updateStatus(obj, x -> status));
     K8sUtils.checkResponse(() -> "Error updating status of " + Yaml.dump(obj), resp);
     log.info("Updated K8s obj status: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDatabaseConfigResolver.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sDatabaseConfigResolver.java
@@ -40,20 +40,14 @@ public final class K8sDatabaseConfigResolver implements DatabaseConfigResolver {
 
   @Override
   public @Nullable Properties databaseProperties(@Nullable String catalog, @Nullable String schema,
-      String connectionPrefix) {
+      String connectionPrefix) throws SQLException {
     if (catalog == null && schema == null) {
       return null;
     }
-    K8sDatabaseTable.Row row;
-    try {
-      row = findDatabase(catalog, schema);
-    } catch (SQLException e) {
-      // Fail loudly rather than returning null: the deployer providers treat a null here as "no
-      // config for this store" and deploy nothing, which would report success while a K8s error
-      // meant we never figured out what to deploy. The SPI signature can't throw, so wrap it.
-      throw new IllegalStateException("Failed to resolve Database config for "
-          + (catalog != null ? catalog : schema) + ": " + e.getMessage(), e);
-    }
+    // findDatabase may throw a typed SQLException (transient/non-transient) on a K8s failure; let it
+    // propagate. Returning null here means "no Database matched", which the deployer providers treat
+    // as "no config for this store" — so a swallowed error would deploy nothing and report success.
+    K8sDatabaseTable.Row row = findDatabase(catalog, schema);
     if (row == null || row.URL == null || !row.URL.startsWith(connectionPrefix)) {
       return null;
     }
@@ -111,9 +105,10 @@ public final class K8sDatabaseConfigResolver implements DatabaseConfigResolver {
   private List<K8sDatabaseTable.Row> listDatabases() throws SQLException {
     if (cachedDatabases == null) {
       List<K8sDatabaseTable.Row> rows = new ArrayList<>();
-      // No catch: a failed list must surface (see databaseName/databaseProperties) rather than be
-      // swallowed into an empty list that reads as "no Databases". cachedDatabases stays null on
-      // failure, so it is not cached and a transient error can recover on the next call.
+      // A failed list must surface (see databaseName/databaseProperties) rather than be swallowed
+      // into an empty list that reads as "no Databases". K8sApi normalizes connectivity failures to
+      // a typed SQLTransientException, so a transient error propagates (and, because cachedDatabases
+      // stays null on failure, is not cached) and can recover on the next call.
       for (V1alpha1Database db : new K8sApi<>(context, K8sApiEndpoints.DATABASES).list()) {
         rows.add(K8sDatabaseTable.rowOf(db));
       }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
@@ -77,6 +77,14 @@ class K8sMaterializedViewDeployer implements Deployer {
   }
 
   @Override
+  public boolean exists() throws SQLException {
+    // The materialized view's identity is its View CRD; the Pipeline and its elements cascade from it.
+    synchronized (crudLock) {
+      return viewDeployer.exists();
+    }
+  }
+
+  @Override
   public void restore() {
     synchronized (crudLock) {
       // There may be a scenario where a view creates multiple pipelines.

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineBundle.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineBundle.java
@@ -62,6 +62,12 @@ public class K8sPipelineBundle implements Deployer {
   }
 
   @Override
+  public boolean exists() throws SQLException {
+    // The bundle's identity is its Pipeline CRD; the owned YAML elements cascade from it.
+    return pipelineDeployer.exists();
+  }
+
+  @Override
   public void update() throws SQLException {
     deployers.add(pipelineDeployer);
     V1OwnerReference pipelineRef = pipelineDeployer.updateAndReference();

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sUtils.java
@@ -8,6 +8,7 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
 import java.sql.SQLTransientException;
@@ -92,18 +93,53 @@ public final class K8sUtils {
     checkResponse(() -> msg, resp);
   }
 
+  /**
+   * Executes a Kubernetes client call, normalizing an unchecked connectivity failure into a typed
+   * {@link SQLException}.
+   *
+   * <p>The Kubernetes client reports a genuine connectivity failure (connection refused, unknown
+   * host, socket timeout) as an unchecked {@link IllegalStateException} wrapping an
+   * {@link IOException}, thrown from the terminal {@code generic()/dynamic().get/list/create/delete/
+   * update} call — HTTP-status errors (404, 409, ...) instead come back in the response and are
+   * classified by {@link #checkResponse}. Left unchecked, the connectivity failure would escape the
+   * {@link SQLException} contract as an unclassified error, and — worse — a swallowed read could
+   * report success while nothing was actually resolved or deployed. Every backend call (in
+   * {@link K8sApi} and {@link K8sYamlApi} alike) routes through here so all SPIs get a uniform
+   * classification: an IOException-caused failure is a {@link SQLTransientException} (a retryable
+   * connectivity blip); any other {@link IllegalStateException} is surfaced as a
+   * {@link SQLNonTransientException} rather than being masked as retryable.
+   */
+  static <R> R normalizingCall(String action, Supplier<R> request) throws SQLException {
+    try {
+      return request.get();
+    } catch (IllegalStateException e) {
+      if (e.getCause() instanceof IOException) {
+        throw new SQLTransientException("Could not reach Kubernetes to " + action + ": " + e.getMessage(), e);
+      }
+      throw new SQLNonTransientException("Kubernetes call failed to " + action + ": " + e.getMessage(), e);
+    }
+  }
+
   static void checkResponse(Supplier<String> msgSupplier, KubernetesApiResponse<?> resp) throws SQLException {
     try {
       resp.throwsApiException();
     } catch (ApiException e) {
       switch (resp.getHttpStatusCode()) {
-      case 404: // not found
-      case 408: // timeout
-      case 409: // conflict
-      case 410: // gone
+      case 408: // request timeout
+      case 409: // conflict (e.g. optimistic-concurrency resourceVersion clash)
+      case 410: // gone (stale resourceVersion)
       case 412: // precondition failed
+      case 429: // too many requests (rate limited)
+      case 500: // internal server error
+      case 502: // bad gateway
+      case 503: // service unavailable
+      case 504: // gateway timeout
+        // Retryable: server-side or optimistic-concurrency failures that may succeed on retry.
         throw new SQLTransientException(msgSupplier.get(), null, resp.getHttpStatusCode(), e);
       default:
+        // Definitive client errors (e.g. 404 not found, 400 bad request, 403 forbidden): the
+        // request won't succeed on retry, so surface a non-transient error rather than masking it
+        // as retryable.
         throw new SQLNonTransientException(msgSupplier.get(), null, resp.getHttpStatusCode(), e);
       }
     }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sYamlApi.java
@@ -38,9 +38,10 @@ public class K8sYamlApi implements Api<String> {
   }
 
   public DynamicKubernetesObject getIfExists(DynamicKubernetesObject obj) throws SQLException {
-    KubernetesApiResponse<DynamicKubernetesObject> resp =
-        context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).get(obj.getMetadata().getNamespace(),
-            obj.getMetadata().getName());
+    KubernetesApiResponse<DynamicKubernetesObject> resp = K8sUtils.normalizingCall(
+        "get " + obj.getKind() + " " + obj.getMetadata().getName(),
+        () -> context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).get(obj.getMetadata().getNamespace(),
+            obj.getMetadata().getName()));
     if (resp.getHttpStatusCode() == 404) {
       return null;
     }
@@ -79,8 +80,9 @@ public class K8sYamlApi implements Api<String> {
       Map<String, String> labels, List<V1OwnerReference> ownerReferences) throws SQLException {
     obj.setMetadata(obj.getMetadata().annotations(annotations).labels(labels).ownerReferences(ownerReferences));
     context.own(obj);
-    KubernetesApiResponse<DynamicKubernetesObject> resp =
-        context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj);
+    KubernetesApiResponse<DynamicKubernetesObject> resp = K8sUtils.normalizingCall(
+        "create " + obj.getKind() + " " + obj.getMetadata().getName(),
+        () -> context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj));
     K8sUtils.checkResponse(String.format("Error creating K8s obj: %s:%s", obj.getKind(), obj.getMetadata().getName()), resp);
     log.info("Created K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());
   }
@@ -96,8 +98,9 @@ public class K8sYamlApi implements Api<String> {
   }
 
   public void delete(String apiVersion, String kind, String namespace, String name) throws SQLException {
-    KubernetesApiResponse<DynamicKubernetesObject> resp =
-        context.dynamic(apiVersion, K8sUtils.guessPlural(kind)).delete(namespace, name);
+    KubernetesApiResponse<DynamicKubernetesObject> resp = K8sUtils.normalizingCall(
+        "delete " + kind + " " + name,
+        () -> context.dynamic(apiVersion, K8sUtils.guessPlural(kind)).delete(namespace, name));
     K8sUtils.checkResponse(String.format("Error getting K8s obj: %s:%s", kind, name), resp);
     log.info("Deleted K8s obj: {}:{}", kind, name);
   }
@@ -109,9 +112,10 @@ public class K8sYamlApi implements Api<String> {
   }
 
   public void update(DynamicKubernetesObject obj) throws SQLException {
-    KubernetesApiResponse<DynamicKubernetesObject> existing =
-        context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj))
-            .get(obj.getMetadata().getNamespace(), obj.getMetadata().getName());
+    KubernetesApiResponse<DynamicKubernetesObject> existing = K8sUtils.normalizingCall(
+        "get " + obj.getKind() + " " + obj.getMetadata().getName(),
+        () -> context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj))
+            .get(obj.getMetadata().getNamespace(), obj.getMetadata().getName()));
     final KubernetesApiResponse<DynamicKubernetesObject> resp;
     if (existing.isSuccess()) {
 
@@ -135,10 +139,14 @@ public class K8sYamlApi implements Api<String> {
       existing.getObject().getMetadata().setAnnotations(annotations);
 
       obj.setMetadata(existing.getObject().getMetadata());
-      resp = context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).update(obj);
+      resp = K8sUtils.normalizingCall(
+          "update " + obj.getKind() + " " + obj.getMetadata().getName(),
+          () -> context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).update(obj));
     } else {
       context.own(obj);
-      resp = context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj);
+      resp = K8sUtils.normalizingCall(
+          "create " + obj.getKind() + " " + obj.getMetadata().getName(),
+          () -> context.dynamic(obj.getApiVersion(), K8sUtils.guessPlural(obj)).create(obj));
     }
     K8sUtils.checkResponse(String.format("Error updating K8s obj: %s:%s", obj.getKind(), obj.getMetadata().getName()), resp);
     log.info("Updated K8s obj: {}:{}", obj.getKind(), obj.getMetadata().getName());

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sApiTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sApiTest.java
@@ -18,7 +18,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,6 +34,8 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -231,6 +238,64 @@ class K8sApiTest {
     api.delete("name");
 
     verify(mockGenericApi).delete(eq("test-ns"), eq("name"), any(DeleteOptions.class));
+  }
+
+  @Test
+  void listNormalizesConnectivityFailureToTransient() {
+    IllegalStateException connectivityFailure =
+        new IllegalStateException(new SocketTimeoutException("Connect timed out"));
+    when(mockGenericApi.list(eq("test-ns"), any(ListOptions.class))).thenThrow(connectivityFailure);
+
+    SQLTransientException thrown = assertThrows(SQLTransientException.class, () -> api.list());
+
+    assertSame(connectivityFailure, thrown.getCause());
+  }
+
+  @Test
+  void getNormalizesConnectivityFailureToTransient() {
+    IllegalStateException connectivityFailure =
+        new IllegalStateException(new UnknownHostException("k8s.invalid"));
+    when(mockGenericApi.get(eq("test-ns"), eq("my-pipeline"))).thenThrow(connectivityFailure);
+
+    SQLTransientException thrown = assertThrows(SQLTransientException.class, () -> api.get("my-pipeline"));
+
+    assertSame(connectivityFailure, thrown.getCause());
+  }
+
+  @Test
+  void createNormalizesConnectivityFailureToTransient() {
+    V1alpha1Pipeline pipeline = makePipeline("new-pipeline", "test-ns");
+    IllegalStateException connectivityFailure =
+        new IllegalStateException(new ConnectException("Connection refused"));
+    when(mockGenericApi.create(any(V1alpha1Pipeline.class))).thenThrow(connectivityFailure);
+
+    SQLTransientException thrown = assertThrows(SQLTransientException.class, () -> api.create(pipeline));
+
+    assertSame(connectivityFailure, thrown.getCause());
+  }
+
+  @Test
+  void deleteNormalizesConnectivityFailureToTransient() {
+    IllegalStateException connectivityFailure =
+        new IllegalStateException(new ConnectException("Connection refused"));
+    when(mockGenericApi.delete(eq("test-ns"), eq("name"), any(DeleteOptions.class)))
+        .thenThrow(connectivityFailure);
+
+    SQLTransientException thrown = assertThrows(SQLTransientException.class, () -> api.delete("name"));
+
+    assertSame(connectivityFailure, thrown.getCause());
+  }
+
+  @Test
+  void nonIoIllegalStateIsClassifiedNonTransient() {
+    // An IllegalStateException NOT wrapping an IOException is not a known-retryable connectivity
+    // failure, so it must surface as non-transient rather than being masked as retryable.
+    IllegalStateException notConnectivity = new IllegalStateException("unexpected client state");
+    when(mockGenericApi.list(eq("test-ns"), any(ListOptions.class))).thenThrow(notConnectivity);
+
+    SQLNonTransientException thrown = assertThrows(SQLNonTransientException.class, () -> api.list());
+
+    assertSame(notConnectivity, thrown.getCause());
   }
 
   @Test

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sDatabaseConfigResolverTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sDatabaseConfigResolverTest.java
@@ -11,6 +11,7 @@ import io.kubernetes.client.util.generic.options.ListOptions;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
+import java.sql.SQLTransientException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
@@ -77,12 +78,12 @@ class K8sDatabaseConfigResolverTest {
   }
 
   @Test
-  void databasePropertiesReturnsNullWhenNoCatalogOrSchema() {
+  void databasePropertiesReturnsNullWhenNoCatalogOrSchema() throws Exception {
     assertThat(resolver().databaseProperties(null, null, "jdbc:kafka://")).isNull();
   }
 
   @Test
-  void databasePropertiesParsesUrlForSchemaStyleDatabase() {
+  void databasePropertiesParsesUrlForSchemaStyleDatabase() throws Exception {
     V1alpha1Database kafka = db("kafka-database",
         "jdbc:kafka://bootstrap.servers=localhost:9092", null, "KAFKA");
 
@@ -95,7 +96,7 @@ class K8sDatabaseConfigResolverTest {
   }
 
   @Test
-  void databasePropertiesReturnsNullWhenUrlDoesNotMatchPrefix() {
+  void databasePropertiesReturnsNullWhenUrlDoesNotMatchPrefix() throws Exception {
     V1alpha1Database venice = db("venice", "jdbc:venice://clusters=venice-cluster0", null, "VENICE");
 
     // Database exists for VENICE but the requested prefix is a different store type.
@@ -103,7 +104,7 @@ class K8sDatabaseConfigResolverTest {
   }
 
   @Test
-  void databasePropertiesReturnsNullWhenNoDatabaseMatches() {
+  void databasePropertiesReturnsNullWhenNoDatabaseMatches() throws Exception {
     assertThat(resolver().databaseProperties(null, "MISSING", "jdbc:kafka://")).isNull();
   }
 
@@ -147,9 +148,27 @@ class K8sDatabaseConfigResolverTest {
     K8sDatabaseConfigResolver resolver = new K8sDatabaseConfigResolver(new Properties(), contextWithListFailure());
 
     // Must fail loudly rather than returning null (which reads as "no config, deploy nothing").
+    // A 500 from the API surfaces as a (non-transient) SQLException.
     assertThatThrownBy(() -> resolver.databaseProperties(null, "KAFKA", "jdbc:kafka://"))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Failed to resolve Database config");
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  void listConnectionFailureIsNormalizedToTransient() {
+    // K8sApi.list() surfaces a connectivity failure as an unchecked exception; it must be normalized
+    // to a typed SQLTransientException so callers can classify it as a retryable transient failure.
+    K8sContext context = mock(K8sContext.class);
+    @SuppressWarnings("unchecked")
+    GenericKubernetesApi<V1alpha1Database, V1alpha1DatabaseList> generic = mock(GenericKubernetesApi.class);
+    when(context.namespace()).thenReturn(NAMESPACE);
+    when(context.generic(K8sApiEndpoints.DATABASES)).thenReturn(generic);
+    when(generic.list(eq(NAMESPACE), any(ListOptions.class)))
+        .thenThrow(new IllegalStateException(new java.net.UnknownHostException("k8s.invalid")));
+    K8sDatabaseConfigResolver resolver = new K8sDatabaseConfigResolver(new Properties(), context);
+
+    assertThatThrownBy(() -> resolver.databaseProperties(null, "KAFKA", "jdbc:kafka://"))
+        .isInstanceOf(SQLTransientException.class)
+        .hasMessageContaining("Could not reach Kubernetes");
   }
 
   @Test

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployerTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -196,6 +197,21 @@ class K8sMaterializedViewDeployerTest {
     // viewDeployer.delete() is mocked, so this should succeed
     deployer.delete();
     assertNotNull(deployer);
+  }
+
+  @Test
+  void existsDelegatesToViewDeployer() throws SQLException {
+    Sink sink = new Sink("sinkdb", Arrays.asList("schema", "sink_table"), Collections.emptyMap());
+    Job job = new Job("j", Collections.emptySet(), sink, Collections.emptyMap());
+    MaterializedView view = createTestMaterializedView(
+        Arrays.asList("SCHEMA", "VIEW"),
+        Collections.emptyList(), sink, job);
+
+    K8sMaterializedViewDeployer deployer = makeDeployerWithMockView(view);
+    when(viewDeployer.exists()).thenReturn(true);
+
+    assertTrue(deployer.exists());
+    verify(viewDeployer).exists();
   }
 
   @Test

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sPipelineBundleTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sPipelineBundleTest.java
@@ -17,12 +17,15 @@ import com.linkedin.hoptimator.Sink;
 import com.linkedin.hoptimator.Source;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -148,6 +151,23 @@ class K8sPipelineBundleTest {
     bundle.delete();
 
     verify(pipelineDeployer).delete();
+  }
+
+  @Test
+  void existsDelegatesToPipelineDeployer() throws SQLException {
+    K8sPipelineBundle bundle = makeBundleWithMocks("test-pipeline", Collections.singletonList("spec1"));
+    when(pipelineDeployer.exists()).thenReturn(true);
+
+    assertTrue(bundle.exists());
+    verify(pipelineDeployer).exists();
+  }
+
+  @Test
+  void existsReturnsFalseWhenPipelineDeployerAbsent() throws SQLException {
+    K8sPipelineBundle bundle = makeBundleWithMocks("test-pipeline", Collections.singletonList("spec1"));
+    when(pipelineDeployer.exists()).thenReturn(false);
+
+    assertFalse(bundle.exists());
   }
 
   @Test

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sUtilsTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sUtilsTest.java
@@ -140,11 +140,15 @@ class K8sUtilsTest {
 
   static Stream<Arguments> transientStatusCodes() {
     return Stream.of(
-        Arguments.of(404),
         Arguments.of(408),
         Arguments.of(409),
         Arguments.of(410),
-        Arguments.of(412)
+        Arguments.of(412),
+        Arguments.of(429),
+        Arguments.of(500),
+        Arguments.of(502),
+        Arguments.of(503),
+        Arguments.of(504)
     );
   }
 
@@ -157,11 +161,22 @@ class K8sUtilsTest {
     assertThrows(SQLTransientException.class, () -> K8sUtils.checkResponse("test", resp));
   }
 
-  @Test
-  void checkResponseNonTransientCodeThrowsSQLNonTransientException() throws Exception {
+  static Stream<Arguments> nonTransientStatusCodes() {
+    return Stream.of(
+        Arguments.of(400),
+        Arguments.of(401),
+        Arguments.of(403),
+        Arguments.of(404), // not found is definitive: won't succeed on retry
+        Arguments.of(422)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonTransientStatusCodes")
+  void checkResponseNonTransientCodeThrowsSQLNonTransientException(int statusCode) throws Exception {
     KubernetesApiResponse<?> resp = mock(KubernetesApiResponse.class);
     doThrow(new ApiException("error")).when(resp).throwsApiException();
-    when(resp.getHttpStatusCode()).thenReturn(500);
+    when(resp.getHttpStatusCode()).thenReturn(statusCode);
     assertThrows(SQLNonTransientException.class, () -> K8sUtils.checkResponse("test", resp));
   }
 

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sYamlApiTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sYamlApiTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLTransientException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +24,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -173,6 +176,54 @@ class K8sYamlApiTest {
       K8sYamlApi api = new K8sYamlApi(mockContext);
       api.delete("v1", "ConfigMap", "ns", "to-delete");
       // No exception = success
+    }
+
+    @Test
+    void createNormalizesConnectivityFailureToTransient() {
+      DynamicKubernetesApi dynApi = mock(DynamicKubernetesApi.class);
+      doReturn(dynApi).when(mockContext).dynamic(anyString(), anyString());
+      IllegalStateException connectivityFailure =
+          new IllegalStateException(new java.net.ConnectException("Connection refused"));
+      doThrow(connectivityFailure).when(dynApi).create(any(DynamicKubernetesObject.class));
+
+      K8sYamlApi api = new K8sYamlApi(mockContext);
+      DynamicKubernetesObject obj = new DynamicKubernetesObject();
+      obj.setApiVersion("v1");
+      obj.setKind("ConfigMap");
+      obj.setMetadata(new V1ObjectMeta().name("new-obj").namespace("ns"));
+
+      SQLTransientException thrown =
+          assertThrows(SQLTransientException.class, () -> api.createWithMetadata(obj, null, null, null));
+      assertSame(connectivityFailure, thrown.getCause());
+    }
+
+    @Test
+    void deleteNormalizesConnectivityFailureToTransient() {
+      DynamicKubernetesApi dynApi = mock(DynamicKubernetesApi.class);
+      doReturn(dynApi).when(mockContext).dynamic(anyString(), anyString());
+      IllegalStateException connectivityFailure =
+          new IllegalStateException(new java.net.UnknownHostException("k8s.invalid"));
+      doThrow(connectivityFailure).when(dynApi).delete(anyString(), anyString());
+
+      K8sYamlApi api = new K8sYamlApi(mockContext);
+
+      SQLTransientException thrown =
+          assertThrows(SQLTransientException.class, () -> api.delete("v1", "ConfigMap", "ns", "to-delete"));
+      assertSame(connectivityFailure, thrown.getCause());
+    }
+
+    @Test
+    void deleteNonIoIllegalStateIsClassifiedNonTransient() {
+      DynamicKubernetesApi dynApi = mock(DynamicKubernetesApi.class);
+      doReturn(dynApi).when(mockContext).dynamic(anyString(), anyString());
+      IllegalStateException notConnectivity = new IllegalStateException("unexpected client state");
+      doThrow(notConnectivity).when(dynApi).delete(anyString(), anyString());
+
+      K8sYamlApi api = new K8sYamlApi(mockContext);
+
+      SQLNonTransientException thrown =
+          assertThrows(SQLNonTransientException.class, () -> api.delete("v1", "ConfigMap", "ns", "to-delete"));
+      assertSame(notConnectivity, thrown.getCause());
     }
 
     @Test

--- a/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDeployerProvider.java
+++ b/hoptimator-kafka/src/main/java/com/linkedin/hoptimator/kafka/KafkaDeployerProvider.java
@@ -6,6 +6,7 @@ import com.linkedin.hoptimator.DeployerProvider;
 import com.linkedin.hoptimator.DeploymentContext;
 import com.linkedin.hoptimator.Source;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -24,7 +25,7 @@ import java.util.Properties;
 public class KafkaDeployerProvider implements DeployerProvider {
 
   @Override
-  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) {
+  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) throws SQLException {
     List<Deployer> deployers = new ArrayList<>();
     if (obj instanceof Source) {
       Source source = (Source) obj;

--- a/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/KafkaDeployerProviderTest.java
+++ b/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/KafkaDeployerProviderTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -55,12 +56,12 @@ class KafkaDeployerProviderTest {
   }
 
   @Test
-  void testPriority() {
+  void testPriority() throws SQLException {
     assertEquals(2, provider.priority());
   }
 
   @Test
-  void testReturnsDeployerForKafkaSchema() {
+  void testReturnsDeployerForKafkaSchema() throws SQLException {
     Source source = new Source("kafka-database", List.of("KAFKA", "MyTopic"), Collections.emptyMap());
 
     // Mock the chain: connection -> calciteConnection -> rootSchema -> subSchema -> HoptimatorJdbcSchema -> BasicDataSource
@@ -81,7 +82,7 @@ class KafkaDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyForNonKafkaDatabase() {
+  void testReturnsEmptyForNonKafkaDatabase() throws SQLException {
     // Database name "test" doesn't start with "kafka" — short-circuits before schema lookup
     Source source = new Source("test", List.of("TEST", "MyStore"), Collections.emptyMap());
 
@@ -90,7 +91,7 @@ class KafkaDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyForNonKafkaDatabaseEvenWhenSchemaWouldMatch() {
+  void testReturnsEmptyForNonKafkaDatabaseEvenWhenSchemaWouldMatch() throws SQLException {
     // Use schema name "KAFKA" but database "not-kafka" to verify the database prefix guard
     // is what causes the empty result (not downstream schema lookup).
     // If the database guard is removed the lookup would proceed, but
@@ -105,7 +106,7 @@ class KafkaDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenSchemaNotFound() {
+  void testReturnsEmptyWhenSchemaNotFound() throws SQLException {
     Source source = new Source("kafka-unknown", List.of("UNKNOWN", "MyTable"), Collections.emptyMap());
 
     when(connection.calciteConnection()).thenReturn(calciteConnection);
@@ -118,14 +119,14 @@ class KafkaDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyForNonSourceDeployable() {
+  void testReturnsEmptyForNonSourceDeployable() throws SQLException {
     MaterializedView view = mock(MaterializedView.class);
     Collection<Deployer> deployers = provider.deployers(view, new CalciteDeploymentContext(connection));
     assertTrue(deployers.isEmpty());
   }
 
   @Test
-  void testReturnsEmptyWhenSchemaNameIsNull() {
+  void testReturnsEmptyWhenSchemaNameIsNull() throws SQLException {
     // Source with only a table name (single-element path) — schema() returns null
     Source source = new Source("kafka-database", List.of("MyTopic"), Collections.emptyMap());
     Collection<Deployer> deployers = provider.deployers(source, new CalciteDeploymentContext(connection));
@@ -133,14 +134,14 @@ class KafkaDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenDatabaseIsNull() {
+  void testReturnsEmptyWhenDatabaseIsNull() throws SQLException {
     Source source = new Source(null, List.of("KAFKA", "MyTopic"), Collections.emptyMap());
     Collection<Deployer> deployers = provider.deployers(source, new CalciteDeploymentContext(connection));
     assertTrue(deployers.isEmpty());
   }
 
   @Test
-  void testReturnsEmptyWhenUnwrapThrowsException() {
+  void testReturnsEmptyWhenUnwrapThrowsException() throws SQLException {
     Source source = new Source("kafka-database", List.of("KAFKA", "MyTopic"), Collections.emptyMap());
 
     when(connection.calciteConnection()).thenReturn(calciteConnection);

--- a/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/KafkaTableServiceIntegrationTest.java
+++ b/hoptimator-kafka/src/test/java/com/linkedin/hoptimator/kafka/KafkaTableServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class KafkaTableServiceIntegrationTest {
       // updateIfExists=false against an existing table must fail.
       assertThatThrownBy(() ->
           TableService.create(properties, List.of(), List.of(SCHEMA, table), schema, Map.of(), false, false))
-          .isInstanceOf(SQLException.class)
+          .isInstanceOf(SQLNonTransientException.class)
           .hasMessageContaining("already exists");
     } finally {
       TableService.delete(properties, List.of(SCHEMA, table));

--- a/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployer.java
+++ b/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployer.java
@@ -185,6 +185,14 @@ public class LogicalTableDeployer implements Deployer, Validated {
   }
 
   @Override
+  public boolean exists() throws SQLException {
+    // A logical table's identity is its LogicalTable CRD (the implicit inter-tier pipelines and
+    // triggers are owned by it and cascade). Mirror how delete() names and builds that deployer.
+    String selfName = K8sUtils.canonicalizeName(source.path());
+    return createLogicalTableDeployer(selfName, source.database(), buildTierMap()).exists();
+  }
+
+  @Override
   public void update() throws SQLException {
     deployAll(true);
   }

--- a/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployerProvider.java
+++ b/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployerProvider.java
@@ -1,5 +1,6 @@
 package com.linkedin.hoptimator.logical;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +30,7 @@ public class LogicalTableDeployerProvider implements DeployerProvider {
   private static final Logger log = LoggerFactory.getLogger(LogicalTableDeployerProvider.class);
 
   @Override
-  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) {
+  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) throws SQLException {
     if (!(obj instanceof Source)) {
       return Collections.emptyList();
     }

--- a/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/LogicalTableDeployerProviderTest.java
+++ b/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/LogicalTableDeployerProviderTest.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.logical;
 
 import com.linkedin.hoptimator.DeploymentContext;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -26,14 +27,14 @@ public class LogicalTableDeployerProviderTest {
   }
 
   @Test
-  public void deployersReturnsEmptyWhenInputIsNotSource() {
+  public void deployersReturnsEmptyWhenInputIsNotSource() throws SQLException {
     Deployable notASource = new Deployable() { };
     Collection<Deployer> deployers = provider.deployers(notASource, null);
     assertTrue(deployers.isEmpty());
   }
 
   @Test
-  public void deployersReturnsEmptyWhenDatabaseUnresolvable() {
+  public void deployersReturnsEmptyWhenDatabaseUnresolvable() throws SQLException {
     // A context that can't resolve the database (databaseProperties returns null) yields no deployers.
     Source source = new Source("mydb", List.of("mydb", "myschema", "mytable"), Map.of());
     DeploymentContext context = org.mockito.Mockito.mock(DeploymentContext.class);

--- a/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/LogicalTableDeployerTest.java
+++ b/hoptimator-logical/src/test/java/com/linkedin/hoptimator/logical/LogicalTableDeployerTest.java
@@ -270,6 +270,30 @@ class LogicalTableDeployerTest {
   }
 
   @Test
+  void existsDelegatesToCrdDeployer() throws SQLException {
+    LogicalTableDeployer deployer = deployerWithApis(
+        twoTierProps("kafka-db", "venice-db"),
+        Arrays.asList(makeDb("kafka-db", "KAFKA"), makeDb("venice-db", "VENICE")));
+
+    // The logical table's identity is its LogicalTable CRD; exists() reflects that CRD's presence.
+    when(mockCrdDeployer.exists()).thenReturn(true);
+
+    assertTrue(deployer.exists());
+    verify(mockCrdDeployer).exists();
+  }
+
+  @Test
+  void existsReturnsFalseWhenCrdAbsent() throws SQLException {
+    LogicalTableDeployer deployer = deployerWithApis(
+        twoTierProps("kafka-db", "venice-db"),
+        Arrays.asList(makeDb("kafka-db", "KAFKA"), makeDb("venice-db", "VENICE")));
+
+    when(mockCrdDeployer.exists()).thenReturn(false);
+
+    assertFalse(deployer.exists());
+  }
+
+  @Test
   void deleteThrowsWhenCrdDeleteFails() throws SQLException {
     LogicalTableDeployer deployer = deployerWithApis(
         twoTierProps("kafka-db", "venice-db"),
@@ -713,7 +737,7 @@ class LogicalTableDeployerTest {
   }
 
   @Test
-  void deployerProviderReturnsDeployerWhenLogicalSchemaFound() {
+  void deployerProviderReturnsDeployerWhenLogicalSchemaFound() throws SQLException {
     Properties tierProps = new Properties();
     tierProps.setProperty(LogicalTier.NEARLINE.tierName(), "nearline-db");
     deployerUtilsMock.when(() -> DeployerUtils.extractPropertiesFromJdbcSchema(

--- a/hoptimator-mysql/src/main/java/com/linkedin/hoptimator/mysql/MySqlDeployerProvider.java
+++ b/hoptimator-mysql/src/main/java/com/linkedin/hoptimator/mysql/MySqlDeployerProvider.java
@@ -6,6 +6,7 @@ import com.linkedin.hoptimator.DeployerProvider;
 import com.linkedin.hoptimator.DeploymentContext;
 import com.linkedin.hoptimator.Source;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.Properties;
 public class MySqlDeployerProvider implements DeployerProvider {
 
   @Override
-  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) {
+  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) throws SQLException {
     List<Deployer> deployers = new ArrayList<>();
     if (obj instanceof Source) {
       Source source = (Source) obj;

--- a/hoptimator-mysql/src/test/java/com/linkedin/hoptimator/mysql/MySqlDeployerProviderTest.java
+++ b/hoptimator-mysql/src/test/java/com/linkedin/hoptimator/mysql/MySqlDeployerProviderTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -62,12 +63,12 @@ class MySqlDeployerProviderTest {
   }
 
   @Test
-  void testPriority() {
+  void testPriority() throws SQLException {
     assertEquals(2, provider.priority());
   }
 
   @Test
-  void testReturnsDeployerForMySqlSchema() {
+  void testReturnsDeployerForMySqlSchema() throws SQLException {
     Source source = new Source("mysql", List.of("MYSQL", "testdb", "users"), Collections.emptyMap());
 
     // Mock the chain: connection -> calciteConnection -> rootSchema -> MYSQL catalog -> testdb schema -> HoptimatorJdbcSchema -> BasicDataSource
@@ -90,7 +91,7 @@ class MySqlDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyForNonMySqlCatalog() {
+  void testReturnsEmptyForNonMySqlCatalog() throws SQLException {
     // Catalog name "KAFKA" doesn't match "MYSQL" — short-circuits before schema lookup
     Source source = new Source("kafka", List.of("KAFKA", "MyTopic"), Collections.emptyMap());
 
@@ -99,7 +100,7 @@ class MySqlDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenCatalogNotFound() {
+  void testReturnsEmptyWhenCatalogNotFound() throws SQLException {
     Source source = new Source("mysql", List.of("UNKNOWN", "testdb", "users"), Collections.emptyMap());
 
     // No mocking needed - catalog name doesn't match, short-circuits early
@@ -108,14 +109,14 @@ class MySqlDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyForNonSourceDeployable() {
+  void testReturnsEmptyForNonSourceDeployable() throws SQLException {
     MaterializedView view = mock(MaterializedView.class);
     Collection<Deployer> deployers = provider.deployers(view, new CalciteDeploymentContext(connection));
     assertTrue(deployers.isEmpty());
   }
 
   @Test
-  void testReturnsEmptyWhenCatalogIsNull() {
+  void testReturnsEmptyWhenCatalogIsNull() throws SQLException {
     // Source with only schema and table (2-level path) — catalog() returns null
     Source source = new Source("mysql", List.of("testdb", "users"), Collections.emptyMap());
     Collection<Deployer> deployers = provider.deployers(source, new CalciteDeploymentContext(connection));
@@ -123,7 +124,7 @@ class MySqlDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenSchemaNotFoundInCatalog() {
+  void testReturnsEmptyWhenSchemaNotFoundInCatalog() throws SQLException {
     Source source = new Source("mysql", List.of("MYSQL", "nonexistent", "users"), Collections.emptyMap());
 
     when(connection.calciteConnection()).thenReturn(calciteConnection);
@@ -138,7 +139,7 @@ class MySqlDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenUnwrapThrowsException() {
+  void testReturnsEmptyWhenUnwrapThrowsException() throws SQLException {
     Source source = new Source("mysql", List.of("MYSQL", "testdb", "users"), Collections.emptyMap());
 
     when(connection.calciteConnection()).thenReturn(calciteConnection);
@@ -156,7 +157,7 @@ class MySqlDeployerProviderTest {
   // --- deployers() with non-HoptimatorConnection returns empty ---
 
   @Test
-  void testReturnsEmptyWhenDatabaseUnresolvable() {
+  void testReturnsEmptyWhenDatabaseUnresolvable() throws SQLException {
     Source source = new Source("mysql", List.of("MYSQL", "testdb", "users"), Collections.emptyMap());
 
     // A context that can't resolve the database (databaseProperties returns null) yields no deployers.
@@ -169,7 +170,7 @@ class MySqlDeployerProviderTest {
   // --- catalog check: catalog name comparison is case-insensitive ---
 
   @Test
-  void testDeployersCatalogMatchIsCaseInsensitive() {
+  void testDeployersCatalogMatchIsCaseInsensitive() throws SQLException {
     // "mysql" lower-case catalog should NOT match "MYSQL" since equalsIgnoreCase is used
     // but non-matching catalog returns empty
     Source source = new Source("mysql", List.of("OTHER", "testdb", "users"), Collections.emptyMap());

--- a/hoptimator-mysql/src/test/java/com/linkedin/hoptimator/mysql/MySqlDeployerTest.java
+++ b/hoptimator-mysql/src/test/java/com/linkedin/hoptimator/mysql/MySqlDeployerTest.java
@@ -207,6 +207,22 @@ class MySqlDeployerTest {
   }
 
   @Test
+  void testExistsReturnsFalseWhenSchemaDoesNotExist() throws Exception {
+    // When the target schema (MySQL catalog) doesn't exist, DatabaseMetaData.getTables against that
+    // catalog returns an empty result set rather than throwing.
+    // So exists() reports false — "the table isn't a duplicate" — and lets the CREATE guard
+    // proceed; the real "unknown database" error then surfaces at create() time, not here.
+    Source source = new Source("db", List.of("MYSQL", "ghost_db", "SomeTable"), Collections.emptyMap());
+
+    ResultSet emptyRs = mock(ResultSet.class);
+    when(emptyRs.next()).thenReturn(false);
+    when(mockMetaData.getTables(eq("ghost_db"), any(), eq("SomeTable"), any())).thenReturn(emptyRs);
+
+    assertFalse(createDeployer(source).exists());
+    verify(mockConnection).close();
+  }
+
+  @Test
   void testCreatePropagatesException() throws Exception {
     Source source = new Source("db", List.of("MYSQL", DATABASE, "ErrorTable"), Collections.emptyMap());
 

--- a/hoptimator-mysql/src/test/java/com/linkedin/hoptimator/mysql/MySqlTableServiceIntegrationTest.java
+++ b/hoptimator-mysql/src/test/java/com/linkedin/hoptimator/mysql/MySqlTableServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -143,7 +144,7 @@ public class MySqlTableServiceIntegrationTest {
           List.of(CATALOG, DB, table),
           recordOf(table, nullable("KEY_id", Schema.Type.INT), nullable("name", Schema.Type.STRING)),
           Map.of(), false, false))
-          .isInstanceOf(SQLException.class)
+          .isInstanceOf(SQLNonTransientException.class)
           .hasMessageContaining("already exists");
     } finally {
       drop(table);

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConnectionService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/ConnectionService.java
@@ -11,7 +11,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 
 
 public final class ConnectionService {
@@ -35,9 +34,11 @@ public final class ConnectionService {
     return providers;
   }
 
-  public static <T> Collection<Connector> connectors(T obj, DeploymentContext context) {
-    return providers().stream()
-        .flatMap(x -> x.connectors(obj, context).stream())
-        .collect(Collectors.toList());
+  public static <T> Collection<Connector> connectors(T obj, DeploymentContext context) throws SQLException {
+    List<Connector> connectors = new ArrayList<>();
+    for (ConnectorProvider provider : providers()) {
+      connectors.addAll(provider.connectors(obj, context));
+    }
+    return connectors;
   }
 }

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/DeploymentService.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 
 public final class DeploymentService {
@@ -85,12 +84,13 @@ public final class DeploymentService {
     return providers;
   }
 
-  public static <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) {
+  public static <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context)
+      throws SQLException {
     return deployers(obj, context, providers());
   }
 
   static <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context,
-      Collection<DeployerProvider> providers) {
+      Collection<DeployerProvider> providers) throws SQLException {
     // Filter out base classes when subclasses exist
     Set<DeployerProvider> filteredProviders = new HashSet<>();
     for (DeployerProvider provider : providers) {
@@ -108,9 +108,11 @@ public final class DeploymentService {
     }
 
     // Now collect deployers from filtered providers
-    return filteredProviders.stream()
-        .flatMap(x -> x.deployers(obj, context).stream())
-        .collect(Collectors.toList());
+    List<Deployer> deployers = new ArrayList<>();
+    for (DeployerProvider provider : filteredProviders) {
+      deployers.addAll(provider.deployers(obj, context));
+    }
+    return deployers;
   }
 
   /** Plans a deployable Pipeline which implements the query. */

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/ConnectionServiceTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/ConnectionServiceTest.java
@@ -41,7 +41,7 @@ class ConnectionServiceTest {
   }
 
   @Test
-  void testConnectorsReturnsCollectionForObject() {
+  void testConnectorsReturnsCollectionForObject() throws SQLException {
     Collection<?> connectors = ConnectionService.connectors("test", mockConnection);
 
     assertNotNull(connectors);

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/DeploymentServiceTest.java
@@ -254,7 +254,7 @@ class DeploymentServiceTest {
   }
 
   @Test
-  void testDeployersReturnsEmptyWithNoProviders() {
+  void testDeployersReturnsEmptyWithNoProviders() throws SQLException {
     // A simple Deployable implementation for testing
     Deployable deployable = new Deployable() { };
 
@@ -376,7 +376,7 @@ class DeploymentServiceTest {
   }
 
   @Test
-  void testDeployersWithProvidersFiltersSubclasses() {
+  void testDeployersWithProvidersFiltersSubclasses() throws SQLException {
     // The deployers() method uses providers() which relies on ServiceLoader
     // Without registered providers, the filtering loop doesn't execute
     // This test verifies the method handles the empty providers case
@@ -386,7 +386,7 @@ class DeploymentServiceTest {
   }
 
   @Test
-  void testDeployersFilteringWithSingleProvider() {
+  void testDeployersFilteringWithSingleProvider() throws SQLException {
     Deployable deployable = new Deployable() { };
     DeployerProvider provider = new DeployerProvider() {
       @Override
@@ -406,7 +406,7 @@ class DeploymentServiceTest {
   }
 
   @Test
-  void testDeployersFilteringRemovesBaseClassProvider() {
+  void testDeployersFilteringRemovesBaseClassProvider() throws SQLException {
     Deployable deployable = new Deployable() { };
 
     DeployerProvider baseProvider = new DeployerProvider() {
@@ -441,7 +441,7 @@ class DeploymentServiceTest {
   }
 
   @Test
-  void testDeployersFilteringWithActualSubclass() {
+  void testDeployersFilteringWithActualSubclass() throws SQLException {
     Deployable deployable = new Deployable() { };
 
     // Base class provider
@@ -458,7 +458,7 @@ class DeploymentServiceTest {
   }
 
   @Test
-  void testDeployersFilteringWithEmptyProviders() {
+  void testDeployersFilteringWithEmptyProviders() throws SQLException {
     Deployable deployable = new Deployable() { };
 
     Collection<Deployer> deployers = DeploymentService.deployers(deployable, mockConnection,
@@ -468,7 +468,7 @@ class DeploymentServiceTest {
   }
 
   @Test
-  void testDeployersFilteringWithMultipleUnrelatedProviders() {
+  void testDeployersFilteringWithMultipleUnrelatedProviders() throws SQLException {
     Deployable deployable = new Deployable() { };
 
     BaseTestProvider provider1 = new BaseTestProvider(mockDeployer1);
@@ -609,7 +609,7 @@ class DeploymentServiceTest {
   // (i.e., the list is populated from loader). Since no SPI providers are registered in test,
   // verify the result is non-null and that a registered provider IS returned.
   @Test
-  void testProvidersWithRegisteredProviderIsNonNull() {
+  void testProvidersWithRegisteredProviderIsNonNull() throws SQLException {
     Collection<DeployerProvider> providers = DeploymentService.providers();
     assertNotNull(providers, "providers() must never return null");
     // Sort is called on the list — if VoidMethodCall removes providers::add, list is empty

--- a/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDeployerProvider.java
+++ b/hoptimator-venice/src/main/java/com/linkedin/hoptimator/venice/VeniceDeployerProvider.java
@@ -6,6 +6,7 @@ import com.linkedin.hoptimator.DeployerProvider;
 import com.linkedin.hoptimator.DeploymentContext;
 import com.linkedin.hoptimator.Source;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.Properties;
 public class VeniceDeployerProvider implements DeployerProvider {
 
   @Override
-  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) {
+  public <T extends Deployable> Collection<Deployer> deployers(T obj, DeploymentContext context) throws SQLException {
     List<Deployer> deployers = new ArrayList<>();
     if (obj instanceof Source) {
       Source source = (Source) obj;

--- a/hoptimator-venice/src/test/java/com/linkedin/hoptimator/venice/VeniceDeployerProviderTest.java
+++ b/hoptimator-venice/src/test/java/com/linkedin/hoptimator/venice/VeniceDeployerProviderTest.java
@@ -3,6 +3,8 @@ package com.linkedin.hoptimator.venice;
 import com.linkedin.hoptimator.jdbc.CalciteDeploymentContext;
 import com.linkedin.hoptimator.DeploymentContext;
 
+import java.sql.SQLException;
+
 import com.linkedin.hoptimator.Deployer;
 import com.linkedin.hoptimator.MaterializedView;
 import com.linkedin.hoptimator.Source;
@@ -56,12 +58,12 @@ class VeniceDeployerProviderTest {
   }
 
   @Test
-  void testPriority() {
+  void testPriority() throws SQLException {
     assertEquals(2, provider.priority());
   }
 
   @Test
-  void testReturnsDeployerForVeniceSchema() {
+  void testReturnsDeployerForVeniceSchema() throws SQLException {
     Source source = new Source("venice", List.of("VENICE", "MyStore"), Collections.emptyMap());
 
     // Mock the chain: connection -> calciteConnection -> rootSchema -> subSchema -> HoptimatorJdbcSchema -> BasicDataSource
@@ -82,7 +84,7 @@ class VeniceDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyForNonVeniceDatabase() {
+  void testReturnsEmptyForNonVeniceDatabase() throws SQLException {
     // Database name "test" doesn't match "venice" — short-circuits before schema lookup
     Source source = new Source("test", List.of("TEST", "MyStore"), Collections.emptyMap());
 
@@ -91,7 +93,7 @@ class VeniceDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenSchemaNotFound() {
+  void testReturnsEmptyWhenSchemaNotFound() throws SQLException {
     Source source = new Source("venice", List.of("UNKNOWN", "MyStore"), Collections.emptyMap());
 
     when(connection.calciteConnection()).thenReturn(calciteConnection);
@@ -104,14 +106,14 @@ class VeniceDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyForNonSourceDeployable() {
+  void testReturnsEmptyForNonSourceDeployable() throws SQLException {
     MaterializedView view = mock(MaterializedView.class);
     Collection<Deployer> deployers = provider.deployers(view, new CalciteDeploymentContext(connection));
     assertTrue(deployers.isEmpty());
   }
 
   @Test
-  void testReturnsEmptyWhenSchemaNameIsNull() {
+  void testReturnsEmptyWhenSchemaNameIsNull() throws SQLException {
     // Source with only a table name (single-element path) — schema() returns null
     Source source = new Source("venice", List.of("MyStore"), Collections.emptyMap());
     Collection<Deployer> deployers = provider.deployers(source, new CalciteDeploymentContext(connection));
@@ -119,14 +121,14 @@ class VeniceDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenDatabaseIsNull() {
+  void testReturnsEmptyWhenDatabaseIsNull() throws SQLException {
     Source source = new Source(null, List.of("VENICE", "MyStore"), Collections.emptyMap());
     Collection<Deployer> deployers = provider.deployers(source, new CalciteDeploymentContext(connection));
     assertTrue(deployers.isEmpty());
   }
 
   @Test
-  void testReturnsEmptyWhenDatabaseUnresolvable() {
+  void testReturnsEmptyWhenDatabaseUnresolvable() throws SQLException {
     // A context that can't resolve the database (databaseProperties returns null) yields no deployers.
     Source source = new Source("venice", List.of("VENICE", "MyStore"), Collections.emptyMap());
     DeploymentContext unresolvable = mock(DeploymentContext.class);
@@ -135,7 +137,7 @@ class VeniceDeployerProviderTest {
   }
 
   @Test
-  void testReturnsDeployerForCaseInsensitiveVeniceDatabase() {
+  void testReturnsDeployerForCaseInsensitiveVeniceDatabase() throws SQLException {
     // equalsIgnoreCase — database name "venice" (lowercase) should still match CATALOG_NAME "VENICE"
     Source source = new Source("venice", List.of("VENICE", "MyStore"), Collections.emptyMap());
 
@@ -157,7 +159,7 @@ class VeniceDeployerProviderTest {
   }
 
   @Test
-  void testReturnsEmptyWhenUnwrapThrowsException() {
+  void testReturnsEmptyWhenUnwrapThrowsException() throws SQLException {
     Source source = new Source("venice", List.of("VENICE", "MyStore"), Collections.emptyMap());
 
     when(connection.calciteConnection()).thenReturn(calciteConnection);

--- a/hoptimator-venice/src/test/java/com/linkedin/hoptimator/venice/VeniceTableServiceIntegrationTest.java
+++ b/hoptimator-venice/src/test/java/com/linkedin/hoptimator/venice/VeniceTableServiceIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -186,7 +187,7 @@ public class VeniceTableServiceIntegrationTest {
           List.of(SCHEMA, store),
           recordOf(sanitize(store), nullable("KEY", Schema.Type.INT), nullable("i", Schema.Type.INT)),
           Map.of(), false, false))
-          .isInstanceOf(SQLException.class)
+          .isInstanceOf(SQLNonTransientException.class)
           .hasMessageContaining("already exists");
     } finally {
       drop(store);


### PR DESCRIPTION
# Decouple Proteus DDL
Hoptimator's validation and deployment logic is currently reachable only by issuing SQL DDL through a Calcite/JDBC connection. That couples every caller to Calcite and forces schema definitions through a lossy  Avro → RelDataType → Avro  round-trip. Hoptimator via a CLI or over REST/gRPC may want to create/validate tables by handing us a table name + a schema directly — not by constructing DDL.

This stacked series decouples the validators and deployers from Calcite so the same validation and deployment engine can be driven either by SQL or by a direct, connection-free call — while keeping validators/deployers as a clean SPI. The payoff: an API call to "create table from a schema" path with identical guarantees to DDL (including dry-run), lossless Avro fidelity, and no Calcite dependency for callers that don't want one. It also keeps the door open for follow-ups (e.g. materializations, source→sink field mappings) without re-plumbing.

Stacked series (review/merge in order):
1.  decouple-pr1-spi  — SPI foundation:  java.sql.Connection  →  DeploymentContext  (pure decoupling, no behavior change)
2.  decouple-pr2-api  — SQL-free  TableService  + lossless Avro preservation
3.  decouple-pr3-hardening  — typed transient failures + required  Deployer.exists() 
(This is PR 3 of 3.)

## PR 3/3 — Hardening: typed transient failures + required `Deployer.exists()`

**Base:** `jogrogan/decouple-pr2-api` · **Branch:** `jogrogan/decouple-pr3-hardening`
**Stacked series:** 3 of 3 (PR1 SPI foundation → PR2 direct table API → **this**)

> Review/merge after PR2. The diff below is against PR2.

## Why

PR1 and PR2 deliver the SPI decoupling and the SQL-free `TableService`. This final PR
hardens that surface so it behaves correctly under real-world failure modes and so the
direct-path contract is enforced rather than assumed.

## What changes

### 1. Typed transient failures across the SPI
- K8s failures are now classified by **retryability** instead of being blanket-treated as
  transient. `K8sApi`/`K8sYamlApi` normalize connectivity failures to a typed
  `SQLTransientException`, and genuinely non-retryable failures surface as
  `SQLNonTransientException`.
- These typed exceptions propagate through the deploy/validate path
  (`ValidationService`, `DeploymentService`, `ConnectionService`) so callers can
  distinguish "retry me" from "this will never succeed."
- `Database`-list failures are surfaced instead of being swallowed into an empty
  "no databases" result.

### 2. `Deployer.exists()` is now an abstract SPI method
- Previously an "assume-absent" default masked re-creates. `exists()` is now abstract, and
  the three real implementors (K8s, Venice, and the logical/materialized-view deployers)
  are backfilled with genuine existence checks.
- Consequence: a direct-path `create` against an **incompatible existing table** (e.g. a
  different schema, `updateIfExists=false`) is **rejected** with a clear
  `SQLNonTransientException("... already exists")` rather than silently masked.

## Testing

- New/expanded unit tests: `K8sApiTest`, `K8sYamlApiTest`, `K8sUtilsTest`,
  `K8sPipelineBundleTest`, `K8sMaterializedViewDeployerTest`, `ValidationServiceTest`,
  `DeploymentServiceTest`, `ConnectionServiceTest`, and the per-deployer `exists()`
  backfills (`Venice`, `MySQL`, `Logical`, provider tests).
- Integration tests updated to assert the typed-exception contract (e.g. Venice
  `createWithoutUpdateIfExistsFailsWhenStoreExists` now expects `SQLNonTransientException`).

## Review notes

- ~44 files. Two independent themes (typed transient failures; required `exists()`); both
  are additive/behavioral hardening on top of PR2's API.
- Does **not** re-touch PR2's `TableService`/`DirectDeploymentContext` core or the Venice
  test's `resolveVenice` helper — the only change to `VeniceTableServiceIntegrationTest`
  here is the exception-type assertion, a different hunk than PR2's resolution change.
