### PR TITLE
Skip SQL job generation when a pipeline source or sink has no connector

### DIFF
--- a/deploy/samples/demodb.yaml
+++ b/deploy/samples/demodb.yaml
@@ -56,6 +56,7 @@ spec:
   databases:
   - profile-database
   - ads-database
+  - ads-catalog-database
   methods:
   - Modify
   connector: |

--- a/hoptimator-api/src/main/java/com/linkedin/hoptimator/MissingConnectorException.java
+++ b/hoptimator-api/src/main/java/com/linkedin/hoptimator/MissingConnectorException.java
@@ -1,0 +1,20 @@
+package com.linkedin.hoptimator;
+
+import java.sql.SQLNonTransientException;
+
+
+/**
+ * Signals that a table has no connector configuration, and therefore cannot participate
+ * in a generated SQL job. Callers that generate SQL-based jobs are expected to catch this
+ * and skip SQL generation, while still emitting any non-SQL jobs.
+ *
+ * <p>This is not necessarily an error: some tables are moved by means other than a SQL job.
+ * For example, a JobTemplate may render a non-SQL job (rather than {@code SqlJob}) to move data
+ * into or out of such a table.
+ */
+public class MissingConnectorException extends SQLNonTransientException {
+
+  public MissingConnectorException(String path) {
+    super("No connector configured for '" + path + "'.");
+  }
+}

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sJobDeployer.java
@@ -1,6 +1,7 @@
 package com.linkedin.hoptimator.k8s;
 
 import com.linkedin.hoptimator.Job;
+import com.linkedin.hoptimator.MissingConnectorException;
 import com.linkedin.hoptimator.Source;
 import com.linkedin.hoptimator.SqlDialect;
 import com.linkedin.hoptimator.ThrowingFunction;
@@ -45,6 +46,7 @@ class K8sJobDeployer extends K8sYamlDeployer {
     ThrowingFunction<SqlDialect, String> sql = job.sql();
     ThrowingFunction<SqlDialect, String> fieldMap = job.fieldMap();
     String name = K8sUtils.canonicalizeName(job.sink().database(), job.name());
+
     Template.Environment env = new Template.SimpleEnvironment()
         .with("name", name)
         .with("database", job.sink().database())
@@ -55,8 +57,8 @@ class K8sJobDeployer extends K8sYamlDeployer {
         .with("sourceCatalogs", () -> job.sources().stream().map(Source::catalog).filter(Objects::nonNull).collect(Collectors.joining(",")))
         .with("sourceSchemas", () -> job.sources().stream().map(Source::schema).collect(Collectors.joining(",")))
         .with("sourceTables", () -> job.sources().stream().map(Source::table).collect(Collectors.joining(",")))
-        .with("sql", () -> sql.apply(SqlDialect.ANSI))
-        .with("flinksql", () -> sql.apply(SqlDialect.FLINK))
+        .with("sql", () -> sqlOrNull(sql, SqlDialect.ANSI))
+        .with("flinksql", () -> sqlOrNull(sql, SqlDialect.FLINK))
         .with("flinkconfigs", properties)
         .with("fieldMap", () -> "'" + fieldMap.apply(SqlDialect.ANSI) + "'")
         .with(properties);
@@ -76,5 +78,19 @@ class K8sJobDeployer extends K8sYamlDeployer {
       }
     }
     return renderedTemplates;
+  }
+
+  /**
+   * Renders the pipeline SQL for the given dialect, returning {@code null} if a source or the
+   * sink has no connector. Such a pipeline cannot be materialized by a SQL job; returning
+   * {@code null} causes SQL-based JobTemplates to be skipped, while non-SQL JobTemplates still
+   * render.
+   */
+  private static String sqlOrNull(ThrowingFunction<SqlDialect, String> sql, SqlDialect dialect) throws SQLException {
+    try {
+      return sql.apply(dialect);
+    } catch (MissingConnectorException e) {
+      return null;
+    }
   }
 }

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sMaterializedViewDeployer.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.k8s;
 
 import com.linkedin.hoptimator.Deployer;
 import com.linkedin.hoptimator.MaterializedView;
+import com.linkedin.hoptimator.MissingConnectorException;
 import com.linkedin.hoptimator.Sink;
 import com.linkedin.hoptimator.Source;
 import com.linkedin.hoptimator.SqlDialect;
