### PR TITLE
Defer NOT NULL enforcement to the engine instead of rejecting nullable casts

### DIFF
--- a/docs/user-guide/ddl-reference.md
+++ b/docs/user-guide/ddl-reference.md
@@ -157,11 +157,8 @@ How each column is reconciled depends on the `castMode`
   including lossy numeric narrowing (e.g. `BIGINT → INTEGER`); the deliberate
   opt-in for passthroughs that intentionally coerce across families or narrow.
 
-Regardless of mode, two mismatches are always errors: a nullable source into a
-`NOT NULL` sink column **when that column also needs a cast** — a cast cannot add
-a null guard (matching types are assigned as-is and the engine enforces
-`NOT NULL` at runtime, as with a native `INSERT`) — and any structural difference
-between complex `ROW`/`ARRAY`/`MAP`/`MULTISET` types.
+Any structural difference between complex `ROW`/`ARRAY`/`MAP`/`MULTISET` types
+is always an error.
 
 Complex types are compared structurally and Hoptimator does not cast individual
 nested fields.

--- a/docs/user-guide/hints.md
+++ b/docs/user-guide/hints.md
@@ -57,9 +57,8 @@ template or connector:
   | `explicit`         | Also cast any explicitly-castable scalar pair — the deliberate "risky" opt-in. |
 
   A missing or unrecognized value falls back to `strict`, so a dropped hint can
-  never silently widen the policy. A type mismatch that also crosses from a
-  nullable source into a `NOT NULL` sink, and structural complex-type
-  mismatches, remain errors at every level.
+  never silently widen the policy. Structural complex-type mismatches remain
+  errors at every level.
 
 ## Reading what was applied
 

--- a/hoptimator-k8s/src/test/resources/k8s-cast-assign.id
+++ b/hoptimator-k8s/src/test/resources/k8s-cast-assign.id
@@ -36,9 +36,26 @@ create or replace materialized view ads."cast_asgn$to-binary" ("vb") as select m
 Incompatible types for sink column 'vb': query produces VARCHAR but sink expects VARBINARY (no safe conversion is available under castMode=assign).
 !error
 
-create or replace materialized view ads."cast_asgn_nn$null-into-nn" ("member_id") as select member_urn AS "member_id" from profile.members;
-Incompatible types for sink column 'member_id': query produces VARCHAR but sink expects BIGINT NOT NULL (no safe conversion is available under castMode=assign).
-!error
+insert into ads."cast_asgn_nn" ("member_id") select member_urn AS "member_id" from profile.members;
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: profile-database-castasgnnn
+spec:
+  deploymentName: basic-session-deployment
+  job:
+    entryClass: com.linkedin.hoptimator.flink.runner.FlinkRunner
+    args:
+    - CREATE DATABASE IF NOT EXISTS `PROFILE` WITH ()
+    - CREATE TABLE IF NOT EXISTS `PROFILE`.`MEMBERS` (`FIRST_NAME` VARCHAR, `LAST_NAME` VARCHAR, `MEMBER_URN` VARCHAR, `COMPANY_URN` VARCHAR) WITH ('connector'='datagen', 'number-of-rows'='10')
+    - CREATE DATABASE IF NOT EXISTS `ADS` WITH ()
+    - CREATE TABLE IF NOT EXISTS `ADS`.`cast_asgn_nn` (`member_id` BIGINT) WITH ('connector'='blackhole')
+    - INSERT INTO `ADS`.`cast_asgn_nn` (`member_id`) SELECT CAST(`MEMBER_URN` AS BIGINT) AS `member_id` FROM `PROFILE`.`MEMBERS`
+    jarURI: file:///opt/hoptimator-flink-runner.jar
+    parallelism: 1
+    upgradeMode: stateless
+    state: running
+!specify cast_asgn_nn
 
 drop table ads."cast_asgn";
 (0 rows modified)

