### PR TITLE
Enhance DualLogger to fan out throwables to log hooks

### DIFF
--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DualLogger.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/DualLogger.java
@@ -2,6 +2,7 @@ package com.linkedin.hoptimator.jdbc;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 
 import java.util.List;
@@ -26,12 +27,63 @@ final class DualLogger {
   }
 
   /**
-   * Log a message with slf4j format at the INFO level.
+   * Log a message with slf4j format at the TRACE level. If the last argument is a {@link Throwable},
+   * SLF4J logs it with a stack trace and its message is appended to the text sent to the hooks.
+   */
+  public void trace(String format, Object... arguments) {
+    slf4jLogger.trace(format, arguments);
+    fanOut(format, arguments);
+  }
+
+  /**
+   * Log a message with slf4j format at the DEBUG level. If the last argument is a {@link Throwable},
+   * SLF4J logs it with a stack trace and its message is appended to the text sent to the hooks.
+   */
+  public void debug(String format, Object... arguments) {
+    slf4jLogger.debug(format, arguments);
+    fanOut(format, arguments);
+  }
+
+  /**
+   * Log a message with slf4j format at the INFO level. If the last argument is a {@link Throwable},
+   * SLF4J logs it with a stack trace and its message is appended to the text sent to the hooks.
    */
   public void info(String format, Object... arguments) {
     slf4jLogger.info(format, arguments);
-    String msg = MessageFormatter.arrayFormat(format, arguments).getMessage();
-    String msgWithClassName = String.format("[%s] %s", className, msg);
-    hooks.forEach(hook -> hook.accept(msgWithClassName));
+    fanOut(format, arguments);
+  }
+
+  /**
+   * Log a message with slf4j format at the WARN level. If the last argument is a {@link Throwable},
+   * SLF4J logs it with a stack trace and its message is appended to the text sent to the hooks.
+   */
+  public void warn(String format, Object... arguments) {
+    slf4jLogger.warn(format, arguments);
+    fanOut(format, arguments);
+  }
+
+  /**
+   * Log a message with slf4j format at the ERROR level. If the last argument is a {@link Throwable},
+   * SLF4J logs it with a stack trace and its message is appended to the text sent to the hooks.
+   */
+  public void error(String format, Object... arguments) {
+    slf4jLogger.error(format, arguments);
+    fanOut(format, arguments);
+  }
+
+  /**
+   * Formats the message, prefixes it with the class name, appends the throwable detail (if any), and
+   * fans the result out to every hook. The slf4j logging happens in the level-specific methods.
+   */
+  private void fanOut(String format, Object... arguments) {
+    FormattingTuple tuple = MessageFormatter.arrayFormat(format, arguments);
+    String msgWithClassName = String.format("[%s] %s", className, tuple.getMessage());
+    Throwable throwable = tuple.getThrowable();
+    if (throwable != null) {
+      String detail = throwable.getMessage() != null ? throwable.getMessage() : throwable.toString();
+      msgWithClassName = String.format("%s: %s", msgWithClassName, detail);
+    }
+    String finalMsg = msgWithClassName;
+    hooks.forEach(hook -> hook.accept(finalMsg));
   }
 }

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlExecutor.java
@@ -163,7 +163,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
       schemaPlus.add(viewName, viewTable);
       logger.info("Added view {} to schema {}", viewName, schemaPlus.getName());
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to deploy view {}", viewName);
+      logger.warn("Failed to deploy view {}", viewName, e);
       if (deployers != null) {
         DeploymentService.restore(deployers);
         logger.info("Restored deployable resources for view {}", viewName);
@@ -187,7 +187,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
           create,
           mode);
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to deploy materialized view {}", create.name);
+      logger.warn("Failed to deploy materialized view {}", create.name, e);
       throw new DdlException(create, e.getMessage(), e);
     }
     logger.info("CREATE MATERIALIZED VIEW {} completed", create.name);
@@ -283,7 +283,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
     try {
       HoptimatorDdlUtils.processCreateTable(context, connection, create, mode);
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to deploy table {}", create.name);
+      logger.warn("Failed to deploy table {}", create.name, e);
       throw new DdlException(create, e.getMessage(), e);
     }
     logger.info("CREATE TABLE {} completed", create.name);
@@ -295,7 +295,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
     try {
       HoptimatorDdlUtils.processCreateDatabase(connection, create, mode);
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to deploy database {}", create.name);
+      logger.warn("Failed to deploy database {}", create.name, e);
       throw new DdlException(create, e.getMessage(), e);
     }
     logger.info("CREATE DATABASE {} completed", create.name);