@@ -111,7 +112,13 @@ class K8sMaterializedViewDeployer implements Deployer {
   }
 
   String sql() throws SQLException {
-    return view.pipelineSql().apply(SqlDialect.ANSI);
+    try {
+      return view.pipelineSql().apply(SqlDialect.ANSI);
+    } catch (MissingConnectorException e) {
+      // A source or sink has no connector (the pipeline is moved by a non-SQL job rather than
+      // Flink SQL), so there is no pipeline SQL to stamp on the Pipeline resource.
+      return null;
+    }
   }
 
   @Override

--- a/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineDeployer.java
+++ b/hoptimator-k8s/src/main/java/com/linkedin/hoptimator/k8s/K8sPipelineDeployer.java
@@ -38,7 +38,7 @@ class K8sPipelineDeployer extends K8sDeployer<V1alpha1Pipeline, V1alpha1Pipeline
     super(context, K8sApiEndpoints.PIPELINES);
     this.name = name;
     this.yaml = String.join("\n---\n", specs);
-    this.sql = sql;
+    this.sql = sql == null ? "" : sql;
     this.sources = sources == null ? Collections.emptyList() : sources;
     this.sink = sink;
   }

--- a/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sJobDeployerTest.java
+++ b/hoptimator-k8s/src/test/java/com/linkedin/hoptimator/k8s/K8sJobDeployerTest.java
@@ -3,6 +3,7 @@ package com.linkedin.hoptimator.k8s;
 import com.linkedin.hoptimator.DeploymentContext;
 
 import com.linkedin.hoptimator.Job;
+import com.linkedin.hoptimator.MissingConnectorException;
 import com.linkedin.hoptimator.Sink;
 import com.linkedin.hoptimator.Source;
 import com.linkedin.hoptimator.SqlDialect;
@@ -75,8 +76,12 @@ class K8sJobDeployerTest {
   }
 
   private Job createTestJob(Sink sink) {
+    return createTestJob(sink, dialect -> "INSERT INTO sink SELECT * FROM source");
+  }
+
+  private Job createTestJob(Sink sink, ThrowingFunction<SqlDialect, String> sql) {
     Map<String, ThrowingFunction<SqlDialect, String>> lazyEvals = new HashMap<>();
-    lazyEvals.put("sql", dialect -> "INSERT INTO sink SELECT * FROM source");
+    lazyEvals.put("sql", sql);
     lazyEvals.put("fieldMap", dialect -> "{\"a\":\"b\"}");
     Source source = new Source("srcdb", Arrays.asList("schema", "src_table"), Collections.emptyMap());
     return new Job("test-job", new HashSet<>(Collections.singleton(source)), sink, lazyEvals);
@@ -272,5 +277,58 @@ class K8sJobDeployerTest {
     assertFalse(specs.get(0).isEmpty(), "rendered template must be non-empty");
     // The name should be canonicalized from "sinkdb" + "test-job"
     assertTrue(specs.get(0).contains("sinkdb"), "rendered template must contain database name");
+  }
+
+  @Test
+  void specifyWithoutSinkConnectorSkipsSqlTemplate() throws SQLException {
+    // Arrange: the sink has no connector, so the pipeline SQL function throws.
+    ThrowingFunction<SqlDialect, String> throwingSql = dialect -> {
+      throw new MissingConnectorException("sinkdb.schema.sink_table");
+    };
+    // A SQL-based JobTemplate (references {{flinksql}})...
+    templates.add(new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("flink-template"))
+        .spec(new V1alpha1JobTemplateSpec()
+            .yaml("kind: SqlJob\nname: {{name}}\nsql:\n  - {{flinksql}}")));
+    // ...and a non-SQL JobTemplate (references no SQL).
+    templates.add(new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("nonsql-template"))
+        .spec(new V1alpha1JobTemplateSpec()
+            .yaml("kind: BatchJob\nname: {{name}}-job\nsinkTable: {{table}}")));
+
+    Sink sink = new Sink("sinkdb", Arrays.asList("schema", "sink_table"),
+        Collections.emptyMap());
+    Job job = createTestJob(sink, throwingSql);
+    K8sJobDeployer deployer = makeDeployer(job);
+
+    // Act
+    List<String> specs = deployer.specify();
+
+    // Assert: the SQL template is skipped; only the non-SQL template renders.
+    assertEquals(1, specs.size());
+    assertTrue(specs.get(0).contains("BatchJob"), "only the non-SQL template should render");
+    assertFalse(specs.get(0).contains("SqlJob"), "SQL-based template must be skipped when sink has no connector");
+  }
+
+  @Test
+  void specifyWithSinkConnectorRendersSqlTemplate() throws SQLException {
+    // Arrange: the sink has a connector, so the pipeline SQL function returns SQL.
+    templates.add(new V1alpha1JobTemplate()
+        .metadata(new V1ObjectMeta().name("flink-template"))
+        .spec(new V1alpha1JobTemplateSpec()
+            .yaml("kind: SqlJob\nname: {{name}}\nsql:\n  - {{flinksql}}")));
+
+    Sink sink = new Sink("sinkdb", Arrays.asList("schema", "sink_table"),
+        Collections.emptyMap());
+    Job job = createTestJob(sink);
+    K8sJobDeployer deployer = makeDeployer(job);
+
+    // Act
+    List<String> specs = deployer.specify();
+
+    // Assert
+    assertEquals(1, specs.size());
+    assertTrue(specs.get(0).contains("SqlJob"), "SQL-based template must render when sink has a connector");
+    assertTrue(specs.get(0).contains("INSERT INTO sink SELECT * FROM source"));
   }
 }