--- a/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/TypeCoercion.java
+++ b/hoptimator-util/src/main/java/com/linkedin/hoptimator/util/planner/TypeCoercion.java
@@ -23,12 +23,12 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  * the sink, or fail early with a clear error naming the column and both types.
  *
  * <p>The permissiveness is controlled by a {@link CastMode} sourced from the {@code castMode} hint.
- * Two rules hold at <em>every</em> mode and cannot be relaxed:
+ * Nullability is never a plan-time concern: a nullable source may be assigned to a {@code NOT NULL}
+ * sink column (with or without a cast), and the engine enforces the {@code NOT NULL} constraint at
+ * runtime, exactly as for a native {@code INSERT} — this is what lets a nullable Kafka {@code KEY}
+ * project onto a {@code NOT NULL} key column. One rule holds at <em>every</em> mode and cannot be
+ * relaxed:
  * <ul>
- *   <li>When a cast is needed (the source and sink types differ), a nullable source into a
- *       {@code NOT NULL} sink column is incompatible — a cast cannot add a null guard. When the
- *       types already match, assignment is allowed regardless of nullability and the engine enforces
- *       any {@code NOT NULL} constraint at runtime, exactly as for a native {@code INSERT}.</li>
  *   <li>Complex types ({@code ROW}/{@code ARRAY}/{@code MAP}/{@code MULTISET}) must match
  *       structurally — same shape and same base scalar types at every level — because a cast cannot
  *       reshape a record or cast an individual nested field. Nullability is ignored recursively
@@ -127,12 +127,6 @@ public final class TypeCoercion {
     // exactly as for a native INSERT, so we only intervene for genuine cross-family mismatches.
     if (source.getSqlTypeName() == target.getSqlTypeName()) {
       return Decision.NONE;
-    }
-
-    // Types differ, so a cast is required. A cast cannot turn a possibly-null value into a
-    // guaranteed non-null one, so a nullable source feeding a NOT NULL sink column is rejected.
-    if (source.isNullable() && !target.isNullable()) {
-      return Decision.INCOMPATIBLE;
     }
 
     boolean allowed;

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelCastTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/PipelineRelCastTest.java
@@ -245,12 +245,17 @@ class PipelineRelCastTest {
         sink(type(SqlTypeName.BIGINT)), EXPLICIT);
   }
 
-  // --- nullability is never fixable by a cast ---
+  // --- nullability is never a plan-time rejection ---
 
   @Test