@@ -502,7 +502,7 @@ public final class HoptimatorDdlExecutor extends ServerDdlExecutor {
         throw new SQLException(String.format("Unsupported drop type %s.", table.getClass().getSimpleName()));
       }
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to delete element {}", tableName);
+      logger.warn("Failed to delete element {}", tableName, e);
       if (deployers != null) {
         DeploymentService.restore(deployers);
         logger.info("Restored deployable resources for element {}", tableName);

--- a/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
+++ b/hoptimator-jdbc/src/main/java/com/linkedin/hoptimator/jdbc/HoptimatorDdlUtils.java
@@ -467,7 +467,7 @@ public final class HoptimatorDdlUtils {
       success = true;
       return new SpecifyResult(specs, sinkRowType, viewPath);
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to deploy materialized view {}", viewName);
+      logger.warn("Failed to deploy materialized view {}", viewName, e);
       if (deployers != null) {
         DeploymentService.restore(deployers);
         logger.info("Restored deployable resources for materialized view {}", viewName);
@@ -784,7 +784,7 @@ public final class HoptimatorDdlUtils {
       RelDataType sinkRowType = calcite == null ? HoptimatorDriver.rowType(source, context) : calcite.rowType;
       return new SpecifyResult(specs, sinkRowType, tablePath);
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to deploy table {}", tableName);
+      logger.warn("Failed to deploy table {}", tableName, e);
       if (deployers != null) {
         DeploymentService.restore(deployers);
         logger.info("Restored deployable resources for table {}", tableName);
@@ -854,7 +854,7 @@ public final class HoptimatorDdlUtils {
       }
       return new SpecifyResult(specs, null, Collections.singletonList(name));
     } catch (SQLException | RuntimeException e) {
-      logger.info("Failed to deploy database {}", name);
+      logger.warn("Failed to deploy database {}", name, e);
       if (deployers != null) {
         DeploymentService.restore(deployers);
         logger.info("Restored deployable resources for database {}", name);

--- a/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/DualLoggerTest.java
+++ b/hoptimator-jdbc/src/test/java/com/linkedin/hoptimator/jdbc/DualLoggerTest.java
@@ -1,46 +1,222 @@
 package com.linkedin.hoptimator.jdbc;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 
 /**
- * Unit tests for {@link DualLogger}.
+ * Unit tests for {@link DualLogger}. Every level shares the same fan-out behavior, so the shared
+ * cases are parameterized across all of them.
  */
 class DualLoggerTest {
 
-  @Test
-  void infoFansOutToHookWithClassPrefixAndFormatting() {
+  /** A level-specific logging call, e.g. {@link DualLogger#info}. */
+  @FunctionalInterface
+  private interface LogCall {
+    void log(DualLogger logger, String format, Object... arguments);
+  }
+
+  private static Stream<Arguments> levels() {
+    return Stream.of(
+        Arguments.of("trace", (LogCall) DualLogger::trace),
+        Arguments.of("debug", (LogCall) DualLogger::debug),
+        Arguments.of("info", (LogCall) DualLogger::info),
+        Arguments.of("warn", (LogCall) DualLogger::warn),
+        Arguments.of("error", (LogCall) DualLogger::error));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("levels")
+  void fansOutToHookWithClassPrefixAndFormatting(String level, LogCall call) {
     List<String> logged = new ArrayList<>();
     DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
 
-    logger.info("created {} in {}", "table", "schema");
+    call.log(logger, "created {} in {}", "table", "schema");
 
     assertThat(logged).containsExactly("[DualLoggerTest] created table in schema");
   }
 
-  @Test
-  void infoInvokesEveryHook() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("levels")
+  void invokesEveryHook(String level, LogCall call) {
     List<String> first = new ArrayList<>();
     List<String> second = new ArrayList<>();
     DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(first::add, second::add));
 
-    logger.info("hello");
+    call.log(logger, "hello");
 
     assertThat(first).containsExactly("[DualLoggerTest] hello");
     assertThat(second).containsExactly("[DualLoggerTest] hello");
   }
 
-  @Test
-  void infoWithNoHooksDoesNotThrow() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("levels")
+  void withNoHooksDoesNotThrow(String level, LogCall call) {
     DualLogger logger = new DualLogger(DualLoggerTest.class, List.of());
 
     // slf4j still receives the message; with no hooks there is nothing to assert but it must not throw.
-    assertThatCode(() -> logger.info("no hooks {}", "here")).doesNotThrowAnyException();
+    assertThatCode(() -> call.log(logger, "no hooks {}", "here")).doesNotThrowAnyException();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("levels")
+  void withThrowableAppendsThrowableMessageToHooks(String level, LogCall call) {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    call.log(logger, "could not deploy {}", "table", exception);
+
+    assertThat(logged).containsExactly("[DualLoggerTest] could not deploy table: failed");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("levels")
+  void withThrowableWithNullMessageFallsBackToToString(String level, LogCall call) {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException();
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    call.log(logger, "could not deploy {}", "table", exception);
+
+    assertThat(logged).containsExactly("[DualLoggerTest] could not deploy table: java.lang.RuntimeException");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("levels")
+  void withThrowableAndNoHooksDoesNotThrow(String level, LogCall call) {
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of());
+
+    // slf4j still receives the message; with no hooks there is nothing to assert but it must not throw.
+    assertThatCode(() -> call.log(logger, "no hooks {}", "here", exception)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void withoutHooksListStillLogsToSlf4j() {
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of());
+
+    assertThatCode(() -> logger.info("just slf4j {}", "here")).doesNotThrowAnyException();
+  }
+
+  // --- Argument-count x throwable matrix. fanOut is shared across levels, so info() exercises it. ---
+
+  @Test
+  void tooManyArgumentsWithoutThrowableIgnoresExtras() {
+    List<String> logged = new ArrayList<>();
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    logger.info("one {}", "x", "y");
+
+    assertThat(logged).containsExactly("[DualLoggerTest] one x");
+  }
+
+  @Test
+  void notEnoughArgumentsWithoutThrowableLeavesPlaceholderLiteral() {
+    List<String> logged = new ArrayList<>();
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    logger.info("two {} {}", "x");
+
+    assertThat(logged).containsExactly("[DualLoggerTest] two x {}");
+  }
+
+  @Test
+  void exactArgumentsWithoutThrowable() {
+    List<String> logged = new ArrayList<>();
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    logger.info("two {} {}", "x", "y");
+
+    assertThat(logged).containsExactly("[DualLoggerTest] two x y");
+  }
+
+  @Test
+  void noArgumentsLeavesPlaceholderLiteral() {
+    List<String> logged = new ArrayList<>();
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    logger.info("one {}");
+
+    assertThat(logged).containsExactly("[DualLoggerTest] one {}");
+  }
+
+  @Test
+  void throwableWithNotEnoughArgumentsLeavesPlaceholderAndAppendsThrowable() {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    // Two placeholders, one non-throwable arg: the trailing throwable is never used to fill a
+    // placeholder, so the second placeholder stays literal and the throwable is appended.
+    logger.info("two {} {}", "x", exception);
+
+    assertThat(logged).containsExactly("[DualLoggerTest] two x {}: failed");
+  }
+
+  @Test
+  void throwableWithTooManyArgumentsIgnoresExtrasAndAppendsThrowable() {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    logger.info("one {}", "x", "y", exception);
+
+    assertThat(logged).containsExactly("[DualLoggerTest] one x: failed");
+  }
+
+  @Test
+  void throwableWithExactArgumentsAppendsThrowable() {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    logger.info("one {}", "x", exception);
+
+    assertThat(logged).containsExactly("[DualLoggerTest] one x: failed");
+  }
+
+  @Test
+  void throwableAsOnlyArgumentWithNoPlaceholderAppendsThrowable() {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    logger.info("deploy failed", exception);
+
+    assertThat(logged).containsExactly("[DualLoggerTest] deploy failed: failed");
+  }
+
+  @Test
+  void throwableAsOnlyArgumentWithPlaceholderIsNotUsedToFillPlaceholder() {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    // The lone throwable is treated as the exception, not as the {} substitution.
+    logger.info("deploy {}", exception);
+
+    assertThat(logged).containsExactly("[DualLoggerTest] deploy {}: failed");
+  }
+
+  @Test
+  void onlyNonTrailingThrowableIsTreatedAsRegularArgument() {
+    List<String> logged = new ArrayList<>();
+    RuntimeException exception = new RuntimeException("failed");
+    DualLogger logger = new DualLogger(DualLoggerTest.class, List.of(logged::add));
+
+    // A throwable that is NOT the last argument is a normal parameter, not the exception.
+    logger.info("deploy {} {}", exception, "x");
+
+    assertThat(logged).containsExactly("[DualLoggerTest] deploy java.lang.RuntimeException: failed x");
   }
 }


### PR DESCRIPTION
## What

`DualLogger` fans each message out to both an SLF4J logger and a list of log hooks (surfaced to hook consumers such as the CLI/UI deploy log). It only exposed `info()`, and its hook fan-out dropped any `Throwable` argument. As a result, the DDL deploy/delete failure paths logged at `info` **without** the exception, so hook consumers never saw the cause of a failure.

## Changes

- **`DualLogger`**: extracted a shared `fanOut()` helper and added `trace`/`debug`/`warn`/`error` alongside `info`, all `Throwable`-aware. When the trailing argument is a `Throwable`, SLF4J logs it with a stack trace and the throwable detail is appended to the hook text (falling back to `toString()` when the throwable message is `null`).
- **`HoptimatorDdlExecutor` / `HoptimatorDdlUtils`**: the 8 deploy/delete failure `catch` blocks now log at `warn` and pass the caught exception, so the cause reaches the hooks.
- **`DualLoggerTest`**: exhaustive coverage — parameterized across all five levels, plus the full argument-count x throwable matrix (too many / not enough / exact args, with and without a trailing throwable, and corner cases such as a throwable as the sole argument with/without a placeholder, null-message fallback, and a non-trailing throwable treated as a normal parameter).

## Testing

`./gradlew :hoptimator-jdbc:test` — all pass (41 `DualLoggerTest` cases, 0 failures).