--- a/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployer.java
+++ b/hoptimator-logical/src/main/java/com/linkedin/hoptimator/logical/LogicalTableDeployer.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.linkedin.hoptimator.MissingConnectorException;
 import com.linkedin.hoptimator.SqlDialect;
 import com.linkedin.hoptimator.k8s.models.V1alpha1DatabaseSpec;
 import com.linkedin.hoptimator.k8s.models.V1alpha1JobTemplate;
@@ -520,7 +521,15 @@ public class LogicalTableDeployer implements Deployer, Validated {
       throw new SQLNonTransientException(message, e);
     }
 
-    String pipelineSql = pipeline.job().sql().apply(SqlDialect.ANSI);
+    String pipelineSql;
+    try {
+      pipelineSql = pipeline.job().sql().apply(SqlDialect.ANSI);
+    } catch (MissingConnectorException e) {
+      // A tier has no connector so there is no pipeline SQL. The non-SQL job specs are
+      // still emitted below via DeploymentService.specify(pipeline.job(), ...).
+      log.info("No connector for pipeline {}; skipping pipeline SQL.", pipelineName);
+      pipelineSql = null;
+    }
     List<String> pipelineSpecs = new ArrayList<>();
     for (Source src : pipeline.sources()) {
       pipelineSpecs.addAll(DeploymentService.specify(src, context.deploymentContext()));

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/PipelineRel.java
@@ -3,6 +3,7 @@ package com.linkedin.hoptimator.util.planner;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.hoptimator.DeploymentContext;
 import com.linkedin.hoptimator.Job;
+import com.linkedin.hoptimator.MissingConnectorException;
 import com.linkedin.hoptimator.Pipeline;
 import com.linkedin.hoptimator.Sink;
 import com.linkedin.hoptimator.Source;
@@ -126,6 +127,12 @@ public interface PipelineRel extends RelNode {
         script = script.catalog(source.getKey().catalog());
         script = script.database(source.getKey().catalog(), source.getKey().schema());
         Map<String, String> configs = ConnectionService.configure(source.getKey(), context);
+        // A source with no connector configuration cannot be read by a SQL job. As with a
+        // connector-less sink, such a table is moved by a non-SQL job (with source and sink
+        // reversed). Signal this to callers so they can skip SQL generation.
+        if (configs.isEmpty()) {
+          throw new MissingConnectorException(source.getKey().pathString());
+        }
         String suffix = needsSuffixes ? "_source" : null;
         script = script.connector(source.getKey().catalog(), source.getKey().schema(), source.getKey().table(), suffix, source.getValue(), configs);
       }
@@ -161,6 +168,11 @@ public interface PipelineRel extends RelNode {
           validateFieldMapping(targetRowType);
         }
         Map<String, String> sinkConfigs = ConnectionService.configure(sink, context);
+        // A sink with no connector configuration cannot be materialized by a SQL job. Signal
+        // this to callers so they can skip SQL generation while still emitting non-SQL jobs.
+        if (sinkConfigs.isEmpty()) {
+          throw new MissingConnectorException(sink.pathString());
+        }
         script = script.catalog(sink.catalog());
         script = script.database(sink.catalog(), sink.schema());
         // Check if we need to add suffixes to avoid table name collisions

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelImplementorTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelImplementorTest.java
@@ -2,9 +2,12 @@ package com.linkedin.hoptimator.util.planner;
 
 import com.linkedin.hoptimator.DeploymentContext;
 
+import com.linkedin.hoptimator.MissingConnectorException;
 import com.linkedin.hoptimator.Pipeline;
+import com.linkedin.hoptimator.Source;
 import com.linkedin.hoptimator.SqlDialect;
 import com.linkedin.hoptimator.ThrowingFunction;
+import com.linkedin.hoptimator.util.ConnectionService;
 import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
@@ -30,6 +33,7 @@ import org.apache.calcite.tools.RelBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
@@ -46,6 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -53,6 +59,18 @@ class PipelineRelImplementorTest {
 
   @Mock
   private DeploymentContext mockConnection;
+
+  // PipelineRel.sql() resolves connector configs via ConnectionService.configure(...). Tests that
+  // PipelineRel.sql()/query() resolve connector configs via ConnectionService.configure(...). Tests
+  // that assert on generated SQL stub this to return a non-empty connector for every source and the
+  // sink so the pipeline is materializable by a SQL job.
+  @Mock
+  private MockedStatic<ConnectionService> connectionServiceStatic;
+
+  private void stubHasConnector() {
+    connectionServiceStatic.when(() -> ConnectionService.configure(any(), any()))
+        .thenReturn(Collections.singletonMap("connector", "test-connector"));
+  }
 
   @Test
   void testWrapAnsiDialect() throws SQLException {
@@ -167,6 +185,7 @@ class PipelineRelImplementorTest {
 
   @Test
   void testSqlFunctionWithCollision() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -192,6 +211,7 @@ class PipelineRelImplementorTest {
 
   @Test
   void testSqlFunctionWithoutCollision() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -211,7 +231,56 @@ class PipelineRelImplementorTest {
   }
 
   @Test
+  void testSqlFunctionThrowsWhenSinkHasNoConnector() throws SQLException {
+    // Arrange: no sources; the sink's connector configs are empty (configure returns empty by default).
+    RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataType rowType = typeFactory.builder()
+        .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+        .build();
+
+    PipelineRel.Implementor impl = new PipelineRel.Implementor(
+        ImmutablePairList.of(), Collections.emptyMap());
+
+    RelNode query = createScanRelNode();
+    impl.setQuery(query);
+    impl.setSink("db", Arrays.asList("schema", "sinkTable"), rowType, Collections.emptyMap());
+
+    ThrowingFunction<SqlDialect, String> sqlFunc = impl.sql(mockConnection);
+
+    // Act + Assert: a sink with no connector cannot be materialized by a SQL job.
+    assertThrows(MissingConnectorException.class, () -> sqlFunc.apply(SqlDialect.ANSI));
+  }
+
+  @Test
+  void testSqlFunctionThrowsWhenSourceHasNoConnector() throws SQLException {
+    // Arrange: the sink has a connector, but the source's connector configs are empty.
+    RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataType rowType = typeFactory.builder()
+        .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+        .build();
+
+    // Only the sink table has a connector; the source resolves to an empty map (default).
+    connectionServiceStatic.when(() -> ConnectionService.configure(
+            argThat(o -> o instanceof Source && "sinkTable".equals(((Source) o).table())), any()))
+        .thenReturn(Collections.singletonMap("connector", "test-connector"));
+
+    PipelineRel.Implementor impl = new PipelineRel.Implementor(
+        ImmutablePairList.of(), Collections.emptyMap());
+
+    RelNode query = createScanRelNode();
+    impl.setQuery(query);
+    impl.addSource("db", Arrays.asList("schema", "sourceTable"), rowType, Collections.emptyMap());
+    impl.setSink("db", Arrays.asList("schema", "sinkTable"), rowType, Collections.emptyMap());
+
+    ThrowingFunction<SqlDialect, String> sqlFunc = impl.sql(mockConnection);
+
+    // Act + Assert: a source with no connector cannot be read by a SQL job.
+    assertThrows(MissingConnectorException.class, () -> sqlFunc.apply(SqlDialect.ANSI));
+  }
+
+  @Test
   void testQueryFunctionReturnsSelectSql() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -632,6 +701,7 @@ class PipelineRelImplementorTest {
    */
   @Test
   void testAddSourceAppearsInPipelineSql() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -659,6 +729,7 @@ class PipelineRelImplementorTest {
    */
   @Test
   void testSetSinkAppearsInPipelineSql() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -687,6 +758,7 @@ class PipelineRelImplementorTest {
    */
   @Test
   void testNoCollisionWithNoSink() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -715,6 +787,7 @@ class PipelineRelImplementorTest {
    */
   @Test
   void testNoCollisionWithDistinctSourceAndSink() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -743,6 +816,7 @@ class PipelineRelImplementorTest {
    */
   @Test
   void testCollisionWithSameSourceAndSink() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))
@@ -770,6 +844,7 @@ class PipelineRelImplementorTest {
    */
   @Test
   void testCollisionAndNoCollisionProduceDifferentSql() throws SQLException {
+    stubHasConnector();
     RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder()
         .add("COL1", typeFactory.createSqlType(SqlTypeName.VARCHAR))


### PR DESCRIPTION
## What

Teach the pipeline planner to skip Flink SQL job generation when a table involved in the pipeline has no connector configuration (i.e. an empty `WITH ()` clause). Such tables are moved by a non-SQL `JobTemplate` (e.g. a triggered/ETL-style job) rather than a Flink `SqlJob`, so emitting a `SqlJob` for them produces SQL that is unrunnable and fails at Flink runtime.

## Why

A `JobTemplate` with no `databases` filter matches every sink, so a connector-less table would still get a Flink `SqlJob` rendered against it — e.g. `CREATE TABLE … WITH ()` followed by an `INSERT INTO` that Flink cannot execute. This affects both directions:

- **Connector-less sink** (e.g. a table materialized by a downstream non-SQL job): the generated `SqlJob` writes into an empty-connector sink.
- **Connector-less source** (the reverse case): the generated `SqlJob` reads from an empty-connector source.

Both should render only their non-SQL `JobTemplate`, never a broken `SqlJob`.

## How

- Add `MissingConnectorException` (`hoptimator-api`), a `SQLNonTransientException` signaling that a table has no connector and therefore cannot participate in a generated SQL job.
- `PipelineRel` throws it while resolving connector configs when the **sink** (`sql()`) or any **source** (`script()`) has an empty config map.
- Callers that generate SQL treat it as "skip the SQL job," not an error:
  - `K8sJobDeployer` — a `sqlOrNull` helper catches it so `{{sql}}`/`{{flinksql}}` resolve to `null`, which drops SQL-based `JobTemplate`s during rendering while non-SQL templates still render.
  - `LogicalTableDeployer` and `K8sMaterializedViewDeployer` — catch it and treat the pipeline as having no SQL (null → nullable Pipeline CR field).
- `K8sPipelineDeployer` stores `""` instead of `null` for the Pipeline CR `sql` field.

## Tests

- `PipelineRelImplementorTest` — new cases asserting `sql()` throws `MissingConnectorException` when the sink or a source has no connector; existing SQL-generation tests stub a non-empty connector.
- `K8sJobDeployerTest` — new cases asserting a connector-less sink skips the SQL template while a non-SQL template still renders, and that a sink with a connector still renders the SQL template.

## Fixtures

- `deploy/samples/demodb.yaml`: add `ads-catalog-database` to `demodb-write-template`'s `databases`. The offline demo tier (`ADS_CATALOG`) previously had only a read/trigger template, so its sink had no write connector — the missing write connector is the fixture bug this surfaced. The `nearline→offline` logical-table integration graph now correctly renders a `FlinkSessionJob` for that tier.

## Compatibility

No public API changes. `sql()`'s contract now allows throwing `MissingConnectorException`; all in-tree callers handle it.