-  void nullableSourceIntoNotNullSinkRejectedEvenWhenCastable() {
+  void nullableSourceIntoNotNullSinkCastsAndDefersNotNullToEngine() throws Exception {
+    // The canonical Kafka-key case: a nullable STRING key projected onto a NOT NULL BIGINT sink key.
+    // We inject the assignment cast and let the engine enforce NOT NULL at runtime (Flink accepts
+    // CAST(nullable AS BIGINT) into a NOT NULL column), rather than rejecting at plan time.
     stubHasConnector();
-    assertRejects(selectAs(nullable(type(SqlTypeName.VARCHAR))), sink(notNull(type(SqlTypeName.BIGINT))), ASSIGN);
+    String sql = generate(selectAs(nullable(type(SqlTypeName.VARCHAR))), sink(notNull(type(SqlTypeName.BIGINT))),
+        ASSIGN);
+    assertThat(sql).contains("CAST").contains("BIGINT");
   }
 
   @Test

--- a/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/TypeCoercionTest.java
+++ b/hoptimator-util/src/test/java/com/linkedin/hoptimator/util/planner/TypeCoercionTest.java
@@ -356,26 +356,16 @@ class TypeCoercionTest {
 
   @ParameterizedTest(name = "{0} -> {1}")
   @MethodSource("allPairs")
-  void nullableSourceIntoNotNullSinkNeverWidensAcceptance(RelDataType source, RelDataType target) {
+  void nullabilityDoesNotAffectScalarDecision(RelDataType source, RelDataType target) {
     // Scoped to scalars: making a struct nullable also flips its inner field nullability, which is a
-    // structural change governed by the complex-type rule rather than this scalar nullability rule.
+    // structural change governed by the complex-type rule rather than this scalar rule.
     if (isComplex(source) || isComplex(target)) {
       return;
     }
-    // Making the source nullable and the sink NOT NULL can only remove acceptance, never add it,
-    // and when the types differ it must turn any cast into an error.
-    RelDataType nullableSource = nullable(source);
-    RelDataType notNullTarget = notNull(target);
     for (CastMode mode : CastMode.values()) {
       Decision base = TypeCoercion.decide(notNull(source), notNull(target), mode);
-      Decision withNulls = TypeCoercion.decide(nullableSource, notNullTarget, mode);
-      if (base == Decision.CAST) {
-        // A cast can't add a null guard, so a nullable source into a NOT NULL sink is rejected.
-        assertThat(withNulls).as(mode.name()).isEqualTo(Decision.INCOMPATIBLE);
-      } else if (base == Decision.NONE) {
-        // Same type: still a plain assignment regardless of nullability.
-        assertThat(withNulls).as(mode.name()).isEqualTo(Decision.NONE);
-      }
+      Decision withNulls = TypeCoercion.decide(nullable(source), notNull(target), mode);
+      assertThat(withNulls).as(mode.name()).isEqualTo(base);
     }
   }
 }


### PR DESCRIPTION
## Problem

The type-coercion write check (PR #250) rejected a **nullable source column assigned to a `NOT NULL` sink column whenever the types differed** (a cast was needed), on the theory that "a cast cannot add a null guard."

This breaks the exact use case the feature exists for. A Kafka record `KEY` is always exposed as a **nullable** column, while a keyed sink's key column is `NOT NULL`. So the canonical passthrough:

```sql
CREATE OR REPLACE MATERIALIZED VIEW "VENICE"."my_store$default" AS
SELECT KEY AS "KEY_member_id", ... FROM "TRACKING"."my_topic"
```

fails under `castMode=assign` with:

```
Incompatible types for sink column 'KEY_member_id': query produces VARCHAR
but sink expects BIGINT NOT NULL (no safe conversion is available under castMode=assign).
```

## Why the rejection was wrong

- **Internally inconsistent.** Matching types — and an explicit user `CAST` whose result matched the sink base type (`CAST("KEY" AS BIGINT)`) — were *already* allowed nullable to `NOT NULL`, deferring `NOT NULL` enforcement to the engine at runtime (as for a native `INSERT`). Only the case where *we* inject the cast was rejected.
- **Stricter than the engine.** Verified empirically against Flink 1.18 (`explainSql`, no job launched): Flink **accepts** `CAST(nullable AS BIGINT)` into a `NOT NULL` column and enforces `NOT NULL` at runtime — for scalars, structs, arrays, and maps alike.

## Fix

Drop the nullable-source-into-`NOT NULL` rejection from `TypeCoercion.decide()`. Nullability is never a plan-time error; the engine enforces it at runtime. The complex-type path already ignored nullability recursively (`structurallyEqualSansNullability`), so **structs need no change** — the scalar path is now consistent with it.

## Changes

- `TypeCoercion.java` — remove the rejection block; update class javadoc.
- `TypeCoercionTest.java` — nullability no longer changes a scalar decision (invariance test).
- `PipelineRelCastTest.java` — the canonical Kafka-key case now injects the cast.
- `k8s-cast-assign.id` — flip the `null-into-nn` case from error to a `!specify` success (injected `CAST(MEMBER_URN AS BIGINT)`).
- `ddl-reference.md`, `hints.md` — document that nullability is enforced at runtime.

## Verification

- `:hoptimator-util:test`, `:hoptimator-jdbc:test` — green.
- `:hoptimator-k8s:intTest` cast scripts (assign/strict/explicit) — pass against a live cluster.
- Scanned all `.id` scripts — no other error assertions flip.
